### PR TITLE
feat: enforce issue visibility policies

### DIFF
--- a/agent/db.md
+++ b/agent/db.md
@@ -70,7 +70,7 @@ tbc-db query "SELECT * FROM issues WHERE status = 'open' ORDER BY created_at DES
 
 Your access to the tracker may be restricted by your manager:
 - **Full**: You can access everything
-- **Focused**: You can only access specific issues assigned to you
-- **Blind**: You cannot access the tracker — focus on the repo code and your task
+- **Focused**: You can only read/write specific allowed issues assigned to you, plus create new issues
+- **Blind**: You cannot read the tracker, but you can still create new issues to raise blockers or findings
 
 If you get "Access denied", respect the restriction and work with what you have.

--- a/agent/manager.md
+++ b/agent/manager.md
@@ -146,8 +146,8 @@ You can control what each worker sees by adding `visibility` to your SCHEDULE:
 
 **Three levels:**
 - **`full`** (default): Worker can see all issues, comments, and reports via `tbc-db`
-- **`focused`**: Worker can only see issues mentioned in the task (e.g., `#42`). All other issues are hidden. Good for keeping workers on-task without distractions.
-- **`blind`**: Worker cannot access the tracker at all. They only see the task description and the repo code. Good for independent verification — the worker must evaluate on their own without seeing prior discussion.
+- **`focused`**: Worker can only read/write issues mentioned in the task (e.g., `#42`). All other issues are hidden. They may still create new issues if needed.
+- **`blind`**: Worker cannot read the tracker. They only see the task description and the repo code, but may still create new issues to report blockers or findings. Good for independent verification — the worker must evaluate on their own without seeing prior discussion.
 
 ## Escalate to Human
 

--- a/src/agent-runner.js
+++ b/src/agent-runner.js
@@ -106,6 +106,68 @@ function checkSensitiveDbAccess(command) {
   return null;
 }
 
+function extractTbcDbCommand(command) {
+  if (!command || !/(?:^|[;&|`\s])tbc-db\b/.test(` ${command}`)) return null;
+  const trimmed = command.trim();
+  const match = trimmed.match(/(?:^|.*?[;&|`]\s*)tbc-db\s+(.+)$/);
+  const args = (match ? match[1] : trimmed.replace(/^tbc-db\s+/, '')).trim();
+  if (!args) return { kind: 'unknown' };
+
+  const issueFlagMatch = args.match(/--issue\s+(\d+)/);
+  const positionalIssueMatch = args.match(/^(?:issue-view|issue-edit|issue-close|comments)\s+(\d+)\b/);
+  const issueId = issueFlagMatch?.[1] || positionalIssueMatch?.[1] || null;
+
+  if (/^issue-create\b/.test(args)) return { kind: 'issue-create' };
+  if (/^issue-list\b/.test(args)) return { kind: 'issue-list' };
+  if (/^issue-view\b/.test(args)) return { kind: 'issue-view', issueId };
+  if (/^comments\b/.test(args)) return { kind: 'comments', issueId };
+  if (/^comment\b/.test(args)) return { kind: 'comment', issueId };
+  if (/^issue-edit\b/.test(args)) return { kind: 'issue-edit', issueId };
+  if (/^issue-close\b/.test(args)) return { kind: 'issue-close', issueId };
+  if (/^query\b/.test(args)) return { kind: 'query' };
+  return { kind: 'unknown' };
+}
+
+function isIssueAllowed(issueId, issuePolicy) {
+  if (!issuePolicy) return true;
+  if (issuePolicy.mode !== 'focused') return true;
+  return !!issueId && (issuePolicy.issues || []).map(String).includes(String(issueId));
+}
+
+function checkIssueAccessInCommand(command, issuePolicy = null) {
+  if (!issuePolicy) return null;
+  const parsed = extractTbcDbCommand(command);
+  if (!parsed) return null;
+
+  const mode = issuePolicy.mode || 'full';
+  if (mode === 'full') return null;
+
+  if (parsed.kind === 'issue-create') return null;
+
+  if (mode === 'blind') {
+    return 'Blocked: blind mode cannot read the issue tracker. You may only create new issues with tbc-db issue-create.';
+  }
+
+  if (mode === 'focused') {
+    switch (parsed.kind) {
+      case 'issue-view':
+      case 'comments':
+      case 'comment':
+      case 'issue-edit':
+      case 'issue-close':
+        if (isIssueAllowed(parsed.issueId, issuePolicy)) return null;
+        return `Blocked: focused issues access denied${parsed.issueId ? ` for issue #${parsed.issueId}` : ''}. Allowed issues: ${(issuePolicy.issues || []).join(', ') || 'none'}.`;
+      case 'issue-list':
+      case 'query':
+      case 'unknown':
+      default:
+        return `Blocked: focused issues mode only allows access to issues ${(issuePolicy.issues || []).join(', ') || 'none'} and issue creation.`;
+    }
+  }
+
+  return null;
+}
+
 function normalizePath(targetPath) {
   const resolved = path.resolve(targetPath);
   try {
@@ -401,7 +463,7 @@ function getToolDefinitions() {
 // ---------------------------------------------------------------------------
 // Tool Execution
 // ---------------------------------------------------------------------------
-function executeBash(input, cwd, remainingMs = 0, bashEnv = null, runtime = null, allowedRepo = null, allowedPaths = null) {
+function executeBash(input, cwd, remainingMs = 0, bashEnv = null, runtime = null, allowedRepo = null, allowedPaths = null, issuePolicy = null) {
   let timeout = Math.min(input.timeout || 120000, 600000);
   if (remainingMs > 0) {
     timeout = Math.min(timeout, remainingMs);
@@ -424,6 +486,11 @@ function executeBash(input, cwd, remainingMs = 0, bashEnv = null, runtime = null
     const dbBlock = checkSensitiveDbAccess(command);
     if (dbBlock) {
       resolve(dbBlock);
+      return;
+    }
+    const issueBlock = checkIssueAccessInCommand(command, issuePolicy);
+    if (issueBlock) {
+      resolve(issueBlock);
       return;
     }
     const pathBlock = checkPathAccessInCommand(command, cwd, allowedPaths);
@@ -620,9 +687,9 @@ function executeGrep(input, cwd, allowedPaths = null) {
   }
 }
 
-async function executeTool(toolName, toolInput, cwd, remainingMs = 0, bashEnv = null, runtime = null, allowedRepo = null, allowedPaths = null) {
+async function executeTool(toolName, toolInput, cwd, remainingMs = 0, bashEnv = null, runtime = null, allowedRepo = null, allowedPaths = null, issuePolicy = null) {
   switch (toolName) {
-    case 'Bash':  return await executeBash(toolInput, cwd, remainingMs, bashEnv, runtime, allowedRepo, allowedPaths);
+    case 'Bash':  return await executeBash(toolInput, cwd, remainingMs, bashEnv, runtime, allowedRepo, allowedPaths, issuePolicy);
     case 'Read':  return executeRead(toolInput, cwd, allowedPaths);
     case 'Write': return executeWrite(toolInput, cwd, allowedPaths);
     case 'Edit':  return executeEdit(toolInput, cwd, allowedPaths);
@@ -668,6 +735,7 @@ export async function runAgentWithAPI(opts) {
     log = () => {},
     allowedRepo = null,
     allowedPaths = null,
+    issuePolicy = null,
     keyId: initialKeyId = null,
     onRateLimited = null,
     resolveNewToken = null,
@@ -1032,7 +1100,7 @@ export async function runAgentWithAPI(opts) {
           log(`Tool: ${tc.name}${tc.name === 'Bash' ? ` → ${(tc.input.command || '').slice(0, 300)}` : ''}`);
 
           const remainingMs = timeoutMs > 0 ? Math.max(0, timeoutMs - (Date.now() - startTime)) : 0;
-          const result = await executeTool(tc.name, tc.input, cwd, remainingMs, bashEnv, runtime, allowedRepo, allowedPaths);
+          const result = await executeTool(tc.name, tc.input, cwd, remainingMs, bashEnv, runtime, allowedRepo, allowedPaths, issuePolicy);
           toolResults.push({ toolCallId: tc.id, toolName: tc.name, content: result });
         }
 

--- a/src/server.js
+++ b/src/server.js
@@ -1703,7 +1703,7 @@ class ProjectRunner {
           sharedRules += dbContent + '\n\n---\n\n';
         } catch {}
       } else {
-        sharedRules += '\n> **You are in blind mode.** You cannot access the issue tracker (tbc-db). Focus only on the task described above and the repository code.\n\n---\n\n';
+        sharedRules += '\n> **You are in blind mode.** You cannot read the issue tracker (tbc-db), but you may still create new issues to report blockers or findings. Focus on the task described above and the repository code.\n\n---\n\n';
       }
       const rolePath = path.join(ROOT, 'agent', agent.isManager ? 'manager.md' : 'worker.md');
       sharedRules += fs.readFileSync(rolePath, 'utf-8') + '\n\n---\n\n';
@@ -1948,6 +1948,7 @@ class ProjectRunner {
       env: agentEnv,
       allowedRepo: this.repo || null,
       allowedPaths: this._getAgentFilesystemPolicy(agent),
+      issuePolicy: visibility || { mode: 'full', issues: [] },
       abortSignal: runAbortController.signal,
       keyId: resolvedKeyId,
       onRateLimited: (kid, cooldownMs) => markRateLimited(kid, cooldownMs || 5 * 60_000),

--- a/tests/issue-visibility-policy.test.js
+++ b/tests/issue-visibility-policy.test.js
@@ -1,0 +1,109 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { executeTool } from '../src/agent-runner.js';
+
+function mkProject() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tbc-issue-policy-'));
+  const repo = path.join(root, 'repo');
+  const workspaceRoot = path.join(root, 'workspace');
+  const own = path.join(workspaceRoot, 'workspace', 'leo');
+  fs.mkdirSync(repo, { recursive: true });
+  fs.mkdirSync(own, { recursive: true });
+  fs.writeFileSync(path.join(repo, 'README.md'), 'repo ok');
+  fs.writeFileSync(path.join(workspaceRoot, 'project.db'), 'sqlite');
+
+  const allowedPaths = {
+    read: [repo, own],
+    write: [repo, own],
+    denied: [
+      path.join(workspaceRoot, 'workspace'),
+      path.join(workspaceRoot, 'responses'),
+      path.join(workspaceRoot, 'uploads'),
+      path.join(workspaceRoot, 'skills'),
+      path.join(workspaceRoot, 'state.json'),
+      path.join(workspaceRoot, 'orchestrator.log'),
+      path.join(workspaceRoot, 'project.db'),
+    ],
+    dbPath: path.join(workspaceRoot, 'project.db'),
+  };
+
+  return {
+    repo,
+    allowedPaths,
+    issuePolicies: {
+      full: { mode: 'full', issues: [] },
+      focused: { mode: 'focused', issues: ['12', '34'] },
+      blind: { mode: 'blind', issues: [] },
+    },
+  };
+}
+
+describe('issue visibility policy', () => {
+  it('blind blocks issue reads but allows issue creation', async () => {
+    const p = mkProject();
+
+    const listResult = await executeTool('Bash', { command: 'tbc-db issue-list' }, p.repo, 0, { TBC_DB: '/tmp/project.db' }, null, null, p.allowedPaths, p.issuePolicies.blind);
+    assert.match(listResult, /access denied|blind mode|issue tracker/i);
+
+    const viewResult = await executeTool('Bash', { command: 'tbc-db issue-view 12' }, p.repo, 0, { TBC_DB: '/tmp/project.db' }, null, null, p.allowedPaths, p.issuePolicies.blind);
+    assert.match(viewResult, /access denied|blind mode|issue tracker/i);
+
+    const createResult = await executeTool('Bash', { command: 'tbc-db issue-create --title "Need help" --creator leo --body "blocked"' }, p.repo, 0, { TBC_DB: '/tmp/project.db' }, null, null, p.allowedPaths, p.issuePolicies.blind);
+    assert.doesNotMatch(createResult, /access denied|blind mode|issue tracker/i);
+  });
+
+  it('focused allows only explicitly allowed issues', async () => {
+    const p = mkProject();
+
+    const allowedView = await executeTool('Bash', { command: 'tbc-db issue-view 12' }, p.repo, 0, { TBC_DB: '/tmp/project.db' }, null, null, p.allowedPaths, p.issuePolicies.focused);
+    assert.doesNotMatch(allowedView, /access denied|focused issues/i);
+
+    const allowedComments = await executeTool('Bash', { command: 'tbc-db comments 34' }, p.repo, 0, { TBC_DB: '/tmp/project.db' }, null, null, p.allowedPaths, p.issuePolicies.focused);
+    assert.doesNotMatch(allowedComments, /access denied|focused issues/i);
+
+    const deniedView = await executeTool('Bash', { command: 'tbc-db issue-view 99' }, p.repo, 0, { TBC_DB: '/tmp/project.db' }, null, null, p.allowedPaths, p.issuePolicies.focused);
+    assert.match(deniedView, /access denied|focused issues/i);
+
+    const deniedList = await executeTool('Bash', { command: 'tbc-db issue-list' }, p.repo, 0, { TBC_DB: '/tmp/project.db' }, null, null, p.allowedPaths, p.issuePolicies.focused);
+    assert.match(deniedList, /access denied|focused issues/i);
+  });
+
+  it('focused allows writes only on allowed issues, plus create', async () => {
+    const p = mkProject();
+
+    const allowedComment = await executeTool('Bash', { command: 'tbc-db comment --issue 12 --author leo --body "working"' }, p.repo, 0, { TBC_DB: '/tmp/project.db' }, null, null, p.allowedPaths, p.issuePolicies.focused);
+    assert.doesNotMatch(allowedComment, /access denied|focused issues/i);
+
+    const deniedComment = await executeTool('Bash', { command: 'tbc-db comment --issue 77 --author leo --body "working"' }, p.repo, 0, { TBC_DB: '/tmp/project.db' }, null, null, p.allowedPaths, p.issuePolicies.focused);
+    assert.match(deniedComment, /access denied|focused issues/i);
+
+    const createResult = await executeTool('Bash', { command: 'tbc-db issue-create --title "New blocker" --creator leo --body "blocked"' }, p.repo, 0, { TBC_DB: '/tmp/project.db' }, null, null, p.allowedPaths, p.issuePolicies.focused);
+    assert.doesNotMatch(createResult, /access denied|focused issues/i);
+  });
+
+  it('full allows issue reads and writes', async () => {
+    const p = mkProject();
+
+    const listResult = await executeTool('Bash', { command: 'tbc-db issue-list' }, p.repo, 0, { TBC_DB: '/tmp/project.db' }, null, null, p.allowedPaths, p.issuePolicies.full);
+    assert.doesNotMatch(listResult, /access denied|issue tracker/i);
+
+    const viewResult = await executeTool('Bash', { command: 'tbc-db issue-view 99' }, p.repo, 0, { TBC_DB: '/tmp/project.db' }, null, null, p.allowedPaths, p.issuePolicies.full);
+    assert.doesNotMatch(viewResult, /access denied|issue tracker/i);
+
+    const commentResult = await executeTool('Bash', { command: 'tbc-db comment --issue 99 --author leo --body "working"' }, p.repo, 0, { TBC_DB: '/tmp/project.db' }, null, null, p.allowedPaths, p.issuePolicies.full);
+    assert.doesNotMatch(commentResult, /access denied|issue tracker/i);
+  });
+
+  it('blocks raw SQL query for non-full visibility', async () => {
+    const p = mkProject();
+
+    const focusedQuery = await executeTool('Bash', { command: 'tbc-db query "SELECT * FROM issues"' }, p.repo, 0, { TBC_DB: '/tmp/project.db' }, null, null, p.allowedPaths, p.issuePolicies.focused);
+    assert.match(focusedQuery, /access denied|query|focused issues/i);
+
+    const blindQuery = await executeTool('Bash', { command: 'tbc-db query "SELECT * FROM issues"' }, p.repo, 0, { TBC_DB: '/tmp/project.db' }, null, null, p.allowedPaths, p.issuePolicies.blind);
+    assert.match(blindQuery, /access denied|query|blind mode/i);
+  });
+});


### PR DESCRIPTION
## Summary
- add failing backend tests for `tbc-db` visibility enforcement, then implement the runtime policy
- enforce issue visibility in the orchestrator runtime (`server.js` policy + `agent-runner.js` command interception)
- support `full`, `focused`, and `blind` modes for `tbc-db` commands
- allow blind agents to create issues but block issue reads
- allow focused agents to read/write only their allowed issues, plus create new issues
- update prompt/docs text to match the enforced behavior

## Policy
### Full
- unrestricted `tbc-db` issue access

### Focused
- allow: `issue-view`, `comments`, `comment`, `issue-edit`, `issue-close` only for allowed issue IDs
- allow: `issue-create`
- deny: `issue-list`, `query`, and access to non-allowed issue IDs

### Blind
- allow: `issue-create`
- deny: issue reads and other tracker access

## Why server-side
This is enforced in orchestrator runtime, not the CLI. The orchestrator owns the agent context and visibility policy, so the runtime must gate `tbc-db` access before Bash executes.

## Testing
- added `tests/issue-visibility-policy.test.js` (failing first, now green)
- `node --test tests/*.test.js`
- `cd monitor && npm run build`