### PR TITLE
feat: add lightweight tool call status indicators

### DIFF
--- a/monitor/src/components/panels/ChatPanel.jsx
+++ b/monitor/src/components/panels/ChatPanel.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react'
-import { Send, Loader2, ChevronDown, ChevronRight, Terminal, FileText, Pencil, Search, FolderSearch, Paperclip, X } from 'lucide-react'
+import { Send, Loader2, ChevronDown, ChevronRight, Terminal, FileText, Pencil, Search, FolderSearch, Paperclip, X, CheckCircle2, AlertCircle } from 'lucide-react'
 import { Panel, PanelHeader, PanelContent } from '@/components/ui/panel'
 import { useAuth } from '@/hooks/useAuth'
 import ReactMarkdown from 'react-markdown'
@@ -17,12 +17,25 @@ const TOOL_ICONS = {
 function ToolCallBlock({ name, input, output }) {
   const [expanded, setExpanded] = useState(false)
   const Icon = TOOL_ICONS[name] || Terminal
+  const isRunning = !output
+  const isError = typeof output === 'string' && output.trim().startsWith('Error:')
+  const StatusIcon = isRunning ? Loader2 : isError ? AlertCircle : CheckCircle2
+  const statusIconClass = isRunning
+    ? 'w-3.5 h-3.5 shrink-0 animate-spin text-neutral-400'
+    : isError
+      ? 'w-3.5 h-3.5 shrink-0 text-red-500'
+      : 'w-3.5 h-3.5 shrink-0 text-emerald-500'
+  const containerClass = isRunning
+    ? 'border-neutral-200 dark:border-neutral-700 bg-neutral-50 dark:bg-neutral-900/50'
+    : isError
+      ? 'border-red-200 dark:border-red-900 bg-red-50 dark:bg-red-950/20'
+      : 'border-emerald-200 dark:border-emerald-900 bg-emerald-50 dark:bg-emerald-950/20'
 
   return (
-    <div className="my-1.5 rounded border border-neutral-200 dark:border-neutral-700 bg-neutral-50 dark:bg-neutral-900/50 text-xs overflow-hidden">
+    <div className={`my-1.5 rounded border text-xs overflow-hidden ${containerClass}`}>
       <button
         onClick={() => setExpanded(!expanded)}
-        className="w-full flex items-center gap-1.5 px-2 py-1.5 hover:bg-neutral-100 dark:hover:bg-neutral-800/50 transition-colors"
+        className="w-full flex items-center gap-1.5 px-2 py-1.5 hover:bg-black/5 dark:hover:bg-white/5 transition-colors"
       >
         {expanded ? <ChevronDown className="w-3 h-3 shrink-0" /> : <ChevronRight className="w-3 h-3 shrink-0" />}
         <Icon className="w-3 h-3 shrink-0 text-blue-500" />
@@ -33,6 +46,7 @@ function ToolCallBlock({ name, input, output }) {
           {name === 'Grep' && input?.pattern ? `/${input.pattern}/` : ''}
           {name === 'Glob' && input?.pattern ? input.pattern : ''}
         </span>
+        <StatusIcon className={statusIconClass} />
       </button>
       {expanded && (
         <div className="border-t border-neutral-200 dark:border-neutral-700">

--- a/monitor/src/components/panels/ReportsPanel.jsx
+++ b/monitor/src/components/panels/ReportsPanel.jsx
@@ -4,6 +4,7 @@ import { Panel, PanelHeader, PanelContent } from '@/components/ui/panel'
 import { Badge } from '@/components/ui/badge'
 import { Separator } from '@/components/ui/separator'
 import StatusPill from '@/components/ui/status-pill'
+import ToolCallBlock from '@/components/ui/tool-call-block'
 import { ReportCardHeader } from '@/components/project/AgentReportsCard'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -74,6 +75,15 @@ export default function ReportsPanel({
     }
   }, [liveAgentLog])
 
+  const parseToolLogLine = (line) => {
+    const match = line.match(/Tool:\s+([^→]+?)(?:\s+→\s+(.*))?$/)
+    if (!match) return null
+    const name = match[1].trim()
+    const summary = (match[2] || '').trim()
+    const input = name === 'Bash' ? { command: summary } : { raw: summary }
+    return { name, summary, input }
+  }
+
   return (
     <Panel id="reports" open={open} onClose={onClose}>
       <PanelHeader onClose={onClose}>
@@ -115,12 +125,23 @@ export default function ReportsPanel({
                   className="max-h-[400px] overflow-y-auto rounded bg-neutral-50 dark:bg-neutral-900/50 p-2 text-xs font-mono space-y-0.5 mt-1"
                 >
                   {liveAgentLog.log.length === 0 && <p className="text-neutral-400 italic">Waiting for output...</p>}
-                  {liveAgentLog.log.map((entry, i) => (
-                    <div key={i} className={`leading-relaxed break-words whitespace-pre-wrap ${entry.msg.startsWith('Tool:') ? 'text-blue-600 dark:text-blue-400' : 'text-neutral-600 dark:text-neutral-300'}`}>
-                      <span className="text-neutral-400 dark:text-neutral-500 mr-1.5">{new Date(entry.time).toLocaleTimeString()}</span>
-                      {entry.msg}
-                    </div>
-                  ))}
+                  {liveAgentLog.log.map((entry, i) => {
+                    const tool = parseToolLogLine(entry.msg)
+                    if (tool) {
+                      return (
+                        <div key={i}>
+                          <div className="text-neutral-400 dark:text-neutral-500 text-[10px] mb-1">{new Date(entry.time).toLocaleTimeString()}</div>
+                          <ToolCallBlock name={tool.name} input={tool.input} summary={tool.summary} />
+                        </div>
+                      )
+                    }
+                    return (
+                      <div key={i} className="leading-relaxed break-words whitespace-pre-wrap text-neutral-600 dark:text-neutral-300">
+                        <span className="text-neutral-400 dark:text-neutral-500 mr-1.5">{new Date(entry.time).toLocaleTimeString()}</span>
+                        {entry.msg}
+                      </div>
+                    )
+                  })}
                 </div>
               </div>
               <Separator className="my-4" />

--- a/monitor/src/components/ui/tool-call-block.jsx
+++ b/monitor/src/components/ui/tool-call-block.jsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react'
+import { Loader2, ChevronDown, ChevronRight, Terminal, FileText, Pencil, Search, FolderSearch, Paperclip, CheckCircle2, AlertCircle, Globe } from 'lucide-react'
+
+const TOOL_ICONS = {
+  Bash: Terminal,
+  Read: FileText,
+  Write: Pencil,
+  Edit: Pencil,
+  Grep: Search,
+  Glob: FolderSearch,
+  WebFetch: Globe,
+}
+
+export default function ToolCallBlock({ name, input, output, summary }) {
+  const [expanded, setExpanded] = useState(false)
+  const Icon = TOOL_ICONS[name] || Paperclip
+  const isRunning = !output
+  const isError = typeof output === 'string' && output.trim().startsWith('Error:')
+  const StatusIcon = isRunning ? Loader2 : isError ? AlertCircle : CheckCircle2
+  const statusIconClass = isRunning
+    ? 'w-3.5 h-3.5 shrink-0 animate-spin text-neutral-400'
+    : isError
+      ? 'w-3.5 h-3.5 shrink-0 text-red-500'
+      : 'w-3.5 h-3.5 shrink-0 text-emerald-500'
+  const containerClass = isRunning
+    ? 'border-neutral-200 dark:border-neutral-700 bg-neutral-50 dark:bg-neutral-900/50'
+    : isError
+      ? 'border-red-200 dark:border-red-900 bg-red-50 dark:bg-red-950/20'
+      : 'border-emerald-200 dark:border-emerald-900 bg-emerald-50 dark:bg-emerald-950/20'
+
+  return (
+    <div className={`my-1.5 rounded border text-xs overflow-hidden ${containerClass}`}>
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="w-full flex items-center gap-1.5 px-2 py-1.5 hover:bg-black/5 dark:hover:bg-white/5 transition-colors"
+      >
+        {expanded ? <ChevronDown className="w-3 h-3 shrink-0" /> : <ChevronRight className="w-3 h-3 shrink-0" />}
+        <Icon className="w-3 h-3 shrink-0 text-blue-500" />
+        <span className="font-semibold text-blue-600 dark:text-blue-400">{name}</span>
+        <span className="text-neutral-500 dark:text-neutral-400 truncate text-left flex-1">{summary || ''}</span>
+        <StatusIcon className={statusIconClass} />
+      </button>
+      {expanded && (
+        <div className="border-t border-neutral-200 dark:border-neutral-700">
+          <div className="px-2 py-1.5 bg-neutral-100 dark:bg-neutral-800/50">
+            <div className="text-[10px] font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400 mb-1">Input</div>
+            <pre className="text-[11px] text-neutral-700 dark:text-neutral-300 whitespace-pre-wrap break-words overflow-x-auto">{JSON.stringify(input, null, 2)}</pre>
+          </div>
+          {output && (
+            <div className="px-2 py-1.5">
+              <div className="text-[10px] font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400 mb-1">Output</div>
+              <pre className="text-[11px] text-neutral-700 dark:text-neutral-300 whitespace-pre-wrap break-words overflow-x-auto">{typeof output === 'string' ? output : JSON.stringify(output, null, 2)}</pre>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add lightweight success/failure/running status indicators to chat tool call blocks
- use subtle green/red background tinting for completed states
- keep the UI minimal with small status icons instead of heavy labels

## Testing
- cd monitor && npm run build