### PR TITLE
feat: SSE live updates for orchestrator state and reports

### DIFF
--- a/monitor/src/App.jsx
+++ b/monitor/src/App.jsx
@@ -130,8 +130,35 @@ function App() {
       }
     }
     init()
-    const interval = setInterval(fetchGlobalStatus, 5000)
-    return () => clearInterval(interval)
+    // Polling as fallback (longer interval since SSE handles real-time)
+    const interval = setInterval(fetchGlobalStatus, 30000)
+
+    // SSE for instant status updates
+    const evtSource = new EventSource('/api/events')
+    evtSource.onmessage = (e) => {
+      try {
+        const event = JSON.parse(e.data)
+        if (event.type === 'status-update' && event.status) {
+          setProjects(prev => prev.map(p => p.id === event.project ? event.status : p))
+          setSelectedProject(prev => {
+            if (!prev || prev.id !== event.project) return prev
+            const prevAgent = prevAgentRef.current
+            const curAgent = event.status.currentAgent || null
+            if (prevAgent !== null && prevAgent !== curAgent) {
+              if (onAgentChangeRef.current) onAgentChangeRef.current()
+            }
+            prevAgentRef.current = curAgent
+            return event.status
+          })
+          setLastUpdate(new Date())
+        }
+      } catch {}
+    }
+
+    return () => {
+      clearInterval(interval)
+      evtSource.close()
+    }
   }, [])
 
   // Handle browser back/forward

--- a/monitor/src/components/layout/ProjectView.jsx
+++ b/monitor/src/components/layout/ProjectView.jsx
@@ -223,13 +223,26 @@ export default function ProjectView({
       }
 
       const logsInterval = setInterval(fetchLogs, 10000)
-      const commentsInterval = setInterval(() => fetchComments(1, localStorage.getItem('selectedAgent') || null, false, true), 30000)
-      const projectDataInterval = setInterval(fetchProjectData, 30000)
+      // Longer polling intervals — SSE handles real-time updates
+      const commentsInterval = setInterval(() => fetchComments(1, localStorage.getItem('selectedAgent') || null, false, true), 60000)
+      const projectDataInterval = setInterval(fetchProjectData, 60000)
+
+      // SSE for instant report updates
+      const evtSource = new EventSource('/api/events')
+      evtSource.onmessage = (e) => {
+        try {
+          const event = JSON.parse(e.data)
+          if (event.type === 'report-new' && event.project === selectedProject.id) {
+            fetchComments(1, localStorage.getItem('selectedAgent') || null, false, true)
+          }
+        } catch {}
+      }
       
       return () => {
         clearInterval(logsInterval)
         clearInterval(commentsInterval)
         clearInterval(projectDataInterval)
+        evtSource.close()
       }
     }
   }, [selectedProject?.id])

--- a/src/server.js
+++ b/src/server.js
@@ -171,6 +171,28 @@ const sseClients = new Set();
 const notifications = []; // In-memory notification store
 const MAX_NOTIFICATIONS = 200;
 
+// Throttled status broadcasts — at most once per second per project
+const _statusBroadcastTimers = new Map();
+function broadcastStatusUpdate(projectId) {
+  if (_statusBroadcastTimers.has(projectId)) return; // already scheduled
+  _statusBroadcastTimers.set(projectId, setTimeout(() => {
+    _statusBroadcastTimers.delete(projectId);
+    const runner = projects.get(projectId);
+    if (!runner) return;
+    const data = JSON.stringify({ type: 'status-update', project: projectId, status: runner.getStatus() });
+    for (const client of sseClients) {
+      client.write(`data: ${data}\n\n`);
+    }
+  }, 500)); // 500ms debounce
+}
+
+function broadcastReportUpdate(projectId, reportId, agent, cycle) {
+  const data = JSON.stringify({ type: 'report-new', project: projectId, reportId, agent, cycle });
+  for (const client of sseClients) {
+    client.write(`data: ${data}\n\n`);
+  }
+}
+
 function broadcastEvent(event) {
   const messages = {
     milestone: `📌 New milestone: ${event.title}`,
@@ -317,6 +339,9 @@ class ProjectRunner {
     }
 
     if (save) this.saveState();
+
+    // Broadcast status update via SSE for instant dashboard refresh
+    broadcastStatusUpdate(this.id);
   }
 
   get projectDir() {
@@ -1689,8 +1714,11 @@ class ProjectRunner {
         )`);
         try { db.exec('ALTER TABLE reports ADD COLUMN summary TEXT'); } catch {}
         db.prepare('INSERT INTO reports (cycle, agent, body, created_at) VALUES (?, ?, ?, ?)').run(this.cycleCount, agent.name, reportBody, new Date().toISOString());
+        const lastId = db.prepare('SELECT last_insert_rowid() as id').get().id;
         db.close();
         log(`Saved report for ${agent.name}`, this.id);
+        // Broadcast new report via SSE
+        broadcastReportUpdate(this.id, lastId, agent.name, this.cycleCount);
       } catch (dbErr) {
         log(`Failed to write report: ${dbErr.message}`, this.id);
       }
@@ -1703,6 +1731,7 @@ class ProjectRunner {
     this.currentAgentProcess = null;
     this.currentAgentStartTime = null;
     this.currentAgentLog = [];
+    broadcastStatusUpdate(this.id);
     this.currentAgentModel = null;
 
     return { success, resultText, killedByTimeout: !!killedByTimeout };
@@ -1711,6 +1740,7 @@ class ProjectRunner {
   async runAgent(agent, config, mode = null, task = null, visibility = null) {
     this.currentAgent = agent.name;
     this.currentAgentStartTime = Date.now();
+    broadcastStatusUpdate(this.id);
     const runAbortController = new AbortController();
     this.currentAgentProcess = {
       kill: () => runAbortController.abort(),


### PR DESCRIPTION
## What
Real-time dashboard updates via Server-Sent Events instead of polling.

## Backend
- `broadcastStatusUpdate(projectId)` — fires on every `setState()` + agent start/done, 500ms debounce to avoid flooding
- `broadcastReportUpdate()` — fires when a new agent report is saved to DB
- Uses existing `/api/events` SSE infrastructure

## Frontend
- **App.jsx**: Listens for `status-update` SSE events → updates project state + orchestrator card instantly
- **ProjectView.jsx**: Listens for `report-new` SSE events → refreshes agent reports immediately
- Polling intervals increased as fallback: status 5s→30s, project data/reports 30s→60s

## Result
- Orchestrator state card updates **instantly** when agents start/stop, phases change, cycles complete
- Agent reports panel refreshes **immediately** when a new report is saved
- Reduced polling load (~6x fewer HTTP requests)