### PR TITLE
feat: add global server log rotation (5 MB, keep 2)

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -78,6 +78,19 @@ async function ensureEnv() {
   console.log(`   (VAPID keys will be auto-generated on first start)\n`);
 }
 
+function rotateLog(logPath, maxBytes = 5 * 1024 * 1024, keep = 2) {
+  if (!fs.existsSync(logPath)) return;
+  const stats = fs.statSync(logPath);
+  if (stats.size < maxBytes) return;
+  // Rotate: .2 → delete, .1 → .2, current → .1
+  for (let i = keep; i >= 1; i--) {
+    const older = `${logPath}.${i}`;
+    if (i === keep && fs.existsSync(older)) fs.unlinkSync(older);
+    const newer = i === 1 ? logPath : `${logPath}.${i - 1}`;
+    if (fs.existsSync(newer)) fs.renameSync(newer, `${logPath}.${i}`);
+  }
+}
+
 function getPort() {
   const envPath = path.join(TBC_HOME, '.env');
   if (fs.existsSync(envPath)) {
@@ -105,8 +118,9 @@ async function main() {
       // Build monitor first
       buildMonitor();
       
-      // Start server as background process with logs to file
+      // Rotate global log if over 5 MB
       const logFile = path.join(TBC_HOME, 'logs', 'server.log');
+      rotateLog(logFile);
       const out = fs.openSync(logFile, 'a');
       const err = fs.openSync(logFile, 'a');
       

--- a/bin/tbc
+++ b/bin/tbc
@@ -81,6 +81,19 @@ async function ensureEnv() {
   console.log(`   (VAPID keys will be auto-generated on first start)\n`);
 }
 
+function rotateLog(logPath, maxBytes = 5 * 1024 * 1024, keep = 2) {
+  if (!fs.existsSync(logPath)) return;
+  const stats = fs.statSync(logPath);
+  if (stats.size < maxBytes) return;
+  // Rotate: .2 → delete, .1 → .2, current → .1
+  for (let i = keep; i >= 1; i--) {
+    const older = `${logPath}.${i}`;
+    if (i === keep && fs.existsSync(older)) fs.unlinkSync(older);
+    const newer = i === 1 ? logPath : `${logPath}.${i - 1}`;
+    if (fs.existsSync(newer)) fs.renameSync(newer, `${logPath}.${i}`);
+  }
+}
+
 function getPort() {
   const envPath = path.join(TBC_HOME, '.env');
   if (fs.existsSync(envPath)) {
@@ -125,8 +138,9 @@ async function main() {
       // Build monitor first
       buildMonitor();
       
-      // Start server as background process with logs to file
+      // Rotate global log if over 5 MB
       const logFile = path.join(TBC_HOME, 'logs', 'server.log');
+      rotateLog(logFile);
       const out = fs.openSync(logFile, 'a');
       const err = fs.openSync(logFile, 'a');
       


### PR DESCRIPTION
Rotates `~/.thebotcompany/logs/server.log` on `tbc start` when it exceeds 5 MB. Keeps up to 2 rotated copies (`.1`, `.2`).

Added `rotateLog()` helper to both `bin/tbc` and `bin/cli.js`.

Partially addresses #24 — global log only. Project orchestrator and agent response logs are kept as-is for now (see #32).