### PR TITLE
fix: read port from .env instead of hardcoding 3100

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -78,6 +78,15 @@ async function ensureEnv() {
   console.log(`   (VAPID keys will be auto-generated on first start)\n`);
 }
 
+function getPort() {
+  const envPath = path.join(TBC_HOME, '.env');
+  if (fs.existsSync(envPath)) {
+    const match = fs.readFileSync(envPath, 'utf-8').match(/^TBC_PORT=(.+)$/m);
+    if (match) return match[1].trim();
+  }
+  return process.env.TBC_PORT || '3100';
+}
+
 function buildMonitor() {
   console.log('Building monitor...');
   if (!fs.existsSync(path.join(MONITOR_DIR, 'node_modules'))) {
@@ -113,7 +122,7 @@ async function main() {
       fs.writeFileSync(path.join(TBC_HOME, 'server.pid'), String(child.pid));
       
       console.log(`TheBotCompany started (PID: ${child.pid})`);
-      console.log(`  Dashboard: http://localhost:3100`);
+      console.log(`  Dashboard: http://localhost:${getPort()}`);
       console.log(`  Logs: ${logFile}`);
       console.log(`\nRun 'tbc stop' to stop, 'tbc logs' to tail logs`);
       break;
@@ -136,10 +145,10 @@ async function main() {
       
       const server = spawn('node', ['--watch', path.join(ROOT, 'src', 'server.js')], {
         stdio: ['ignore', devOut, devErr],
-        env: { ...process.env, TBC_SERVE_STATIC: 'false', TBC_PORT: '3100' }
+        env: { ...process.env, TBC_SERVE_STATIC: 'false', TBC_PORT: getPort() }
       });
       
-      console.log(`API server started on http://localhost:3100`);
+      console.log(`API server started on http://localhost:${getPort()}`);
       console.log(`Server logs: ${devLogFile}\n`);
       
       // Give server a moment to start
@@ -164,7 +173,7 @@ async function main() {
 
     case 'status':
       try {
-        const res = await fetch('http://localhost:3100/api/status');
+        const res = await fetch(`http://localhost:${getPort()}/api/status`);
         const data = await res.json();
         console.log(`TheBotCompany - ${data.projectCount} projects`);
         console.log(`Uptime: ${Math.floor(data.uptime / 60)}m ${data.uptime % 60}s\n`);

--- a/bin/tbc
+++ b/bin/tbc
@@ -81,6 +81,15 @@ async function ensureEnv() {
   console.log(`   (VAPID keys will be auto-generated on first start)\n`);
 }
 
+function getPort() {
+  const envPath = path.join(TBC_HOME, '.env');
+  if (fs.existsSync(envPath)) {
+    const match = fs.readFileSync(envPath, 'utf-8').match(/^TBC_PORT=(.+)$/m);
+    if (match) return match[1].trim();
+  }
+  return process.env.TBC_PORT || '3100';
+}
+
 function loadProjectsYaml() {
   if (!fs.existsSync(PROJECTS_PATH)) return { projects: {} };
   const raw = fs.readFileSync(PROJECTS_PATH, 'utf-8');
@@ -133,7 +142,7 @@ async function main() {
       fs.writeFileSync(path.join(TBC_HOME, 'server.pid'), String(child.pid));
       
       console.log(`TheBotCompany started (PID: ${child.pid})`);
-      console.log(`  Dashboard: http://localhost:3100`);
+      console.log(`  Dashboard: http://localhost:${getPort()}`);
       console.log(`  Logs: ${logFile}`);
       console.log(`\nRun 'tbc stop' to stop, 'tbc logs' to tail logs`);
       break;
@@ -156,10 +165,10 @@ async function main() {
       
       const server = spawn('node', ['--watch', path.join(ROOT, 'src', 'server.js')], {
         stdio: ['ignore', devOut, devErr],
-        env: { ...process.env, TBC_SERVE_STATIC: 'false', TBC_PORT: '3100' }
+        env: { ...process.env, TBC_SERVE_STATIC: 'false', TBC_PORT: getPort() }
       });
       
-      console.log(`API server started on http://localhost:3100`);
+      console.log(`API server started on http://localhost:${getPort()}`);
       console.log(`Server logs: ${devLogFile}\n`);
       
       // Give server a moment to start
@@ -184,7 +193,7 @@ async function main() {
 
     case 'status':
       try {
-        const res = await fetch('http://localhost:3100/api/status');
+        const res = await fetch(`http://localhost:${getPort()}/api/status`);
         const data = await res.json();
         console.log(`TheBotCompany - ${data.projectCount} projects`);
         console.log(`Uptime: ${Math.floor(data.uptime / 60)}m ${data.uptime % 60}s\n`);


### PR DESCRIPTION
Both `bin/tbc` and `bin/cli.js` hardcoded port 3100 in dashboard URLs, dev mode env, and status API calls. This was confusing for users who configured a different port during setup.

**Changes:**
- Added `getPort()` helper that reads `TBC_PORT` from `~/.thebotcompany/.env`, falls back to `TBC_PORT` env var, then defaults to `3100`
- Replaced all hardcoded `3100` references in both CLI files

**Affected locations (4 per file):**
- `tbc start` dashboard URL
- `tbc dev` server env and printout
- `tbc status` API fetch URL

Fixes #29