### PR TITLE
Fix CORS: restrict to same-origin instead of wildcard

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1439,10 +1439,15 @@ const server = http.createServer(async (req, res) => {
   const url = new URL(req.url, `http://localhost:${PORT}`);
   const pathParts = url.pathname.split('/').filter(Boolean);
   
-  res.setHeader('Access-Control-Allow-Origin', '*');
-  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
-  
+  // CORS: only allow requests from the same origin (the dashboard served by this server)
+  const origin = req.headers.origin;
+  const allowedOrigin = `http://localhost:${PORT}`;
+  if (origin === allowedOrigin || origin === `http://127.0.0.1:${PORT}`) {
+    res.setHeader('Access-Control-Allow-Origin', origin);
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+  }
+
   if (req.method === 'OPTIONS') {
     res.writeHead(204);
     res.end();


### PR DESCRIPTION
Replace Access-Control-Allow-Origin: * with origin checking that only
allows requests from localhost/127.0.0.1 on the server's port. This
prevents malicious websites from making cross-origin requests to the
dashboard API.

https://claude.ai/code/session_01J1Dn8gqxp8QAH5uwFGjMaw