### PR TITLE
fix: kill entire process group on agent abort to prevent orphan leaks

### DIFF
--- a/src/agent-runner.js
+++ b/src/agent-runner.js
@@ -216,9 +216,11 @@ function executeBash(input, cwd, remainingMs = 0, bashEnv = null, runtime = null
     const proc = spawn('bash', ['-c', command], {
       cwd,
       stdio: ['ignore', 'pipe', 'pipe'],
+      detached: true,  // new process group so grandchildren can be killed too
       timeout,
       ...(bashEnv ? { env: bashEnv } : {}),
     });
+    proc.unref();  // don't keep the event loop alive
     runtime?.registerProcess?.(proc);
 
     let stdout = '';
@@ -227,15 +229,19 @@ function executeBash(input, cwd, remainingMs = 0, bashEnv = null, runtime = null
     proc.stdout.on('data', (d) => { stdout += d; });
     proc.stderr.on('data', (d) => { stderr += d; });
 
+    const killProc = (signal) => {
+      // Kill the entire process group (negative pid) to catch grandchildren
+      try { process.kill(-proc.pid, signal); } catch {}
+    };
     const onAbort = () => {
-      try { proc.kill('SIGTERM'); } catch {}
-      setTimeout(() => { try { proc.kill('SIGKILL'); } catch {} }, 5000);
+      killProc('SIGTERM');
+      setTimeout(() => killProc('SIGKILL'), 5000);
     };
     runtime?.signal?.addEventListener('abort', onAbort, { once: true });
 
     const timer = setTimeout(() => {
-      proc.kill('SIGTERM');
-      setTimeout(() => { try { proc.kill('SIGKILL'); } catch {} }, 5000);
+      killProc('SIGTERM');
+      setTimeout(() => killProc('SIGKILL'), 5000);
     }, timeout);
 
     proc.on('close', (code) => {
@@ -441,7 +447,8 @@ export async function runAgentWithAPI(opts) {
 
   const killRunningProcesses = (signal) => {
     for (const proc of runningProcesses) {
-      try { proc.kill(signal); } catch {}
+      // Kill entire process group to prevent orphaned grandchildren
+      try { process.kill(-proc.pid, signal); } catch {}
     }
   };
 


### PR DESCRIPTION
Fixes #73

## Problem
When an agent run is cancelled or times out, `executeBash` kills the bash process but not its grandchildren (subprocesses spawned by the bash command, e.g. `claude` CLI, `npm`, etc.). These become orphans and accumulate memory, causing OOM crashes on the host.

## Fix
- Add `detached: true` to `spawn` so bash runs in its own process group
- Replace `proc.kill(signal)` with `process.kill(-proc.pid, signal)` everywhere (negative pid = entire process group)
- Apply to all kill paths: timeout handler, abort signal handler, and `killRunningProcesses`
- Add `proc.unref()` so the event loop isn't kept alive by the child

## Changes
- `src/agent-runner.js`: 3 kill sites updated + `detached: true` + `proc.unref()`