### PR TITLE
fix: update model list and pricing for current Claude models

### DIFF
--- a/monitor/src/App.jsx
+++ b/monitor/src/App.jsx
@@ -2528,10 +2528,10 @@ function App() {
               >
                 <option value="">Inherited from global</option>
                 <option value="claude-opus-4-6">claude-opus-4-6</option>
-                <option value="claude-sonnet-4-6">claude-sonnet-4.6</option>
-                <option value="claude-sonnet-4-5-20250929">claude-sonnet-4.5</option>
+                <option value="claude-sonnet-4-6">claude-sonnet-4-6</option>
+                <option value="claude-sonnet-4-5-20250929">claude-sonnet-4-5</option>
                 <option value="claude-sonnet-4-20250514">claude-sonnet-4</option>
-                <option value="claude-haiku-3-5-20241022">claude-haiku-3.5</option>
+                <option value="claude-haiku-4-5-20251001">claude-haiku-4-5</option>
               </select>
               <p className="text-xs text-neutral-400 dark:text-neutral-500 mt-1">Leave empty to use the project's default model.</p>
             </div>

--- a/src/server.js
+++ b/src/server.js
@@ -603,7 +603,7 @@ class ProjectRunner {
       const model = (config.model || '').toLowerCase();
       let perAgentCost;
       if (model.includes('opus')) perAgentCost = 2.50;
-      else if (model.includes('haiku')) perAgentCost = 0.20;
+      else if (model.includes('haiku')) perAgentCost = 0.50;
       else perAgentCost = 1.50; // sonnet default
 
       const estimatedCycleCost = perAgentCost * agentCount;
@@ -1520,7 +1520,7 @@ class ProjectRunner {
                   // Model-aware pricing (per million tokens)
                   let inputRate = 15, outputRate = 75, cacheRate = 1.5; // opus default
                   if (agentModel.includes('sonnet')) { inputRate = 3; outputRate = 15; cacheRate = 0.3; }
-                  else if (agentModel.includes('haiku')) { inputRate = 0.80; outputRate = 4; cacheRate = 0.08; }
+                  else if (agentModel.includes('haiku')) { inputRate = 1; outputRate = 5; cacheRate = 0.1; }
                   cost = ((u.input_tokens * inputRate) + (u.output_tokens * outputRate) + (u.cache_read_input_tokens * cacheRate)) / 1_000_000;
                   tokenInfo = ` | tokens: in=${u.input_tokens} out=${u.output_tokens} cache_read=${u.cache_read_input_tokens} | cost: $${cost.toFixed(4)}`;
                 }


### PR DESCRIPTION
- Replace claude-haiku-3.5 (3-5-20241022) with claude-haiku-4.5 (4-5-20251001) in model dropdown
- Fix display labels to use hyphenated names matching API IDs
- Update Haiku pricing to $1/$5/$0.1 (input/output/cache) per MTok (was $0.80/$4/$0.08)
- Update Haiku per-agent cost estimate from $0.20 to $0.50

The old Haiku 3.5 model ID was causing agent failures since it's no longer available via OAuth tokens.