### PR TITLE
feat: issue modal UI improvements and close/reopen support

### DIFF
--- a/monitor/src/App.jsx
+++ b/monitor/src/App.jsx
@@ -98,7 +98,8 @@ function App() {
   const [prs, setPrs] = useState([])
   const [issues, setIssues] = useState([])
   const [issueFilter, setIssueFilter] = useState('open') // 'open' | 'closed' | 'all'
-  const [createIssueModal, setCreateIssueModal] = useState({ open: false, title: '', body: '', creating: false, error: null })
+  const [createIssueModal, setCreateIssueModal] = useState({ open: false, title: '', body: '', receiver: '', creating: false, error: null, focusedField: 'title' })
+  const modKey = typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.userAgent) ? '⌘' : 'Ctrl'
   const [agentModal, setAgentModal] = useState({ open: false, agent: null, data: null, loading: false, tab: 'skill' })
   const [issueModal, setIssueModal] = useState({ open: false, issue: null, comments: [], loading: false })
   const [bootstrapModal, setBootstrapModal] = useState({ open: false, loading: false, preview: null, error: null, executing: false })
@@ -573,12 +574,12 @@ function App() {
           title: createIssueModal.title.trim(),
           body: createIssueModal.body.trim(),
           creator: 'human',
-          assignee: null
+          assignee: createIssueModal.receiver || null
         })
       })
       const data = await res.json()
       if (data.success) {
-        setCreateIssueModal({ open: false, title: '', body: '', creating: false, error: null })
+        setCreateIssueModal({ open: false, title: '', body: '', receiver: '', creating: false, error: null, focusedField: 'title' })
         await fetchProjectData()
       } else {
         setCreateIssueModal(prev => ({ ...prev, creating: false, error: data.error || 'Failed to create issue' }))
@@ -607,7 +608,7 @@ function App() {
       const res = await authFetch(projectApi(`/issues/${issueModal.issue.id}/comments`), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ author: 'user', body: issueModal.newComment.trim() })
+        body: JSON.stringify({ author: 'human', body: issueModal.newComment.trim() })
       })
       if (res.ok) {
         // Refresh issue modal
@@ -2721,26 +2722,44 @@ function App() {
                 className="w-full px-3 py-2 border rounded-md bg-white dark:bg-neutral-800 border-neutral-300 dark:border-neutral-600 text-neutral-900 dark:text-neutral-100"
                 value={createIssueModal.title}
                 onChange={(e) => setCreateIssueModal(prev => ({ ...prev, title: e.target.value }))}
-                onKeyDown={(e) => { if (e.key === 'Enter') createIssue() }}
+                onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); document.getElementById('create-issue-body')?.focus() } }}
+                onFocus={() => setCreateIssueModal(prev => ({ ...prev, focusedField: 'title' }))}
                 disabled={createIssueModal.creating}
                 autoFocus
               />
               <p className="text-xs text-neutral-400 dark:text-neutral-500 mt-1">Created as a human issue in the project database</p>
             </div>
             <div>
-              <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">Description <span className="text-neutral-400 font-normal">(optional)</span></label>
+              <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">Description <span className="text-neutral-400 font-normal">{createIssueModal.focusedField === 'title' ? `(optional, Enter to move here)` : '(optional)'}</span></label>
               <textarea
+                id="create-issue-body"
                 placeholder="Additional details, context, acceptance criteria..."
                 className="w-full px-3 py-2 border rounded-md min-h-[100px] bg-white dark:bg-neutral-800 border-neutral-300 dark:border-neutral-600 text-neutral-900 dark:text-neutral-100"
                 value={createIssueModal.body}
                 onChange={(e) => setCreateIssueModal(prev => ({ ...prev, body: e.target.value }))}
+                onKeyDown={(e) => { if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') createIssue() }}
+                onFocus={() => setCreateIssueModal(prev => ({ ...prev, focusedField: 'body' }))}
                 disabled={createIssueModal.creating}
               />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">Receiver <span className="text-neutral-400 font-normal">(optional)</span></label>
+              <select
+                className="w-full px-3 py-2 border rounded-md bg-white dark:bg-neutral-800 border-neutral-300 dark:border-neutral-600 text-neutral-900 dark:text-neutral-100"
+                value={createIssueModal.receiver}
+                onChange={(e) => setCreateIssueModal(prev => ({ ...prev, receiver: e.target.value }))}
+                disabled={createIssueModal.creating}
+              >
+                <option value="">None (visible to all)</option>
+                {[...agents.managers, ...agents.workers].map(a => (
+                  <option key={a.name} value={a.name}>{a.name}{a.role ? ` (${a.role})` : ''}</option>
+                ))}
+              </select>
             </div>
             <div className="flex justify-end gap-2">
               <Button variant="outline" onClick={() => setCreateIssueModal(prev => ({ ...prev, open: false }))}>Cancel</Button>
               <Button onClick={createIssue} disabled={!createIssueModal.title.trim() || createIssueModal.creating}>
-                {createIssueModal.creating ? 'Creating...' : 'Create'}
+                {createIssueModal.creating ? 'Creating...' : createIssueModal.focusedField === 'body' ? `Create (${modKey}+Enter)` : 'Create'}
               </Button>
             </div>
           </div>
@@ -2758,37 +2777,81 @@ function App() {
               <RefreshCw className="w-6 h-6 animate-spin text-neutral-400" />
             </div>
           ) : issueModal.issue ? (
-            <div className="space-y-4">
-              {/* Meta */}
-              <div className="flex flex-wrap items-center gap-2">
-                <Badge variant={issueModal.issue.status === 'open' ? 'success' : 'secondary'}>{issueModal.issue.status || 'open'}</Badge>
+            <div className="space-y-5">
+              {/* Header meta row */}
+              <div className="flex items-start justify-between gap-3">
+                <div className="flex flex-wrap items-center gap-2 min-w-0">
+                  <Badge variant={issueModal.issue.status === 'open' ? 'success' : 'secondary'} className="text-xs">{issueModal.issue.status || 'open'}</Badge>
+                  {issueModal.issue.labels && issueModal.issue.labels.split(',').map(l => l.trim()).filter(Boolean).map(label => (
+                    <Badge key={label} variant="outline" className="text-[10px] text-purple-600 dark:text-purple-400 border-purple-300 dark:border-purple-700">{label}</Badge>
+                  ))}
+                </div>
+                {isWriteMode && (
+                  <Button
+                    variant={issueModal.issue.status === 'open' ? 'outline' : 'default'}
+                    size="sm"
+                    className={`text-xs shrink-0 ${issueModal.issue.status === 'open' ? 'text-red-600 dark:text-red-400 border-red-200 dark:border-red-800 hover:bg-red-50 dark:hover:bg-red-950' : 'text-green-600 dark:text-green-400 border-green-200 dark:border-green-800 hover:bg-green-50 dark:hover:bg-green-950'}`}
+                    onClick={async () => {
+                      const newStatus = issueModal.issue.status === 'open' ? 'closed' : 'open'
+                      try {
+                        await authFetch(projectApi(`/issues/${issueModal.issue.id}`), {
+                          method: 'PATCH',
+                          headers: { 'Content-Type': 'application/json' },
+                          body: JSON.stringify({ status: newStatus })
+                        })
+                        setIssueModal(prev => ({ ...prev, issue: { ...prev.issue, status: newStatus } }))
+                        await fetchProjectData()
+                      } catch {}
+                    }}
+                  >{issueModal.issue.status === 'open' ? '✕ Close Issue' : '↻ Reopen Issue'}</Button>
+                )}
+              </div>
+
+              {/* Info grid */}
+              <div className="grid grid-cols-2 gap-x-4 gap-y-1.5 text-xs text-neutral-500 dark:text-neutral-400">
                 {issueModal.issue.creator && (
-                  <span className="text-xs text-neutral-500 dark:text-neutral-400 flex items-center gap-1"><User className="w-3 h-3" />{issueModal.issue.creator}</span>
+                  <>
+                    <span className="text-neutral-400 dark:text-neutral-500">Created by</span>
+                    <span className="flex items-center gap-1 text-neutral-700 dark:text-neutral-200"><User className="w-3 h-3" />{issueModal.issue.creator}</span>
+                  </>
                 )}
                 {issueModal.issue.assignee && (
-                  <span className="text-xs text-green-600 dark:text-green-400 flex items-center gap-1"><UserCheck className="w-3 h-3" />{issueModal.issue.assignee}</span>
+                  <>
+                    <span className="text-neutral-400 dark:text-neutral-500">Assigned to</span>
+                    <span className="flex items-center gap-1 text-green-600 dark:text-green-400"><UserCheck className="w-3 h-3" />{issueModal.issue.assignee}</span>
+                  </>
                 )}
-                {issueModal.issue.labels && (
-                  <span className="text-xs text-purple-500 dark:text-purple-400">{issueModal.issue.labels}</span>
+                <span className="text-neutral-400 dark:text-neutral-500">Created</span>
+                <span className="flex items-center gap-1"><Clock className="w-3 h-3" />{new Date(issueModal.issue.created_at).toLocaleString()}</span>
+                {issueModal.issue.closed_at && (
+                  <>
+                    <span className="text-neutral-400 dark:text-neutral-500">Closed</span>
+                    <span className="flex items-center gap-1"><Clock className="w-3 h-3" />{new Date(issueModal.issue.closed_at).toLocaleString()}</span>
+                  </>
                 )}
-                <span className="text-xs text-neutral-400 dark:text-neutral-500 flex items-center gap-1"><Clock className="w-3 h-3" />{new Date(issueModal.issue.created_at).toLocaleString()}</span>
               </div>
 
               {/* Body */}
               {issueModal.issue.body && (
-                <div className="bg-neutral-50 dark:bg-neutral-900 rounded p-4 prose prose-sm prose-neutral dark:prose-invert max-w-none ">
-                  <ReactMarkdown remarkPlugins={[remarkGfm]}>{issueModal.issue.body}</ReactMarkdown>
-                </div>
+                <>
+                  <Separator />
+                  <div className="bg-neutral-50 dark:bg-neutral-900 rounded-lg p-4 prose prose-sm prose-neutral dark:prose-invert max-w-none">
+                    <ReactMarkdown remarkPlugins={[remarkGfm]}>{issueModal.issue.body}</ReactMarkdown>
+                  </div>
+                </>
               )}
 
               {/* Comments */}
               {issueModal.comments.length > 0 && (
                 <>
                   <Separator />
-                  <h3 className="text-sm font-semibold text-neutral-600 dark:text-neutral-300">Comments ({issueModal.comments.length})</h3>
-                  <div className="space-y-3 ">
+                  <h3 className="text-sm font-semibold text-neutral-600 dark:text-neutral-300 flex items-center gap-2">
+                    <span>Comments</span>
+                    <Badge variant="outline" className="text-[10px] font-normal">{issueModal.comments.length}</Badge>
+                  </h3>
+                  <div className="space-y-3">
                     {issueModal.comments.map((comment) => (
-                      <div key={comment.id} className="bg-neutral-50 dark:bg-neutral-900 rounded p-3">
+                      <div key={comment.id} className="bg-neutral-50 dark:bg-neutral-900 rounded-lg p-3 border border-neutral-100 dark:border-neutral-800">
                         <div className="flex items-center gap-2 mb-2">
                           <Avatar className="w-6 h-6">
                             <AvatarFallback className="bg-gradient-to-br from-blue-400 to-purple-500 text-white text-xs">
@@ -2796,7 +2859,7 @@ function App() {
                             </AvatarFallback>
                           </Avatar>
                           <span className="text-sm font-semibold text-neutral-800 dark:text-neutral-100 capitalize">{comment.author}</span>
-                          <span className="text-xs text-neutral-400 dark:text-neutral-500">{new Date(comment.created_at).toLocaleString()}</span>
+                          <span className="text-xs text-neutral-400 dark:text-neutral-500 ml-auto">{new Date(comment.created_at).toLocaleString()}</span>
                         </div>
                         <div className="text-sm text-neutral-700 dark:text-neutral-300 prose prose-sm prose-neutral dark:prose-invert max-w-none">
                           <ReactMarkdown remarkPlugins={[remarkGfm]}>{stripAllMetaBlocks(comment.body)}</ReactMarkdown>
@@ -2810,13 +2873,14 @@ function App() {
                   </div>
                 </>
               )}
+
               {/* Add Comment */}
               {isWriteMode && <>
               <Separator />
-              <div className="flex gap-2">
+              <div className="space-y-2">
                 <textarea
-                  className="flex-1 text-sm bg-neutral-50 dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-700 rounded p-2 resize-none focus:outline-none focus:ring-1 focus:ring-blue-500 text-neutral-800 dark:text-neutral-100"
-                  rows={2}
+                  className="w-full text-sm bg-neutral-50 dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-700 rounded-lg p-3 resize-none focus:outline-none focus:ring-2 focus:ring-blue-500/40 focus:border-blue-500 text-neutral-800 dark:text-neutral-100 placeholder:text-neutral-400"
+                  rows={3}
                   placeholder="Add a comment..."
                   value={issueModal.newComment || ''}
                   onChange={(e) => setIssueModal(prev => ({ ...prev, newComment: e.target.value }))}
@@ -2827,14 +2891,15 @@ function App() {
                     }
                   }}
                 />
-                <Button
-                  size="sm"
-                  disabled={!issueModal.newComment?.trim() || issueModal.commenting}
-                  onClick={submitIssueComment}
-                  className="self-end"
-                >
-                  {issueModal.commenting ? '...' : 'Post'}
-                </Button>
+                <div className="flex justify-end">
+                  <Button
+                    size="sm"
+                    disabled={!issueModal.newComment?.trim() || issueModal.commenting}
+                    onClick={submitIssueComment}
+                  >
+                    {issueModal.commenting ? 'Posting...' : `Post (${modKey}+↵)`}
+                  </Button>
+                </div>
               </div>
               </>}
             </div>

--- a/src/server.js
+++ b/src/server.js
@@ -2461,11 +2461,41 @@ const server = http.createServer(async (req, res) => {
           }
           const db = runner.getDb();
           const now = new Date().toISOString();
-          const result = db.prepare('INSERT INTO comments (issue_id, author, body, created_at) VALUES (?, ?, ?, ?)').run(issueId, author || 'user', commentBody.trim(), now);
+          const result = db.prepare('INSERT INTO comments (issue_id, author, body, created_at) VALUES (?, ?, ?, ?)').run(issueId, author || 'human', commentBody.trim(), now);
           db.prepare('UPDATE issues SET updated_at = ? WHERE id = ?').run(now, issueId);
           db.close();
           res.writeHead(200, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ id: result.lastInsertRowid }));
+        } catch (e) {
+          res.writeHead(500, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: e.message }));
+        }
+      });
+      return;
+    }
+
+    // PATCH /api/projects/:id/issues/:issueId — update issue status
+    const issuePatchMatch = req.method === 'PATCH' && subPath.match(/^issues\/(\d+)$/);
+    if (issuePatchMatch) {
+      if (!requireWrite(req, res)) return;
+      let body = '';
+      req.on('data', d => body += d);
+      req.on('end', () => {
+        try {
+          const issueId = parseInt(issuePatchMatch[1], 10);
+          const { status } = JSON.parse(body);
+          if (!['open', 'closed'].includes(status)) {
+            res.writeHead(400, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'Status must be "open" or "closed"' }));
+            return;
+          }
+          const db = runner.getDb();
+          const now = new Date().toISOString();
+          const closedAt = status === 'closed' ? now : null;
+          db.prepare('UPDATE issues SET status = ?, updated_at = ?, closed_at = ? WHERE id = ?').run(status, now, closedAt, issueId);
+          db.close();
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ success: true }));
         } catch (e) {
           res.writeHead(500, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: e.message }));


### PR DESCRIPTION
## Changes

### Create Issue modal
- Receiver dropdown to assign issues to specific agents
- Enter in title moves focus to description
- ⌘/Ctrl+Enter submits from description
- Dynamic keyboard shortcut hints (platform-aware)

### Issue detail modal (redesigned)
- Clean info grid layout (created by, assigned to, dates)
- Colored close/reopen button (red for close, green for reopen)
- Comment cards with borders and right-aligned timestamps
- Full-width comment textarea with Post shortcut hint
- Shows closed_at date for closed issues

### API
- `PATCH /api/projects/:id/issues/:issueId` — open/close issues

### Bug fix
- Consistent `human` author instead of `user` for comments

Closes #28