### PR TITLE
refactor: move worker skills into skills/workers

### DIFF
--- a/agent/everyone.md
+++ b/agent/everyone.md
@@ -12,7 +12,7 @@
 
 **Do NOT modify anything in the `{project_dir}/` folder**, except:
 - Your own workspace (`{project_dir}/workspace/{your_name}/`)
-- Managers can modify worker skills in `{project_dir}/workers/`
+- Managers can modify worker skills in `{project_dir}/skills/workers/`
 
 ## Your Workspace
 

--- a/agent/manager.md
+++ b/agent/manager.md
@@ -32,7 +32,7 @@ If the task is done, output your phase transition tag. Control immediately passe
 
 Each manager has their own team of workers. Workers report to whoever hired them. Only read from your worker or other managers. Ignore the message from workers who do not report to you.
 
-**Workers** are discovered from `{project_dir}/workers/`. Each worker's skill file records `reports_to` in frontmatter.
+**Workers** are discovered from `{project_dir}/skills/workers/`. Each worker's skill file records `reports_to` in frontmatter.
 
 ## Phase Flow & Transitions
 
@@ -65,7 +65,7 @@ VERIFICATION (Apollo's phase)
 
 ### Discover Your Workers
 
-Run `ls {project_dir}/workers/`. Only workers with `reports_to: <your_name>` in their frontmatter are on your team. Workers from other teams don't exist in your phase — never schedule them.
+Run `ls {project_dir}/skills/workers/`. Only workers with `reports_to: <your_name>` in their frontmatter are on your team. Workers from other teams don't exist in your phase — never schedule them.
 
 ### Check Worker Status
 
@@ -74,7 +74,7 @@ Read `{project_dir}/workspace/{agent_name}/note.md` for each of your workers to 
 ### Manage Your Team
 
 If the team lacks skills or a worker is ineffective, you can:
-- **Hire:** Create a new skill file in `{project_dir}/workers/{name}.md`. Add `reports_to: your_name` and `role: <role>` in the YAML frontmatter. **You must create the skill file before scheduling the worker.**
+- **Hire:** Create a new skill file in `{project_dir}/skills/workers/{name}.md`. Add `reports_to: your_name` and `role: <role>` in the YAML frontmatter. **You must create the skill file before scheduling the worker.**
 - **Retune:** Update a worker's skill file to clarify responsibilities or adjust model.
 - **Scale:** If one agent consistently has too much work per cycle, hire additional workers with similar skills and responsibilities. Split the workload so each agent gets a manageable task per cycle. For example, instead of one `coder` doing 5 changes, hire 5 coders and assign 1 changes each. More focused tasks = better results.
 - **Timeout recovery:** If a worker timed out in the previous cycle, you MUST take corrective action. Options: (1) break the task into smaller pieces, (2) hire additional workers to share the load, (3) clarify/simplify the worker's skill file to reduce scope, (4) add constraints like "limit changes to 3 files" or "focus on X only." Do NOT re-assign the same oversized task — that wastes another cycle.

--- a/src/server.js
+++ b/src/server.js
@@ -375,6 +375,20 @@ class ProjectRunner {
     return path.join(this.projectDir, 'workspace');
   }
 
+  get skillsDir() {
+    return path.join(this.agentDir, 'skills');
+  }
+
+  get workerSkillsDir() {
+    const dir = path.join(this.skillsDir, 'workers');
+    const legacyDir = path.join(this.agentDir, 'workers');
+    if (!fs.existsSync(dir) && fs.existsSync(legacyDir)) {
+      fs.mkdirSync(this.skillsDir, { recursive: true });
+      fs.renameSync(legacyDir, dir);
+    }
+    return dir;
+  }
+
   get repo() {
     if (this._repo === null) {
       try {
@@ -424,7 +438,7 @@ class ProjectRunner {
     const workers = [];
     
     const managersDir = path.join(ROOT, 'agent', 'managers');
-    const workersDir = path.join(this.agentDir, 'workers');
+    const workersDir = this.workerSkillsDir;
     
     const parseRole = (content) => {
       // Prefer frontmatter role: field
@@ -501,7 +515,7 @@ class ProjectRunner {
   }
 
   getAgentDetails(agentName) {
-    const workersDir = path.join(this.agentDir, 'workers');
+    const workersDir = this.workerSkillsDir;
     const managersDir = path.join(ROOT, 'agent', 'managers');
     const workspaceDir = path.join(this.agentDir, 'workspace', agentName);
     
@@ -985,10 +999,13 @@ class ProjectRunner {
       return;
     }
 
-    // Ensure project workspace directories exist
-    for (const sub of ['', 'responses', 'workers']) {
+    // Ensure project workspace/control-plane directories exist
+    for (const sub of ['', 'responses', 'workspace', 'skills', path.join('skills', 'workers')]) {
       fs.mkdirSync(path.join(this.agentDir, sub), { recursive: true });
     }
+    // Migrate legacy worker skills dir (<project>/workspace/workers) to
+    // the new control-plane location (<project>/workspace/skills/workers).
+    this.workerSkillsDir;
     
     // Load persisted state
     this.loadState();
@@ -1640,7 +1657,7 @@ class ProjectRunner {
   _buildAgentPrompt(agent, task, visibility) {
     const skillPath = agent.isManager
       ? path.join(ROOT, 'agent', 'managers', `${agent.name}.md`)
-      : path.join(this.agentDir, 'workers', `${agent.name}.md`);
+      : path.join(this.workerSkillsDir, `${agent.name}.md`);
 
     if (!fs.existsSync(skillPath)) {
       return null;
@@ -1820,7 +1837,7 @@ class ProjectRunner {
     if (!skillContent) {
       const skillPath = agent.isManager
         ? path.join(ROOT, 'agent', 'managers', `${agent.name}.md`)
-        : path.join(this.agentDir, 'workers', `${agent.name}.md`);
+        : path.join(this.workerSkillsDir, `${agent.name}.md`);
       log(`Skill file not found: ${skillPath}, skipping ${agent.name}`, this.id);
       this.currentAgent = null;
       this.currentAgentProcess = null;
@@ -2897,7 +2914,7 @@ const server = http.createServer(async (req, res) => {
           
           // Check if this is a manager or worker
           const managersDir = path.join(ROOT, 'agent', 'managers');
-          const workersDir = path.join(runner.agentDir, 'workers');
+          const workersDir = runner.workerSkillsDir;
           const isManager = fs.existsSync(path.join(managersDir, `${agentName}.md`));
           const isWorker = fs.existsSync(path.join(workersDir, `${agentName}.md`));
           

--- a/tests/worker-skills-path.test.js
+++ b/tests/worker-skills-path.test.js
@@ -1,0 +1,44 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const serverPath = path.join(__dirname, '..', 'src', 'server.js');
+const managerPromptPath = path.join(__dirname, '..', 'agent', 'manager.md');
+const everyonePromptPath = path.join(__dirname, '..', 'agent', 'everyone.md');
+
+function read(file) {
+  return fs.readFileSync(file, 'utf-8');
+}
+
+describe('worker skill directory layout', () => {
+  it('stores worker skills under skills/workers instead of the legacy workers dir', () => {
+    const src = read(serverPath);
+    assert.ok(src.includes("get skillsDir()"), 'Expected skillsDir getter in server.js');
+    assert.ok(src.includes("get workerSkillsDir()"), 'Expected workerSkillsDir getter in server.js');
+    assert.ok(src.includes("path.join(this.skillsDir, 'workers')"), 'Expected worker skills under skills/workers');
+  });
+
+  it('migrates the legacy workspace/workers directory to skills/workers', () => {
+    const src = read(serverPath);
+    assert.ok(src.includes("const legacyDir = path.join(this.agentDir, 'workers')"), 'Expected legacy workers dir reference for migration');
+    assert.ok(src.includes("fs.renameSync(legacyDir, dir)"), 'Expected legacy workers dir migration');
+  });
+
+  it('creates the new skills/workers control-plane directories at startup', () => {
+    const src = read(serverPath);
+    assert.ok(src.includes("path.join('skills', 'workers')"), 'Expected startup to create skills/workers');
+    assert.ok(src.includes("'workspace'"), 'Expected startup to keep per-agent workspace dir');
+  });
+
+  it('updates manager-facing prompts to use skills/workers', () => {
+    const managerPrompt = read(managerPromptPath);
+    const everyonePrompt = read(everyonePromptPath);
+    assert.ok(managerPrompt.includes('{project_dir}/skills/workers/'));
+    assert.ok(everyonePrompt.includes('{project_dir}/skills/workers/'));
+    assert.ok(!managerPrompt.includes('{project_dir}/workers/'));
+    assert.ok(!everyonePrompt.includes('{project_dir}/workers/'));
+  });
+});


### PR DESCRIPTION
## Summary
- move worker skill lookup/writes from `workspace/workers` to `workspace/skills/workers`
- auto-migrate legacy `workspace/workers` directories to the new control-plane location
- update manager/everyone prompts to point at `skills/workers`
- add regression tests for the new layout and migration behavior

## Why
This is the first step toward real visibility enforcement. It separates worker skill files from per-agent private workspace state, so future workspace isolation can deny cross-agent workspace access without needing a special exception for worker skill files.

## Testing
- `node --test tests/*.test.js`
- `cd monitor && npm run build`