### PR TITLE
refactor: extract DashboardWidget wrapper for consistent dashboard cards

### DIFF
--- a/monitor/src/components/layout/ProjectView.jsx
+++ b/monitor/src/components/layout/ProjectView.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react'
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import DashboardWidget from '@/components/ui/DashboardWidget'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Users, User, Sparkles, Settings, ScrollText, RefreshCw, Pause, Play, RotateCcw, Save, GitPullRequest, ArrowLeft, Github, Bell, ChevronDown, Lock, Unlock } from 'lucide-react'
@@ -740,10 +741,8 @@ export default function ProjectView({
                 onNewChat={(session) => { setChatSession(session); setChatPanelOpen(true) }}
               />}
 
-              <Card className="h-[500px]">
-                <CardHeader><CardTitle className="flex items-center gap-2"><Sparkles className="w-4 h-4" />Managers ({agents.managers.length})</CardTitle></CardHeader>
-                <CardContent className="flex-1 overflow-hidden">
-                  <div className="space-y-2 h-full overflow-y-auto">
+              <DashboardWidget icon={Sparkles} title={`Managers (${agents.managers.length})`}>
+                  <div className="space-y-2">
                     {agents.managers.map((agent) => (
                       <WorkerCard
                         key={agent.name}
@@ -759,13 +758,10 @@ export default function ProjectView({
                     ))}
                     {agents.managers.length === 0 && <p className="text-sm text-neutral-400 dark:text-neutral-500">No managers</p>}
                   </div>
-                </CardContent>
-              </Card>
+              </DashboardWidget>
 
-              <Card className="h-[500px]">
-                <CardHeader><CardTitle className="flex items-center gap-2"><Users className="w-4 h-4" />Workers ({agents.workers.length})</CardTitle></CardHeader>
-                <CardContent className="flex-1 overflow-hidden">
-                  <div className="space-y-2 h-full overflow-y-auto">
+              <DashboardWidget icon={Users} title={`Workers (${agents.workers.length})`}>
+                  <div className="space-y-2">
                     {agents.workers.map((agent) => (
                       <WorkerCard
                         key={agent.name}
@@ -780,13 +776,10 @@ export default function ProjectView({
                     ))}
                     {agents.workers.length === 0 && <p className="text-sm text-neutral-400 dark:text-neutral-500">No workers</p>}
                   </div>
-                </CardContent>
-              </Card>
+              </DashboardWidget>
 
-              <Card>
-                <CardHeader><CardTitle className="flex items-center gap-2"><GitPullRequest className="w-4 h-4" />Open PRs ({prs.length})</CardTitle></CardHeader>
-                <CardContent>
-                  <div className="space-y-2 max-h-96 overflow-y-auto">
+              <DashboardWidget icon={GitPullRequest} title={`Open PRs (${prs.length})`}>
+                  <div className="space-y-2">
                     {prs.map((pr) => (
                       <a key={pr.number} href={`${repoUrl}/pull/${pr.number}`} target="_blank" rel="noopener noreferrer"
                         className="block p-2 bg-neutral-50 dark:bg-neutral-900 hover:bg-neutral-100 dark:hover:bg-neutral-800 rounded cursor-pointer transition-colors">
@@ -802,8 +795,7 @@ export default function ProjectView({
                     ))}
                     {prs.length === 0 && <p className="text-sm text-neutral-400 dark:text-neutral-500">No open PRs</p>}
                   </div>
-                </CardContent>
-              </Card>
+              </DashboardWidget>
 
               <AgentReportsCard
                 comments={comments}

--- a/monitor/src/components/project/AgentReportsCard.jsx
+++ b/monitor/src/components/project/AgentReportsCard.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { MessageSquare, XCircle, Timer } from 'lucide-react'
-import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import DashboardWidget from '@/components/ui/DashboardWidget'
 import { Separator } from '@/components/ui/separator'
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import { Badge } from '@/components/ui/badge'
@@ -109,14 +109,11 @@ export default function AgentReportsCard({
   setReportsPanelOpen,
 }) {
   return (
-    <Card className="h-[500px]">
-      <CardHeader className="pb-2">
-        <CardTitle className="flex items-center justify-between">
-          <span className="flex items-center gap-2"><MessageSquare className="w-4 h-4" />Agent Reports</span>
-          <span className="text-sm font-normal text-neutral-500 dark:text-neutral-400">{comments.length} loaded</span>
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="pt-0 overflow-hidden">
+    <DashboardWidget
+      icon={MessageSquare}
+      title="Agent Reports"
+      headerRight={<span className="text-sm font-normal text-neutral-500 dark:text-neutral-400">{comments.length} loaded</span>}
+    >
         <div className="divide-y divide-neutral-100 dark:divide-neutral-800 overflow-y-auto overflow-x-hidden h-full" onScroll={(e) => {
           const { scrollTop, scrollHeight, clientHeight } = e.target
           if (scrollHeight - scrollTop - clientHeight < 100) loadMoreComments()
@@ -166,7 +163,6 @@ export default function AgentReportsCard({
             </div>
           )}
         </div>
-      </CardContent>
-    </Card>
+    </DashboardWidget>
   )
 }

--- a/monitor/src/components/project/ChatCard.jsx
+++ b/monitor/src/components/project/ChatCard.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { MessageCircle, Plus, Trash2 } from 'lucide-react'
-import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import DashboardWidget from '@/components/ui/DashboardWidget'
 import { useAuth } from '@/hooks/useAuth'
 
 export default function ChatCard({ selectedProject, onOpenChat, onNewChat }) {
@@ -39,23 +39,19 @@ export default function ChatCard({ selectedProject, onOpenChat, onNewChat }) {
   }
 
   return (
-    <Card className="h-[500px]">
-      <CardHeader className="pb-2">
-        <CardTitle className="flex items-center justify-between">
-          <span className="flex items-center gap-2">
-            <MessageCircle className="w-4 h-4" />
-            Chat
-          </span>
-          <button
-            onClick={handleNew}
-            className="p-1 rounded hover:bg-neutral-100 dark:hover:bg-neutral-700 text-neutral-500 dark:text-neutral-400 transition-colors"
-            title="New Chat"
-          >
-            <Plus className="w-4 h-4" />
-          </button>
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="pt-0 overflow-hidden">
+    <DashboardWidget
+      icon={MessageCircle}
+      title="Chat"
+      headerRight={
+        <button
+          onClick={handleNew}
+          className="p-1 rounded hover:bg-neutral-100 dark:hover:bg-neutral-700 text-neutral-500 dark:text-neutral-400 transition-colors"
+          title="New Chat"
+        >
+          <Plus className="w-4 h-4" />
+        </button>
+      }
+    >
         <div className="divide-y divide-neutral-100 dark:divide-neutral-800 overflow-y-auto h-full">
           {sessions.length === 0 && !loading && (
             <p className="text-sm text-neutral-400 dark:text-neutral-500 text-center py-4">
@@ -94,7 +90,6 @@ export default function ChatCard({ selectedProject, onOpenChat, onNewChat }) {
             </div>
           )}
         </div>
-      </CardContent>
-    </Card>
+    </DashboardWidget>
   )
 }

--- a/monitor/src/components/project/HumanInterventionCard.jsx
+++ b/monitor/src/components/project/HumanInterventionCard.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { AlertTriangle, User, UserCheck, MessageSquare, ArrowUp, ArrowDown } from 'lucide-react'
-import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import DashboardWidget from '@/components/ui/DashboardWidget'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
@@ -25,17 +25,15 @@ export default function HumanInterventionCard({
   const toHuman = filtered.filter(i => i.assignee === 'human' && i.creator !== 'human' && i.creator !== 'chat')
 
   return (
-    <Card className="flex flex-col max-h-[500px]">
-      <CardHeader className="shrink-0 pb-2">
-        <CardTitle className="flex items-center gap-2">
-          <AlertTriangle className="w-4 h-4" />
-          Intervention
-          {openCount > 0 && (
-            <Badge variant="destructive" className="text-[10px] px-1.5 py-0 h-4">
-              {openCount}
-            </Badge>
-          )}
-        </CardTitle>
+    <DashboardWidget
+      icon={AlertTriangle}
+      title="Intervention"
+      badge={openCount > 0 && (
+        <Badge variant="destructive" className="text-[10px] px-1.5 py-0 h-4">
+          {openCount}
+        </Badge>
+      )}
+      headerExtra={
         <div className="flex gap-1 mt-2">
           {['open', 'closed', 'all'].map(f => (
             <button key={f} onClick={() => setFilter(f)}
@@ -44,8 +42,9 @@ export default function HumanInterventionCard({
             </button>
           ))}
         </div>
-      </CardHeader>
-      <CardContent className="flex-1 flex flex-col overflow-hidden pt-0">
+      }
+      contentClassName="flex flex-col"
+    >
         <div className="flex-1 overflow-y-auto space-y-3">
           {/* Needs your attention — agents asking for help */}
           {toHuman.length > 0 && (
@@ -92,8 +91,7 @@ export default function HumanInterventionCard({
             </Button>
           </>
         )}
-      </CardContent>
-    </Card>
+    </DashboardWidget>
   )
 }
 

--- a/monitor/src/components/project/OrchestratorState.jsx
+++ b/monitor/src/components/project/OrchestratorState.jsx
@@ -1,15 +1,13 @@
 import React, { useState } from 'react'
 import { Activity, DollarSign, Settings, Save, Info, AlertTriangle } from 'lucide-react'
-import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import DashboardWidget from '@/components/ui/DashboardWidget'
 import { Badge } from '@/components/ui/badge'
 import { Separator } from '@/components/ui/separator'
 import SleepCountdown from '@/components/layout/SleepCountdown'
 
 export function OrchestratorStateCard({ selectedProject, globalUptime, controlAction, isWriteMode }) {
   return (
-    <Card>
-      <CardHeader><CardTitle className="flex items-center gap-2"><Activity className="w-4 h-4" />Orchestrator State</CardTitle></CardHeader>
-      <CardContent>
+    <DashboardWidget icon={Activity} title="Orchestrator State">
         <div className="space-y-3">
           <div className="flex justify-between items-center">
             <span className="text-neutral-600 dark:text-neutral-300">Status</span>
@@ -89,8 +87,7 @@ export function OrchestratorStateCard({ selectedProject, globalUptime, controlAc
         {isWriteMode && !selectedProject.paused && selectedProject.running && (
           <DangerZone controlAction={controlAction} selectedProject={selectedProject} />
         )}
-      </CardContent>
-    </Card>
+    </DashboardWidget>
   )
 }
 
@@ -149,9 +146,7 @@ function DangerZone({ controlAction, selectedProject }) {
 
 export function CostBudgetCard({ selectedProject, setBudgetInfoModal, configForm, configError, configDirty, configSaving, updateConfigField, resetConfig, saveConfig, isWriteMode, setIntervalInfoModal, setTimeoutInfoModal }) {
   return (
-    <Card>
-      <CardHeader><CardTitle className="flex items-center gap-2"><DollarSign className="w-4 h-4" />Cost, Budget & Config</CardTitle></CardHeader>
-      <CardContent>
+    <DashboardWidget icon={DollarSign} title="Cost, Budget & Config">
         <div className="space-y-3">
           <div className="flex justify-between items-center">
             <span className="text-neutral-600 dark:text-neutral-300">Last Cycle</span>
@@ -305,7 +300,6 @@ export function CostBudgetCard({ selectedProject, setBudgetInfoModal, configForm
           </div>
           </div>
         </div>
-      </CardContent>
-    </Card>
+    </DashboardWidget>
   )
 }

--- a/monitor/src/components/ui/DashboardWidget.jsx
+++ b/monitor/src/components/ui/DashboardWidget.jsx
@@ -1,0 +1,24 @@
+import * as React from "react"
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
+import { cn } from "@/lib/utils"
+
+export default function DashboardWidget({ icon: Icon, title, badge, headerRight, headerExtra, children, className, contentClassName }) {
+  return (
+    <Card className={cn("h-[500px] flex flex-col", className)}>
+      <CardHeader className="shrink-0 pb-2">
+        <CardTitle className="flex items-center justify-between">
+          <span className="flex items-center gap-2">
+            {Icon && <Icon className="w-4 h-4" />}
+            {title}
+            {badge}
+          </span>
+          {headerRight}
+        </CardTitle>
+        {headerExtra}
+      </CardHeader>
+      <CardContent className={cn("flex-1 overflow-y-auto overflow-x-hidden pt-0", contentClassName)}>
+        {children}
+      </CardContent>
+    </Card>
+  )
+}


### PR DESCRIPTION
## What

Creates a single `DashboardWidget` component that all dashboard cards now use, replacing ad-hoc `Card`/`CardHeader`/`CardContent` usage with inconsistent height and overflow settings.

## Why

Cards had mismatched constraints:
- `HumanInterventionCard`: `max-h-[500px]` (variable height)
- `ChatCard` / `AgentReportsCard`: `h-[500px]`
- `OrchestratorStateCard` / `CostBudgetCard`: no height
- `Open PRs`: no height, `max-h-96` on inner div

This caused visible gaps at the bottom of shorter cards in the grid row.

## DashboardWidget API

```jsx
<DashboardWidget
  icon={AlertTriangle}
  title="Intervention"
  badge={<Badge>3</Badge>}
  headerRight={<button>+</button>}
  headerExtra={<FilterTabs />}
  contentClassName="flex flex-col"
>
  {children}
</DashboardWidget>
```

All cards get uniform `h-[500px]`, `flex flex-col`, and `overflow-y-auto` on content.

## Changed files

- **New:** `monitor/src/components/ui/DashboardWidget.jsx`
- **Refactored:** OrchestratorStateCard, CostBudgetCard, HumanInterventionCard, ChatCard, AgentReportsCard, + inline Managers/Workers/PRs cards in ProjectView

No logic changes — purely structural.