### PR TITLE
feat: add epoch counter + standardize terminology (#105)

### DIFF
--- a/monitor/src/components/layout/ProjectListPage.jsx
+++ b/monitor/src/components/layout/ProjectListPage.jsx
@@ -263,7 +263,7 @@ export default function ProjectListPage({
                           {Math.floor(project.currentAgentRuntime / 60)}m {project.currentAgentRuntime % 60}s
                         </p>
                       )}
-                      <p className="text-xs text-neutral-400 dark:text-neutral-500 mt-1">Cycle {project.cycleCount}{project.phase ? ` · ${project.phase}` : ''}</p>
+                      <p className="text-xs text-neutral-400 dark:text-neutral-500 mt-1">Epoch {project.epochCount || 0} · Cycle {project.cycleCount}{project.phase ? ` · ${project.phase}` : ''}</p>
                       {project.cost && project.cost.totalCost > 0 && (
                         <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-0.5">${project.cost.totalCost.toFixed(2)} · ${project.cost.last24hCost.toFixed(2)}/24h</p>
                       )}

--- a/monitor/src/components/project/OrchestratorState.jsx
+++ b/monitor/src/components/project/OrchestratorState.jsx
@@ -24,8 +24,8 @@ export function OrchestratorStateCard({ selectedProject, globalUptime, controlAc
             </div>
           )}
           <div className="flex justify-between items-center">
-            <span className="text-neutral-600 dark:text-neutral-300">Cycle</span>
-            <span className="text-2xl font-mono font-bold">{selectedProject.cycleCount}</span>
+            <span className="text-neutral-600 dark:text-neutral-300">Epoch / Cycle</span>
+            <span className="text-2xl font-mono font-bold">{selectedProject.epochCount || 0}<span className="text-base text-neutral-400 dark:text-neutral-500 mx-1">/</span>{selectedProject.cycleCount}</span>
           </div>
           <div className="flex justify-between items-center">
             <span className="text-neutral-600 dark:text-neutral-300">Agent</span>

--- a/src/server.js
+++ b/src/server.js
@@ -290,7 +290,8 @@ class ProjectRunner {
     this.path = config.path.replace(/^~/, process.env.HOME);
     this.enabled = config.enabled !== false;
     this.archived = config.archived === true;
-    this.cycleCount = 0;
+    this.cycleCount = 0;   // Cycles: manager + worker runs
+    this.epochCount = 0;   // Epochs: full Athena → implementation → verification → Athena loops
     this.currentAgent = null;
     this.currentAgentProcess = null;
     this.currentAgentStartTime = null;
@@ -893,6 +894,7 @@ class ProjectRunner {
       paused: this.isPaused,
       pauseReason: this.pauseReason || null,
       cycleCount: this.cycleCount,
+      epochCount: this.epochCount,
       currentAgent: this.currentAgent,
       currentAgentModel: this.currentAgentModel,
       currentAgentRuntime: this.currentAgentStartTime
@@ -958,6 +960,7 @@ class ProjectRunner {
     // 2. Reset cycle count, phase, and save state
     this.setState({
       cycleCount: 0,
+      epochCount: 0,
       phase: 'athena',
       milestoneTitle: null,
       milestoneDescription: null,
@@ -1039,6 +1042,7 @@ class ProjectRunner {
       if (fs.existsSync(statePath)) {
         const state = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
         this.cycleCount = state.cycleCount || 0;
+        this.epochCount = state.epochCount || 0;
         this.completedAgents = state.completedAgents || [];
         this.currentCycleId = state.currentCycleId || null;
         this.currentSchedule = state.currentSchedule || null;
@@ -1075,6 +1079,7 @@ class ProjectRunner {
     try {
       const state = {
         cycleCount: this.cycleCount,
+        epochCount: this.epochCount || 0,
         completedAgents: this.completedAgents || [],
         currentCycleId: this.currentCycleId,
         currentSchedule: this.currentSchedule || null,
@@ -1375,7 +1380,9 @@ class ProjectRunner {
                   isFixRound: false,
                   phase: 'implementation',
                 });
-                log(`New milestone (${this.milestoneCyclesBudget} cycles): ${this.milestoneDescription.slice(0, 100)}...`, this.id);
+                this.epochCount++;
+                this.saveState();
+                log(`Epoch ${this.epochCount}: New milestone (${this.milestoneCyclesBudget} cycles): ${this.milestoneDescription.slice(0, 100)}...`, this.id);
                 broadcastEvent({ type: 'milestone', project: this.id, title: this.milestoneTitle, cycles: this.milestoneCyclesBudget });
               } catch (e) {
                 log(`Failed to parse milestone: ${e.message}`, this.id);


### PR DESCRIPTION
Closes #105

## Terminology
| Term | Definition |
|------|-----------|
| **Run** | Single agent API call |
| **Cycle** | Manager + scheduled worker runs |
| **Epoch** | Full Athena → implementation → verification → Athena loop |

## Changes
- Added `epochCount` field, persisted in state.json
- Increments when Athena assigns a new milestone (→ implementation)
- Resets on bootstrap
- UI: Orchestrator card shows `Epoch N / Cycle N`
- UI: Project list shows `Epoch N · Cycle N · phase`

Existing projects start at epoch 0; first new milestone will set it to 1.