### PR TITLE
fix: update default mid tier to claude-sonnet-4-6

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -47,7 +47,7 @@ function detectTokenProvider(token) {
 const MODEL_TIERS = {
   anthropic: {
     high:  { model: 'claude-opus-4-6' },
-    mid:   { model: 'claude-sonnet-4-5' },
+    mid:   { model: 'claude-sonnet-4-6' },
     low:   { model: 'claude-haiku-4-5-20251001' },
   },
   openai: {


### PR DESCRIPTION
Default Anthropic mid tier was set to `claude-sonnet-4-5` (outdated). Updated to `claude-sonnet-4-6`.