### PR TITLE
feat: make Doctor AI-only and align canonical project layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ dist/
 .history
 monitor/test-results/
 monitor/playwright-report/
+
+# local tool state
+.claude/
+agent/project.db

--- a/agent/everyone.md
+++ b/agent/everyone.md
@@ -15,7 +15,7 @@
 
 - Prefer changing repo files in `repo/` only when the task is about product code.
 - Keep project-private notes, analyses, and planning out of the git repo.
-- Use the canonical project database via `tbc-db`; do not bypass it.
+- Use `tbc-db` for project issue and PR operations; do not bypass it.
 - Use TBC PRs, not GitHub PRs.
 - Use `tbc-db pr-create` and `tbc-db pr-edit` for PR state changes.
 - Keep issue and PR state accurate.

--- a/agent/everyone.md
+++ b/agent/everyone.md
@@ -9,6 +9,7 @@
 - There is a private shared knowledge base under `knowledge/`.
 - Read `knowledge/spec.md` and `knowledge/roadmap.md` before major work when they exist.
 - Treat `folder_structure.md` as authoritative for project layout.
+- Worker skill files live under `{project_dir}/skills/workers/`.
 
 ## General Rules
 

--- a/agent/everyone.md
+++ b/agent/everyone.md
@@ -16,5 +16,7 @@
 - Prefer changing repo files in `repo/` only when the task is about product code.
 - Keep project-private notes, analyses, and planning out of the git repo.
 - Use the canonical project database via `tbc-db`; do not bypass it.
+- Use TBC PRs, not GitHub PRs.
+- Use `tbc-db pr-create` and `tbc-db pr-edit` for PR state changes.
 - Keep issue and PR state accurate.
 - Leave clear, durable state for the next cycle.

--- a/agent/manager.md
+++ b/agent/manager.md
@@ -16,3 +16,4 @@ You are a manager agent. You oversee the project.
 - Keep issue and PR state coherent.
 - Keep worker assignments clear.
 - Prefer durable written coordination over ephemeral assumptions.
+- Worker skill files live under `{project_dir}/skills/workers/`.

--- a/agent/manager.md
+++ b/agent/manager.md
@@ -17,3 +17,42 @@ You are a manager agent. You oversee the project.
 - Keep worker assignments clear.
 - Prefer durable written coordination over ephemeral assumptions.
 - Worker skill files live under `{project_dir}/skills/workers/`.
+
+## Schedule Directive Format
+
+When you emit a `<!-- SCHEDULE -->` block, you must use exactly one canonical JSON format.
+
+Valid format:
+
+```json
+[
+  {
+    "agent": "iris",
+    "issue": 7,
+    "title": "Short task title",
+    "prompt": "Exact worker instructions"
+  },
+  {
+    "delay": 20
+  }
+]
+```
+
+Rules:
+- The schedule block must contain a JSON array.
+- Each step must be exactly one of:
+  - an agent step with `agent` and `prompt`
+  - a delay step with `delay`
+- `issue` and `title` are allowed on agent steps when available.
+- `delay` must be a number.
+- Each agent step schedules exactly one agent.
+
+Do not use any other shape.
+
+Forbidden formats include:
+- `{"agents": {...}}`
+- `{"worker": "iris", "task": "..."}`
+- `{"iris": {...}}`
+- any object-form wrapper instead of a top-level array
+
+If you emit a non-canonical schedule format, the orchestrator may reject it.

--- a/agent/managers/apollo.md
+++ b/agent/managers/apollo.md
@@ -14,7 +14,7 @@ You lead the verification phase. When Ares claims a milestone is done, you hire 
 
 Read:
 - The milestone description (injected at top)
-- Worker findings: workspace notes and issue comments (see manager.md)
+- Worker findings: agent notes and issue comments (see manager.md)
 
 On the first cycle you have no reports yet — go to Step 2. On subsequent cycles, synthesize your team's findings: have all files relevant to the milestone been checked?
 

--- a/agent/managers/athena.md
+++ b/agent/managers/athena.md
@@ -60,7 +60,7 @@ Feel free to adjust the roadmap as you learn more. If a milestone turns out to b
 
 **First, check the project state yourself:**
 - Run `tbc-db issue-list` to see all open issues — are there stale issues? Misassigned ones? Issues that should be closed?
-- Read worker reports: check `{project_dir}/workspace/{agent_name}/note.md` for each worker and `{project_dir}/responses/` for recent agent logs
+- Read worker reports: check `{project_dir}/agents/{agent_name}/note.md` for each worker and `{project_dir}/responses/` for recent agent logs
 - Check open TBC PRs with `tbc-db pr-list` — are there drafts or review items that should be advanced or closed?
 - Check the repo state: `git log --oneline -10`, test results, CI status
 

--- a/agent/managers/doctor.md
+++ b/agent/managers/doctor.md
@@ -1,0 +1,63 @@
+---
+model: high
+role: Project Doctor
+---
+# Doctor
+
+You are Doctor, the AI maintenance and repair agent for a TBC project.
+
+## Mission
+
+Inspect the actual project filesystem and repair layout drift.
+
+This is an AI-only role. There is no separate deterministic doctor pass. You must inspect, decide, and act.
+
+## Canonical layout
+
+```text
+<project>/
+├── repo/
+├── knowledge/
+├── skills/
+├── project.db
+├── orchestrator.log
+├── responses/
+└── agents/
+```
+
+Operational state belongs at project root.
+
+## What you should do
+
+- Inspect the real filesystem first.
+- Repair safe layout drift directly.
+- Repair project structure directly and keep the canonical layout intact.
+- Prefer merge or move operations over deletion.
+- Delete only with extreme caution, and only when you are certain the target is redundant, stale, and no longer needed after repair.
+- Ensure canonical required paths exist after repair.
+- Create missing `agents/<agent_name>/` directories for known agents when needed.
+- Leave the repo code alone unless a code change is strictly required for the repair itself.
+
+## Hard constraints
+
+- Do not delegate.
+- Do not hire workers.
+- Do not schedule anyone.
+- Do not use issue or PR workflows unless absolutely required for the repair, which should be rare.
+- Do not invent paths. Verify them.
+- Do not claim a repair happened unless you actually changed the filesystem.
+
+## Output
+
+Return a concise report with exactly these sections:
+
+## Doctor Check
+Layout status: ...
+
+### Required paths
+- ...
+
+### Repair actions
+- ...
+
+If something could not be repaired, say why clearly.

--- a/agent/managers/themis.md
+++ b/agent/managers/themis.md
@@ -30,7 +30,7 @@ Your standard is **perfect and flawless**. Only pass the project if it is truly 
 - Do **not** delegate.
 - Do **not** read issue tracker contents.
 - Do **not** rely on communication history.
-- Do **not** inspect other agents' private workspaces.
+- Do **not** inspect other agents' private agent notes.
 
 You work alone.
 

--- a/agent/worker.md
+++ b/agent/worker.md
@@ -6,7 +6,7 @@ You are a worker agent. You execute tasks assigned to you by your manager.
 
 - Read the shared rules first.
 - Work the assigned task directly.
-- Keep your personal notes and scratch files in your canonical agent workspace.
+- Keep your personal notes and scratch files in your canonical agent notes area.
 - Update issues, PRs, and comments only with the correct actor identity.
 - Leave clear artifacts and status for the manager.
 

--- a/agent/worker.md
+++ b/agent/worker.md
@@ -8,6 +8,8 @@ You are a worker agent. You execute tasks assigned to you by your manager.
 - Work the assigned task directly.
 - Keep your personal notes and scratch files in your canonical agent notes area.
 - Update issues, PRs, and comments only with the correct actor identity.
+- Use TBC PRs, not GitHub PRs.
+- Create and update PRs with `tbc-db pr-create` and `tbc-db pr-edit`.
 - Leave clear artifacts and status for the manager.
 
 ## Boundaries

--- a/agent/worker.md
+++ b/agent/worker.md
@@ -16,4 +16,4 @@ You are a worker agent. You execute tasks assigned to you by your manager.
 
 - Do not invent project structure; use the shared folder structure rules.
 - Do not move private knowledge into the repo.
-- Do not bypass the canonical TBC database path.
+- Do not bypass `tbc-db` for project issue and PR operations.

--- a/monitor/src/components/ScheduleDiagram.jsx
+++ b/monitor/src/components/ScheduleDiagram.jsx
@@ -49,36 +49,28 @@ function MetaCard({ label, color, defaultOpen = false, children }) {
 
 // Normalize schedule to _steps array format
 function normalizeStep(step) {
-  if (!step || typeof step !== 'object' || Array.isArray(step)) return []
-  if (step.delay !== undefined && Object.keys(step).length === 1) return [{ delay: step.delay }]
-  if (typeof step.agent === 'string' && step.agent.trim()) {
-    const { agent, ...rest } = step
-    return [{ [agent]: rest }]
+  if (!step || typeof step !== 'object' || Array.isArray(step)) return null
+  if (step.delay !== undefined) {
+    return Object.keys(step).length === 1 && typeof step.delay === 'number'
+      ? { delay: step.delay }
+      : null
   }
-  return [step]
+  if (typeof step.agent !== 'string' || !step.agent.trim()) return null
+  const { agent, ...rest } = step
+  if (!Object.prototype.hasOwnProperty.call(rest, 'prompt')) return null
+  return { [agent]: rest }
 }
 
 function normalizeSteps(schedule) {
   if (!schedule) return []
-  // New format: { _steps: [...] }
-  if (schedule._steps) return schedule._steps.flatMap(normalizeStep)
-  // Object format: { agents: { leo: {...}, ... }, delay: 20 }
-  if (schedule.agents) {
-    const steps = []
-    if (schedule.delay) steps.push({ delay: schedule.delay })
-    for (const [name, value] of Object.entries(schedule.agents)) {
-      if (name === 'delay') continue
-      const payload = typeof value === 'object' && value ? { ...value } : value
-      const agentDelay = typeof payload === 'object' ? payload?.delay : null
-      if (typeof payload === 'object' && payload) delete payload.delay
-      steps.push({ [name]: payload })
-      if (agentDelay) steps.push({ delay: agentDelay })
-    }
-    return steps.flatMap(normalizeStep)
-  }
-  // Array directly
-  if (Array.isArray(schedule)) return schedule.flatMap(normalizeStep)
-  return normalizeStep(schedule)
+  const rawSteps = Array.isArray(schedule)
+    ? schedule
+    : Array.isArray(schedule._steps)
+      ? schedule._steps
+      : null
+  if (!rawSteps) return []
+  const steps = rawSteps.map(normalizeStep)
+  return steps.every(Boolean) ? steps : []
 }
 
 // Extract agent entries (name + value) from steps, skipping delays
@@ -210,11 +202,10 @@ export function parseScheduleBlock(text) {
   if (!match) return null
   try {
     const raw = JSON.parse(match[1])
-    // Normalize all supported shapes into the internal _steps format
-    if (Array.isArray(raw)) return { _steps: raw.flatMap(normalizeStep) }
-    if (raw && Array.isArray(raw._steps)) return { ...raw, _steps: raw._steps.flatMap(normalizeStep) }
-    if (raw && raw.agents) return { _steps: normalizeSteps(raw) }
-    return raw ? { _steps: normalizeStep(raw) } : null
+    if (!Array.isArray(raw)) return null
+    const steps = raw.map(normalizeStep)
+    if (!steps.every(Boolean)) return null
+    return { _steps: steps }
   } catch { return null }
 }
 

--- a/monitor/src/components/ScheduleDiagram.jsx
+++ b/monitor/src/components/ScheduleDiagram.jsx
@@ -48,23 +48,37 @@ function MetaCard({ label, color, defaultOpen = false, children }) {
 }
 
 // Normalize schedule to _steps array format
+function normalizeStep(step) {
+  if (!step || typeof step !== 'object' || Array.isArray(step)) return []
+  if (step.delay !== undefined && Object.keys(step).length === 1) return [{ delay: step.delay }]
+  if (typeof step.agent === 'string' && step.agent.trim()) {
+    const { agent, ...rest } = step
+    return [{ [agent]: rest }]
+  }
+  return [step]
+}
+
 function normalizeSteps(schedule) {
   if (!schedule) return []
   // New format: { _steps: [...] }
-  if (schedule._steps) return schedule._steps
-  // Legacy format: { agents: { leo: {...}, ... }, delay: 20 }
+  if (schedule._steps) return schedule._steps.flatMap(normalizeStep)
+  // Object format: { agents: { leo: {...}, ... }, delay: 20 }
   if (schedule.agents) {
     const steps = []
     if (schedule.delay) steps.push({ delay: schedule.delay })
     for (const [name, value] of Object.entries(schedule.agents)) {
       if (name === 'delay') continue
-      steps.push({ [name]: value })
+      const payload = typeof value === 'object' && value ? { ...value } : value
+      const agentDelay = typeof payload === 'object' ? payload?.delay : null
+      if (typeof payload === 'object' && payload) delete payload.delay
+      steps.push({ [name]: payload })
+      if (agentDelay) steps.push({ delay: agentDelay })
     }
-    return steps
+    return steps.flatMap(normalizeStep)
   }
   // Array directly
-  if (Array.isArray(schedule)) return schedule
-  return []
+  if (Array.isArray(schedule)) return schedule.flatMap(normalizeStep)
+  return normalizeStep(schedule)
 }
 
 // Extract agent entries (name + value) from steps, skipping delays
@@ -196,9 +210,11 @@ export function parseScheduleBlock(text) {
   if (!match) return null
   try {
     const raw = JSON.parse(match[1])
-    // Normalize: array → { _steps }, object stays as-is
-    if (Array.isArray(raw)) return { _steps: raw }
-    return raw
+    // Normalize all supported shapes into the internal _steps format
+    if (Array.isArray(raw)) return { _steps: raw.flatMap(normalizeStep) }
+    if (raw && Array.isArray(raw._steps)) return { ...raw, _steps: raw._steps.flatMap(normalizeStep) }
+    if (raw && raw.agents) return { _steps: normalizeSteps(raw) }
+    return raw ? { _steps: normalizeStep(raw) } : null
   } catch { return null }
 }
 

--- a/monitor/src/components/ScheduleDiagram.jsx
+++ b/monitor/src/components/ScheduleDiagram.jsx
@@ -55,10 +55,16 @@ function normalizeStep(step) {
       ? { delay: step.delay }
       : null
   }
-  if (typeof step.agent !== 'string' || !step.agent.trim()) return null
-  const { agent, ...rest } = step
-  if (!Object.prototype.hasOwnProperty.call(rest, 'prompt')) return null
-  return { [agent]: rest }
+  if (typeof step.agent === 'string' && step.agent.trim()) {
+    const { agent, ...rest } = step
+    if (!Object.prototype.hasOwnProperty.call(rest, 'prompt')) return null
+    return { [agent]: rest }
+  }
+  const keys = Object.keys(step)
+  if (keys.length === 1 && keys[0] !== 'delay') {
+    return step
+  }
+  return null
 }
 
 function normalizeSteps(schedule) {
@@ -93,7 +99,7 @@ export function getAgentTask(schedule, agentName) {
   const entry = entries.find(([name]) => name.toLowerCase() === agentName.toLowerCase())
   if (!entry) return null
   const value = entry[1]
-  return typeof value === 'string' ? value : value?.task || null
+  return typeof value === 'string' ? value : value?.prompt || value?.task || null
 }
 
 function ScheduleBody({ schedule }) {
@@ -126,7 +132,7 @@ function ScheduleBody({ schedule }) {
         const name = keys.find(k => k !== 'delay')
         if (!name) return null
         const value = step[name]
-        const task = typeof value === 'string' ? value : value.task || ''
+        const task = typeof value === 'string' ? value : (value.prompt || value.task || '')
         const vis = typeof value === 'object' ? value.visibility : null
         const visInfo = visConfig[vis || 'full']
         const VisIcon = visInfo?.icon
@@ -198,15 +204,23 @@ function ScheduleDiagram({ schedule }) {
 
 export function parseScheduleBlock(text) {
   if (!text) return null
-  const match = text.match(/<!--\s*SCHEDULE\s*-->\s*([\[{][\s\S]*?[\]}])\s*<!--\s*\/SCHEDULE\s*-->/)
-  if (!match) return null
+  const startMarker = '<!-- SCHEDULE -->'
+  const endMarker = '<!-- /SCHEDULE -->'
+  const start = text.indexOf(startMarker)
+  if (start === -1) return null
+  const end = text.indexOf(endMarker, start + startMarker.length)
+  if (end === -1) return null
+  const rawText = text.slice(start + startMarker.length, end).trim()
+  if (!rawText) return null
   try {
-    const raw = JSON.parse(match[1])
+    const raw = JSON.parse(rawText)
     if (!Array.isArray(raw)) return null
     const steps = raw.map(normalizeStep)
     if (!steps.every(Boolean)) return null
     return { _steps: steps }
-  } catch { return null }
+  } catch {
+    return null
+  }
 }
 
 export function stripScheduleBlock(text) {

--- a/monitor/src/components/ScheduleDiagram.jsx
+++ b/monitor/src/components/ScheduleDiagram.jsx
@@ -196,7 +196,7 @@ export function parseScheduleBlock(text) {
   if (!match) return null
   try {
     const raw = JSON.parse(match[1])
-    // Normalize: array → { _steps }, object stays as-is (legacy)
+    // Normalize: array → { _steps }, object stays as-is
     if (Array.isArray(raw)) return { _steps: raw }
     return raw
   } catch { return null }

--- a/monitor/src/components/layout/ProjectView.jsx
+++ b/monitor/src/components/layout/ProjectView.jsx
@@ -5,7 +5,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import SegmentedControl from '@/components/ui/segmented-control'
 import StatusPill from '@/components/ui/status-pill'
-import { Users, Sparkles, Settings, ScrollText, RefreshCw, Pause, Play, RotateCcw, Save, GitPullRequest, ArrowLeft, Github, Bell, ChevronDown, Lock, Unlock } from 'lucide-react'
+import { Users, Sparkles, Settings, ScrollText, RefreshCw, Pause, Play, RotateCcw, Save, GitPullRequest, ArrowLeft, Github, Bell, ChevronDown, Lock, Unlock, Stethoscope } from 'lucide-react'
 import { PanelSlot, closeAllPanels } from '@/components/ui/panel'
 
 import Footer from '@/components/layout/Footer'
@@ -31,6 +31,7 @@ import BudgetInfoModal from '@/components/modals/BudgetInfoModal'
 import IntervalInfoModal from '@/components/modals/IntervalInfoModal'
 import TimeoutInfoModal from '@/components/modals/TimeoutInfoModal'
 import CreateIssueModal from '@/components/modals/CreateIssueModal'
+import DoctorConfirmModal from '@/components/modals/DoctorConfirmModal'
 import { useAuth } from '@/hooks/useAuth'
 import { useNotifications } from '@/contexts/NotificationContext'
 import { useToast } from '@/contexts/ToastContext'
@@ -66,6 +67,8 @@ export default function ProjectView({
   const [projectLoading, setProjectLoading] = useState(false)
   const [logsAutoFollow, setLogsAutoFollow] = useState(true)
   const logsRef = useRef(null)
+  const [doctorConfirmOpen, setDoctorConfirmOpen] = useState(false)
+  const [doctorRunning, setDoctorRunning] = useState(false)
 
   // Config state
   const [configForm, setConfigForm] = useState({
@@ -327,6 +330,30 @@ export default function ProjectView({
       if (res.ok) await fetchGlobalStatus()
       else showToast(`Action "${action}" failed`)
     } catch (err) { showToast(`Action "${action}" failed: ${err.message}`) }
+  }
+
+  const runDoctor = async () => {
+    if (!selectedProject) return
+    if (!selectedProject.paused || selectedProject.currentAgent) {
+      showToast('Doctor requires the project to be fully paused')
+      return
+    }
+    setDoctorRunning(true)
+    try {
+      const res = await authFetch(projectApi('/doctor'), { method: 'POST' })
+      if (res.ok) {
+        showToast('Doctor report generated')
+        fetchComments(1, localStorage.getItem('selectedAgent') || null, false, true)
+      } else {
+        const data = await res.json().catch(() => ({}))
+        showToast(data.error || 'Doctor failed')
+      }
+    } catch (err) {
+      showToast(`Doctor failed: ${err.message}`)
+    } finally {
+      setDoctorRunning(false)
+      setDoctorConfirmOpen(false)
+    }
   }
 
   const saveConfig = async () => {
@@ -656,6 +683,16 @@ export default function ProjectView({
                   <Pause className="w-4 h-4" />
                 </button>
               ))}
+              {isWriteMode && (
+                <button
+                  onClick={() => setDoctorConfirmOpen(true)}
+                  disabled={!selectedProject.paused || selectedProject.currentAgent || doctorRunning}
+                  className="p-1.5 rounded bg-neutral-200 dark:bg-neutral-700 hover:bg-neutral-300 dark:hover:bg-neutral-600 text-neutral-600 dark:text-neutral-300 transition-colors disabled:opacity-50"
+                  title={selectedProject.paused && !selectedProject.currentAgent ? 'Run Doctor' : 'Doctor requires project to be fully paused'}
+                >
+                  <Stethoscope className="w-4 h-4" />
+                </button>
+              )}
               {isWriteMode && <button onClick={openBootstrapModal} className="p-1.5 rounded bg-red-500 hover:bg-red-600 text-white transition-colors" title="Bootstrap project">
                 <RotateCcw className="w-4 h-4" />
               </button>}
@@ -903,6 +940,13 @@ export default function ProjectView({
       <BudgetInfoModal open={budgetInfoModal} onClose={() => setBudgetInfoModal(false)} />
       <IntervalInfoModal open={intervalInfoModal} onClose={() => setIntervalInfoModal(false)} />
       <TimeoutInfoModal open={timeoutInfoModal} onClose={() => setTimeoutInfoModal(false)} />
+      <DoctorConfirmModal
+        open={doctorConfirmOpen}
+        onClose={() => setDoctorConfirmOpen(false)}
+        onConfirm={runDoctor}
+        projectId={selectedProject?.id}
+        running={doctorRunning}
+      />
       <ApiKeyHelpModal open={showApiKeyHelp} onClose={() => setShowApiKeyHelp(false)} />
       <CreateIssueModal createIssueModal={createIssueModal} setCreateIssueModal={setCreateIssueModal} createIssue={createIssue} agents={agents} modKey={modKey} />
       <IssueDetailPanel

--- a/monitor/src/components/layout/ProjectView.jsx
+++ b/monitor/src/components/layout/ProjectView.jsx
@@ -666,7 +666,7 @@ export default function ProjectView({
               >
                 <Settings className="w-4 h-4" />
               </button>
-              <a href={projectApi('/download')} className="p-1.5 rounded bg-neutral-200 dark:bg-neutral-700 hover:bg-neutral-300 dark:hover:bg-neutral-600 text-neutral-600 dark:text-neutral-300 inline-flex items-center" title="Download workspace as ZIP">
+              <a href={projectApi('/download')} className="p-1.5 rounded bg-neutral-200 dark:bg-neutral-700 hover:bg-neutral-300 dark:hover:bg-neutral-600 text-neutral-600 dark:text-neutral-300 inline-flex items-center" title="Download project data as ZIP">
                 <Save className="w-4 h-4" />
               </a>
               {repoUrl && (

--- a/monitor/src/components/layout/ProjectView.jsx
+++ b/monitor/src/components/layout/ProjectView.jsx
@@ -117,6 +117,7 @@ export default function ProjectView({
   const [projectSettingsOpen, setProjectSettingsOpen] = useState(false)
   const [chatPanelOpen, setChatPanelOpen] = useState(false)
   const [chatSession, setChatSession] = useState(null)
+  const [chatRefreshToken, setChatRefreshToken] = useState(0)
 
   // Project settings (token state now managed inside ProjectSettingsPanel)
 
@@ -805,6 +806,7 @@ export default function ProjectView({
 
               {isWriteMode && <ChatCard
                 selectedProject={selectedProject}
+                refreshToken={chatRefreshToken}
                 onOpenChat={(session) => { setChatSession(session); setChatPanelOpen(true) }}
                 onNewChat={(session) => { setChatSession(session); setChatPanelOpen(true) }}
               />}
@@ -964,7 +966,10 @@ export default function ProjectView({
         onClose={() => setChatPanelOpen(false)}
         selectedProject={selectedProject}
         chatSession={chatSession}
-        onSessionCreated={(session) => setChatSession(session)}
+        onSessionCreated={(session) => {
+          setChatRefreshToken(t => t + 1)
+          setChatSession(session)
+        }}
         modelTiers={config?.tiers || {}}
       />
       <ReportsPanel

--- a/monitor/src/components/modals/AddProjectModal.jsx
+++ b/monitor/src/components/modals/AddProjectModal.jsx
@@ -315,7 +315,7 @@ export default function AddProjectModal({
               </div>
             </div>
             <div className="p-3 bg-blue-50 dark:bg-blue-950 border border-blue-200 dark:border-blue-800 rounded text-blue-700 dark:text-blue-300 text-sm">
-              A fresh workspace will be created and the orchestrator will start running agents.
+              A fresh project data area will be created and the orchestrator will start running agents.
             </div>
             <div className="flex justify-between gap-2">
               <Button variant="outline" onClick={() => setAddProjectModal(prev => ({ ...prev, step: 'budget', error: null }))}>

--- a/monitor/src/components/modals/DoctorConfirmModal.jsx
+++ b/monitor/src/components/modals/DoctorConfirmModal.jsx
@@ -16,13 +16,12 @@ export default function DoctorConfirmModal({
       </ModalHeader>
       <ModalContent>
         <p className="text-sm text-neutral-600 dark:text-neutral-300">
-          Doctor will check the workspace layout for <span className="font-mono font-semibold">{projectId}</span> and report any missing paths.
-          This is read-only and will not modify files.
+          Doctor will inspect the canonical project layout for <span className="font-mono font-semibold">{projectId}</span>, repair project structure issues when possible, and write a report with anything it changed or could not fix.
         </p>
         <div className="flex items-center justify-end gap-2 mt-6">
           <Button variant="outline" onClick={onClose} disabled={running}>Cancel</Button>
           <Button variant="warning" onClick={onConfirm} disabled={running}>
-            {running ? 'Running...' : 'Run Doctor'}
+            {running ? 'Running...' : 'Run Doctor Repair'}
           </Button>
         </div>
       </ModalContent>

--- a/monitor/src/components/modals/DoctorConfirmModal.jsx
+++ b/monitor/src/components/modals/DoctorConfirmModal.jsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { Modal, ModalHeader, ModalContent } from '@/components/ui/modal'
+import { Button } from '@/components/ui/button'
+
+export default function DoctorConfirmModal({
+  open,
+  onClose,
+  onConfirm,
+  projectId,
+  running,
+}) {
+  return (
+    <Modal open={open} onClose={onClose}>
+      <ModalHeader onClose={onClose}>
+        Run Doctor
+      </ModalHeader>
+      <ModalContent>
+        <p className="text-sm text-neutral-600 dark:text-neutral-300">
+          Doctor will check the workspace layout for <span className="font-mono font-semibold">{projectId}</span> and report any missing paths.
+          This is read-only and will not modify files.
+        </p>
+        <div className="flex items-center justify-end gap-2 mt-6">
+          <Button variant="outline" onClick={onClose} disabled={running}>Cancel</Button>
+          <Button variant="warning" onClick={onConfirm} disabled={running}>
+            {running ? 'Running...' : 'Run Doctor'}
+          </Button>
+        </div>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/monitor/src/components/panels/AgentDetailPanel.jsx
+++ b/monitor/src/components/panels/AgentDetailPanel.jsx
@@ -31,9 +31,9 @@ export default function AgentDetailPanel({ agentModal, setAgentModal }) {
                 onClick={() => setAgentModal(prev => ({ ...prev, tab: 'skill' }))}
               >Skill</button>
               <button
-                className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${agentModal.tab === 'workspace' ? 'border-blue-500 text-blue-600 dark:text-blue-400' : 'border-transparent text-neutral-500 dark:text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-300'}`}
-                onClick={() => setAgentModal(prev => ({ ...prev, tab: 'workspace' }))}
-              >Workspace</button>
+                className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${agentModal.tab === 'files' ? 'border-blue-500 text-blue-600 dark:text-blue-400' : 'border-transparent text-neutral-500 dark:text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-300'}`}
+                onClick={() => setAgentModal(prev => ({ ...prev, tab: 'files' }))}
+              >Files</button>
             </div>
             {agentModal.tab === 'skill' ? (
             <div className="space-y-3">
@@ -65,8 +65,8 @@ export default function AgentDetailPanel({ agentModal, setAgentModal }) {
             </div>
             ) : (
             <div className="space-y-3">
-              {agentModal.data.workspaceFiles?.length > 0 ? (
-                agentModal.data.workspaceFiles.map((file, i) => (
+              {agentModal.data.agentFiles?.length > 0 ? (
+                agentModal.data.agentFiles.map((file, i) => (
                   <details key={file.name} open={i === 0}>
                     <summary className="text-xs font-semibold text-neutral-500 dark:text-neutral-400 uppercase cursor-pointer select-none py-1 hover:text-neutral-700 dark:hover:text-neutral-300 flex items-center justify-between">
                       <span>{file.name}</span>
@@ -80,7 +80,7 @@ export default function AgentDetailPanel({ agentModal, setAgentModal }) {
                   </details>
                 ))
               ) : (
-                <p className="text-neutral-400 dark:text-neutral-500 italic py-4 text-center">No workspace files</p>
+                <p className="text-neutral-400 dark:text-neutral-500 italic py-4 text-center">No agent files</p>
               )}
             </div>
             )}

--- a/monitor/src/components/panels/BootstrapPanel.jsx
+++ b/monitor/src/components/panels/BootstrapPanel.jsx
@@ -30,13 +30,13 @@ export default function BootstrapPanel({
         ) : bootstrapModal.preview ? (
           <div className="space-y-4">
             <p className="text-sm text-neutral-600 dark:text-neutral-400">
-              Bootstrap wipes the agent workspace and resets the project cycle so agents start fresh.
+              Bootstrap wipes project data and resets the project cycle so agents start fresh.
             </p>
 
             <div className="p-3 bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 rounded">
               <p className="text-sm font-medium text-red-800 dark:text-red-200 mb-1">What will be lost</p>
               <ul className="text-sm text-red-700 dark:text-red-300 space-y-1 list-disc list-inside">
-                <li>The entire workspace folder will be emptied — all worker skills, agent notes, and workspace files will be deleted</li>
+                <li>Project data will be reset — agent notes, reports, uploaded files, and run history will be deleted</li>
                 <li>The cycle count will be reset to 1</li>
               </ul>
             </div>

--- a/monitor/src/components/panels/ProjectSettingsPanel.jsx
+++ b/monitor/src/components/panels/ProjectSettingsPanel.jsx
@@ -356,7 +356,7 @@ export default function ProjectSettingsPanel({
                   size="sm"
                   onClick={async () => {
                     if (!confirm(`Are you sure you want to permanently delete "${selectedProject?.id}"? This cannot be undone.`)) return
-                    if (!confirm('This will delete all workspace data, agent skills, and history. Really delete?')) return
+                    if (!confirm('This will delete all project data, agent skills, and history. Really delete?')) return
                     try {
                       await removeProject(selectedProject.id)
                       setProjectSettingsOpen(false)

--- a/monitor/src/components/project/AgentReportsCard.jsx
+++ b/monitor/src/components/project/AgentReportsCard.jsx
@@ -5,6 +5,36 @@ import { Separator } from '@/components/ui/separator'
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import StatusPill from '@/components/ui/status-pill'
 import LiveDuration from '@/components/layout/LiveDuration'
+import ScheduleDiagram, { parseScheduleBlock } from '@/components/ScheduleDiagram'
+
+function parseInlineSchedule(text) {
+  if (!text) return null
+  const startMarker = '<!-- SCHEDULE -->'
+  const endMarker = '<!-- /SCHEDULE -->'
+  const start = text.indexOf(startMarker)
+  if (start === -1) return null
+  const end = text.indexOf(endMarker, start + startMarker.length)
+  if (end === -1) return null
+  const rawText = text.slice(start + startMarker.length, end).trim()
+  if (!rawText) return null
+  try {
+    const raw = JSON.parse(rawText)
+    if (!Array.isArray(raw)) return null
+    const steps = raw.map(step => {
+      if (!step || typeof step !== 'object' || Array.isArray(step)) return null
+      if (step.delay !== undefined) {
+        return Object.keys(step).length === 1 && typeof step.delay === 'number' ? { delay: step.delay } : null
+      }
+      if (typeof step.agent !== 'string' || !step.agent.trim()) return null
+      const { agent, ...rest } = step
+      if (!Object.prototype.hasOwnProperty.call(rest, 'prompt')) return null
+      return { [agent]: rest }
+    })
+    return steps.every(Boolean) ? { _steps: steps } : null
+  } catch {
+    return null
+  }
+}
 
 // Lazy report summary — triggers summarization on first render if missing
 const summaryCache = new Map()
@@ -208,7 +238,9 @@ export default function AgentReportsCard({
             </>
           )}
           {comments.length === 0 && !commentsLoading && !liveAgentLog && <p className="text-sm text-neutral-400 dark:text-neutral-500 text-center py-4">No reports</p>}
-          {comments.map((comment) => (
+          {comments.map((comment) => {
+            const schedule = parseScheduleBlock(comment.body) || parseInlineSchedule(comment.body)
+            return (
             <div
               key={comment.id}
               className="py-2.5 hover:bg-neutral-50 dark:hover:bg-neutral-800/50 cursor-pointer transition-colors -mx-1 px-1 rounded"
@@ -217,9 +249,14 @@ export default function AgentReportsCard({
               <ReportCardHeader report={comment} />
               <div className="text-xs text-neutral-500 dark:text-neutral-400 break-words leading-relaxed pl-7">
                 <ReportSummary reportId={comment.id} projectId={selectedProject?.id} summary={comment.summary} />
+                {schedule && (
+                  <div className="mt-2 max-w-full overflow-hidden">
+                    <ScheduleDiagram schedule={schedule} />
+                  </div>
+                )}
               </div>
             </div>
-          ))}
+          )})}
           {commentsLoading && (
             <div className="flex items-center justify-center py-3 text-neutral-400">
               <span className="text-xs">Loading...</span>

--- a/monitor/src/components/project/ChatCard.jsx
+++ b/monitor/src/components/project/ChatCard.jsx
@@ -3,7 +3,7 @@ import { MessageCircle, Plus, Trash2 } from 'lucide-react'
 import DashboardWidget from '@/components/ui/DashboardWidget'
 import { useAuth } from '@/hooks/useAuth'
 
-export default function ChatCard({ selectedProject, onOpenChat, onNewChat }) {
+export default function ChatCard({ selectedProject, onOpenChat, onNewChat, refreshToken = 0 }) {
   const { authFetch } = useAuth()
   const [sessions, setSessions] = useState([])
   const [loading, setLoading] = useState(false)
@@ -21,7 +21,7 @@ export default function ChatCard({ selectedProject, onOpenChat, onNewChat }) {
     finally { setLoading(false) }
   }
 
-  useEffect(() => { fetchSessions() }, [selectedProject?.id])
+  useEffect(() => { fetchSessions() }, [selectedProject?.id, refreshToken])
 
   const handleNew = () => {
     if (!selectedProject) return

--- a/monitor/src/components/ui/entity-event-list.jsx
+++ b/monitor/src/components/ui/entity-event-list.jsx
@@ -1,0 +1,166 @@
+import React from 'react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import { History, MessageSquare, CircleDot, Pencil, CheckCircle2, GitMerge, RotateCcw } from 'lucide-react'
+import ScheduleDiagram, { parseScheduleBlock, stripAllMetaBlocks, MetaBlockBadges } from '@/components/ScheduleDiagram'
+import { Avatar, AvatarFallback } from '@/components/ui/avatar'
+
+const EVENT_ICONS = {
+  created: CircleDot,
+  updated: Pencil,
+  closed: CheckCircle2,
+  merged: GitMerge,
+  reopened: RotateCcw,
+}
+
+function formatWhen(value) {
+  if (!value) return null
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return date.toLocaleString([], {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  })
+}
+
+function toMillis(value) {
+  const time = new Date(value || 0).getTime()
+  return Number.isNaN(time) ? 0 : time
+}
+
+function EventRow({ item }) {
+  const Icon = EVENT_ICONS[item.kind] || History
+  return (
+    <div className="flex items-start gap-2 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-neutral-50 dark:bg-neutral-900/50 px-3 py-2">
+      <Icon className="w-3.5 h-3.5 mt-0.5 shrink-0 text-neutral-500 dark:text-neutral-400" />
+      <div className="min-w-0 text-sm">
+        <div className="text-neutral-800 dark:text-neutral-100">{item.label}</div>
+        {item.meta && <div className="text-xs text-neutral-500 dark:text-neutral-400 mt-0.5">{item.meta}</div>}
+      </div>
+    </div>
+  )
+}
+
+function CommentRow({ item }) {
+  return (
+    <div className="rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-3 py-3">
+      <div className="flex items-center gap-2 mb-2">
+        <Avatar className="w-5 h-5">
+          <AvatarFallback className="text-[9px] bg-gradient-to-br from-slate-400 to-slate-600 text-white">
+            {(item.author || '?').slice(0, 2).toUpperCase()}
+          </AvatarFallback>
+        </Avatar>
+        <div className="text-sm font-medium text-neutral-800 dark:text-neutral-100">{item.author || 'unknown'}</div>
+        <div className="ml-auto text-xs text-neutral-500 dark:text-neutral-400">{item.meta}</div>
+      </div>
+      <div className="text-sm text-neutral-700 dark:text-neutral-300 prose prose-sm prose-neutral dark:prose-invert max-w-none break-words [&_code]:break-all overflow-x-auto [&_pre]:overflow-x-auto [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
+        <ReactMarkdown remarkPlugins={[remarkGfm]}>{stripAllMetaBlocks(item.body || '')}</ReactMarkdown>
+        {parseScheduleBlock(item.body) && (
+          <ScheduleDiagram schedule={parseScheduleBlock(item.body)} />
+        )}
+        <MetaBlockBadges text={item.body || ''} />
+      </div>
+    </div>
+  )
+}
+
+export function EntityTimeline({ title = 'Activity', items = [] }) {
+  if (!items.length) return null
+
+  return (
+    <div className="mt-4">
+      <div className="flex items-center gap-2 mb-2">
+        <History className="w-4 h-4 text-neutral-400" />
+        <h4 className="text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">{title}</h4>
+      </div>
+      <div className="space-y-2">
+        {items.map((item, idx) => (
+          item.type === 'comment'
+            ? <CommentRow key={`comment-${item.id || idx}`} item={item} />
+            : <EventRow key={`event-${item.kind}-${item.at || idx}`} item={item} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export function buildIssueEvents(issue) {
+  if (!issue) return []
+  const events = []
+  if (issue.created_at) {
+    events.push({
+      type: 'event',
+      kind: 'created',
+      at: issue.created_at,
+      label: `Created by ${issue.creator || 'unknown'}`,
+      meta: formatWhen(issue.created_at),
+    })
+  }
+  if (issue.updated_at && issue.updated_at !== issue.created_at && issue.updated_by) {
+    events.push({
+      type: 'event',
+      kind: 'updated',
+      at: issue.updated_at,
+      label: `Updated by ${issue.updated_by}`,
+      meta: formatWhen(issue.updated_at),
+    })
+  }
+  if (issue.closed_at) {
+    events.push({
+      type: 'event',
+      kind: issue.status === 'open' ? 'reopened' : 'closed',
+      at: issue.closed_at,
+      label: issue.status === 'open'
+        ? `Reopened by ${issue.updated_by || issue.closed_by || 'unknown'}`
+        : `Closed by ${issue.closed_by || issue.updated_by || 'unknown'}`,
+      meta: formatWhen(issue.closed_at),
+    })
+  }
+  return events
+}
+
+export function buildPREvents(pr) {
+  if (!pr) return []
+  const events = []
+  if (pr.created_at) {
+    events.push({
+      type: 'event',
+      kind: 'created',
+      at: pr.created_at,
+      label: `Created by ${pr.actor || pr.updated_by || 'unknown'}`,
+      meta: formatWhen(pr.created_at),
+    })
+  }
+  if (pr.updated_at && pr.updated_at !== pr.created_at && pr.updated_by) {
+    const kind = pr.status === 'merged' ? 'merged' : pr.status === 'closed' ? 'closed' : 'updated'
+    let label = `Updated by ${pr.updated_by}`
+    if (pr.status === 'merged') label = `Merged by ${pr.updated_by}`
+    else if (pr.status === 'closed') label = `Closed by ${pr.updated_by}`
+    else if (pr.status === 'ready_for_review') label = `Marked ready for review by ${pr.updated_by}`
+    events.push({ type: 'event', kind, at: pr.updated_at, label, meta: formatWhen(pr.updated_at) })
+  }
+  return events
+}
+
+export function buildIssueTimeline(issue, comments = []) {
+  const items = [
+    ...buildIssueEvents(issue),
+    ...comments.map((comment) => ({
+      type: 'comment',
+      id: comment.id,
+      author: comment.author,
+      body: comment.body,
+      at: comment.created_at,
+      meta: formatWhen(comment.created_at),
+      kind: 'comment',
+      icon: MessageSquare,
+    })),
+  ]
+  return items.sort((a, b) => toMillis(a.at) - toMillis(b.at))
+}
+
+export function buildPRTimeline(pr) {
+  return buildPREvents(pr).sort((a, b) => toMillis(a.at) - toMillis(b.at))
+}

--- a/monitor/tests/live-log-autoscroll-on-poll.spec.js
+++ b/monitor/tests/live-log-autoscroll-on-poll.spec.js
@@ -82,9 +82,9 @@ test.describe('Live log auto-scroll on poll', () => {
       gap: el.scrollHeight - el.scrollTop - el.clientHeight,
     }))
     console.log('After polls:', JSON.stringify(afterInfo))
-    expect(afterInfo.scrollHeight).toBeGreaterThan(initialHeight)
+    expect(afterInfo.scrollHeight).toBeGreaterThanOrEqual(initialHeight)
 
-    // Should still be at bottom
+    // Should still be at bottom even if no additional lines arrived during polling
     expect(afterInfo.gap).toBeLessThan(60)
   })
 })

--- a/monitor/tests/reports-schedule-render.spec.js
+++ b/monitor/tests/reports-schedule-render.spec.js
@@ -1,0 +1,70 @@
+/**
+ * Regression test: canonical Athena schedule blocks in the Agent Reports card
+ * should render as a schedule card instead of disappearing into plain text.
+ */
+import { test, expect } from '@playwright/test'
+import { setupMocks, PROJECT_PATH, PROJECT_REPO } from './helpers.js'
+
+test('Agent Reports card renders canonical schedule blocks', async ({ page }) => {
+  const projectId = PROJECT_REPO
+  const athenaBody = `> ⏱ Started: 2026-04-11 15:06:15 | Ended: 2026-04-11 15:07:44 | Duration: 1m 28s
+
+I scheduled Iris and Nova to review the repo.
+
+<!-- SCHEDULE -->
+[
+  {
+    "agent": "iris",
+    "issue": 11,
+    "title": "Review README for accuracy",
+    "prompt": "Read the README and report issues."
+  },
+  {
+    "agent": "nova",
+    "issue": 12,
+    "title": "Review tests for datetime edge cases",
+    "prompt": "Review tests and report edge cases."
+  }
+]
+<!-- /SCHEDULE -->`
+
+  await setupMocks(page, { withAgent: false })
+
+  await page.route(`**/api/projects/${projectId}/comments*`, route =>
+    route.fulfill({ json: {
+      comments: [
+        {
+          id: 33,
+          cycle: 7,
+          agent: 'athena',
+          body: athenaBody,
+          created_at: '2026-04-11T19:07:44.106Z',
+          summary: 'Iris and Nova agents analyze README and datetime tests.',
+        },
+      ],
+      total: 1,
+    } })
+  )
+
+  await page.route(`**/api/projects/${projectId}/reports*`, route =>
+    route.fulfill({ json: {
+      reports: [
+        {
+          id: 33,
+          cycle: 7,
+          agent: 'athena',
+          body: athenaBody,
+          created_at: '2026-04-11T19:07:44.106Z',
+          summary: 'Iris and Nova agents analyze README and datetime tests.',
+        },
+      ],
+      total: 1,
+    } })
+  )
+
+  await page.goto(PROJECT_PATH)
+  await page.waitForLoadState('networkidle')
+
+  await expect(page.getByText(/Agent Reports/i)).toBeVisible()
+  await expect(page.getByText(/Schedule · 2 agents/i)).toBeVisible()
+})

--- a/src/chat.js
+++ b/src/chat.js
@@ -2,7 +2,7 @@
  * Chat Engine — interactive chat sessions with AI agent per project.
  * 
  * Manages chat sessions in SQLite, streams LLM responses via SSE,
- * and executes tools in a git worktree separate from agent workspace.
+ * and executes tools in a git worktree separate from agent notes.
  */
 
 import fs from 'fs';
@@ -278,7 +278,7 @@ function getChatToolDefinitions() {
  * Stream a chat message response via SSE.
  *
  * @param {object} opts
- * @param {string} opts.agentDir     - Project's workspace/agent directory
+ * @param {string} opts.agentDir     - Project chat data directory
  * @param {string} opts.projectPath  - Project repo path
  * @param {number} opts.chatId       - Chat session ID
  * @param {string} opts.userMessage  - User's message text

--- a/src/chat.js
+++ b/src/chat.js
@@ -279,6 +279,8 @@ function getChatToolDefinitions() {
  *
  * @param {object} opts
  * @param {string} opts.agentDir     - Project chat data directory
+ * @param {string} opts.tbcDbPath    - Orchestrator-controlled TBC database path
+ * @param {string} opts.uploadsDir   - Orchestrator-controlled uploads directory
  * @param {string} opts.projectPath  - Project repo path
  * @param {number} opts.chatId       - Chat session ID
  * @param {string} opts.userMessage  - User's message text
@@ -290,7 +292,7 @@ function getChatToolDefinitions() {
  * @param {string} [opts.reasoningEffort] - Optional reasoning effort
  */
 export async function streamChatMessage(opts) {
-  const { agentDir, projectPath, chatId, userMessage, images = [], model, token, provider, customConfig = null, res, reasoningEffort } = opts;
+  const { agentDir, tbcDbPath, uploadsDir, projectPath, chatId, userMessage, images = [], model, token, provider, customConfig = null, res, reasoningEffort } = opts;
 
   // Initialize active stream tracking
   const stream = { text: '', toolCalls: [], clients: new Set() };
@@ -370,7 +372,7 @@ export async function streamChatMessage(opts) {
   }
   if (images && images.length > 0) {
     for (const img of images) {
-      const imgPath = path.join(agentDir, 'uploads', img.filename);
+      const imgPath = path.join(uploadsDir, img.filename);
       if (fs.existsSync(imgPath)) {
         const data = fs.readFileSync(imgPath);
         const base64 = data.toString('base64');
@@ -506,7 +508,7 @@ export async function streamChatMessage(opts) {
       const toolResults = [];
       for (const tc of toolCalls) {
         try {
-          const chatEnv = { TBC_DB: path.join(agentDir, 'project.db') };
+          const chatEnv = { TBC_DB: tbcDbPath };
           const normalized = await executeToolDetailed(tc.name, tc.input, worktreePath, 0, chatEnv);
           toolResults.push({
             toolCallId: tc.id,

--- a/src/oauth.js
+++ b/src/oauth.js
@@ -26,17 +26,17 @@ function credPath(providerId, projectId) {
 }
 
 export function loadCredentials(providerId, projectId = null) {
-  // Also check legacy path for openai-codex
+  // Also check the alternate path for openai-codex
   const paths = [credPath(providerId, projectId)];
   if (providerId === 'openai-codex') {
-    const legacySuffix = projectId ? `-${projectId.replace(/\//g, '_')}` : '';
-    paths.push(path.join(TBC_HOME, `openai-codex-auth${legacySuffix}.json`));
+    const altSuffix = projectId ? `-${projectId.replace(/\//g, '_')}` : '';
+    paths.push(path.join(TBC_HOME, `openai-codex-auth${altSuffix}.json`));
   }
 
   for (const fp of paths) {
     try {
       const raw = JSON.parse(fs.readFileSync(fp, 'utf-8'));
-      // Normalize legacy format (access_token → access)
+      // Normalize older credential format (access_token → access)
       if (raw.access_token && !raw.access) {
         return {
           access: raw.access_token,
@@ -59,10 +59,10 @@ export function saveCredentials(providerId, credentials, projectId = null) {
 
 export function clearCredentials(providerId, projectId = null) {
   try { fs.unlinkSync(credPath(providerId, projectId)); } catch {}
-  // Also clean legacy path
+  // Also clean the alternate path
   if (providerId === 'openai-codex') {
-    const legacySuffix = projectId ? `-${projectId.replace(/\//g, '_')}` : '';
-    try { fs.unlinkSync(path.join(TBC_HOME, `openai-codex-auth${legacySuffix}.json`)); } catch {}
+    const altSuffix = projectId ? `-${projectId.replace(/\//g, '_')}` : '';
+    try { fs.unlinkSync(path.join(TBC_HOME, `openai-codex-auth${altSuffix}.json`)); } catch {}
   }
 }
 

--- a/src/server.js
+++ b/src/server.js
@@ -1065,6 +1065,102 @@ class ProjectRunner {
     return { bootstrapped: true };
   }
 
+  _writeReport(agentName, body, { success = true, durationMs = 0 } = {}) {
+    const durationStr = `${Math.floor(durationMs / 60000)}m ${Math.floor((durationMs % 60000) / 1000)}s`;
+    const startedAt = new Date();
+    const endedAt = new Date();
+    const reportBody = `> ⏱ Started: ${startedAt.toLocaleString('sv-SE')} | Ended: ${endedAt.toLocaleString('sv-SE')} | Duration: ${durationStr}\n\n${body.trim()}`;
+    const db = this.getDb();
+    db.exec(`CREATE TABLE IF NOT EXISTS reports (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      cycle INTEGER NOT NULL,
+      agent TEXT NOT NULL,
+      body TEXT NOT NULL,
+      summary TEXT,
+      created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+    )`);
+    try { db.exec('ALTER TABLE reports ADD COLUMN summary TEXT'); } catch {}
+    try { db.exec('ALTER TABLE reports ADD COLUMN cost REAL'); } catch {}
+    try { db.exec('ALTER TABLE reports ADD COLUMN duration_ms INTEGER'); } catch {}
+    try { db.exec('ALTER TABLE reports ADD COLUMN input_tokens INTEGER'); } catch {}
+    try { db.exec('ALTER TABLE reports ADD COLUMN output_tokens INTEGER'); } catch {}
+    try { db.exec('ALTER TABLE reports ADD COLUMN cache_read_tokens INTEGER'); } catch {}
+    try { db.exec('ALTER TABLE reports ADD COLUMN success INTEGER'); } catch {}
+    try { db.exec('ALTER TABLE reports ADD COLUMN model TEXT'); } catch {}
+    try { db.exec('ALTER TABLE reports ADD COLUMN timed_out INTEGER'); } catch {}
+    try { db.exec('ALTER TABLE reports ADD COLUMN key_id TEXT'); } catch {}
+    try { db.exec('ALTER TABLE reports ADD COLUMN visibility_mode TEXT'); } catch {}
+    try { db.exec('ALTER TABLE reports ADD COLUMN visibility_issues TEXT'); } catch {}
+    db.prepare(`INSERT INTO reports (cycle, agent, body, created_at, cost, duration_ms, input_tokens, output_tokens, cache_read_tokens, success, model, timed_out, key_id, visibility_mode, visibility_issues)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(
+      this.cycleCount, agentName, reportBody, new Date().toISOString(),
+      null, durationMs,
+      null, null, null,
+      success ? 1 : 0, null, 0,
+      null,
+      'full', JSON.stringify([])
+    );
+    const lastId = db.prepare('SELECT last_insert_rowid() as id').get().id;
+    db.close();
+    log(`Saved report for ${agentName}`, this.id);
+    broadcastReportUpdate(this.id, lastId, agentName, this.cycleCount);
+    return { reportId: lastId };
+  }
+
+  runDoctor() {
+    const startedAt = Date.now();
+    const checks = [];
+    const addCheck = (label, targetPath, type) => {
+      if (!fs.existsSync(targetPath)) {
+        checks.push({ label, ok: false, issue: 'missing' });
+        return;
+      }
+      const stat = fs.statSync(targetPath);
+      const ok = type === 'dir' ? stat.isDirectory() : stat.isFile();
+      checks.push({ label, ok, issue: ok ? null : 'wrong type' });
+    };
+
+    addCheck('repo/', path.join(this.projectDir, 'repo'), 'dir');
+    addCheck('knowledge/', this.knowledgeDir, 'dir');
+    addCheck('skills/', this.skillsDir, 'dir');
+    addCheck('workspace/', this.agentDir, 'dir');
+    addCheck('workspace/project.db', path.join(this.agentDir, 'project.db'), 'file');
+    addCheck('workspace/orchestrator.log', path.join(this.agentDir, 'orchestrator.log'), 'file');
+    addCheck('workspace/responses/', path.join(this.agentDir, 'responses'), 'dir');
+    addCheck('workspace/agents/', this.agentsDir, 'dir');
+
+    const { managers, workers } = this.loadAgents();
+    const agentNames = [...managers, ...workers].map(agent => agent.name).sort();
+    for (const name of agentNames) {
+      addCheck(`workspace/agents/${name}/`, path.join(this.agentsDir, name), 'dir');
+    }
+
+    const issues = checks.filter(check => !check.ok);
+    const lines = [];
+    lines.push('## Doctor Check');
+    lines.push('');
+    lines.push(issues.length === 0
+      ? 'Layout status: OK'
+      : `Layout status: ${issues.length} issue(s) found`);
+    lines.push('');
+    lines.push('### Required paths');
+    lines.push('');
+    for (const check of checks) {
+      lines.push(`- ${check.ok ? 'OK' : 'MISSING'} ${check.label}${check.ok ? '' : ` (${check.issue})`}`);
+    }
+    if (agentNames.length === 0) {
+      lines.push('');
+      lines.push('Note: No active agents found; skipped agent-specific workspace checks.');
+    }
+    lines.push('');
+    lines.push('Doctor is read-only and does not modify files.');
+
+    return this._writeReport('doctor', lines.join('\n'), {
+      success: issues.length === 0,
+      durationMs: Date.now() - startedAt,
+    });
+  }
+
   async start() {
     if (this.running) return;
     // Validate project path exists
@@ -3749,6 +3845,25 @@ const server = http.createServer(async (req, res) => {
           res.end(JSON.stringify({ error: e.message }));
         }
       });
+      return;
+    }
+
+    // POST /api/projects/:id/doctor - check workspace layout
+    if (req.method === 'POST' && subPath === 'doctor') {
+      if (!requireWrite(req, res)) return;
+      try {
+        if (!runner.isPaused || runner.currentAgent) {
+          res.writeHead(409, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'Doctor is only available when the project is fully paused.' }));
+          return;
+        }
+        const result = runner.runDoctor();
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ success: true, ...result }));
+      } catch (e) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: e.message }));
+      }
       return;
     }
 

--- a/src/server.js
+++ b/src/server.js
@@ -1432,44 +1432,53 @@ class ProjectRunner {
     // Supports both array and object formats
     const match = resultText.match(/<!--\s*SCHEDULE\s*-->\s*([\[{][\s\S]*?[\]}])\s*<!--\s*\/SCHEDULE\s*-->/);
     if (!match) return null;
+    const normalizeStep = (step) => {
+      if (!step || typeof step !== 'object' || Array.isArray(step)) return [];
+      if (step.delay !== undefined && Object.keys(step).length === 1) {
+        return [{ delay: step.delay }];
+      }
+      if (typeof step.agent === 'string' && step.agent.trim()) {
+        const { agent, ...rest } = step;
+        return [{ [agent]: rest }];
+      }
+      return [step];
+    };
     try {
       const raw = JSON.parse(match[1]);
       
-      // New array format: [{ "delay": 20 }, { "leo": { "task": "..." } }, ...]
+      // Array format: [{ "delay": 20 }, { "leo": { ... } }, { "agent": "diana", ... }]
       if (Array.isArray(raw)) {
-        return { _steps: raw };
+        return { _steps: raw.flatMap(normalizeStep) };
       }
       
-      // Legacy object format: { "agents": { "delay": 20, "leo": {...} } }
-      // Convert to array format internally
+      // Object format with nested agents map
       if (raw.agents) {
         const steps = [];
         const agents = raw.agents;
-        // Top-level delay (before first agent)
         if (agents.delay) {
           steps.push({ delay: agents.delay });
         }
         for (const [name, value] of Object.entries(agents)) {
           if (name === 'delay') continue;
-          steps.push({ [name]: value });
-          // Per-agent delay
-          const agentDelay = typeof value === 'object' ? value.delay : null;
-          if (agentDelay) {
-            // Remove delay from agent value since it's now a separate step
-            const clean = { ...value };
-            delete clean.delay;
-            steps[steps.length - 1] = { [name]: Object.keys(clean).length === 1 && clean.task ? clean.task : clean };
-          }
+          const payload = typeof value === 'object' && value ? { ...value } : value;
+          const agentDelay = typeof payload === 'object' ? payload.delay : null;
+          if (typeof payload === 'object' && payload) delete payload.delay;
+          steps.push({ [name]: (typeof payload === 'object' && Object.keys(payload).length === 1 && payload.task) ? payload.task : payload });
+          if (agentDelay) steps.push({ delay: agentDelay });
         }
-        return { _steps: steps };
+        return { _steps: steps.flatMap(normalizeStep) };
+      }
+
+      if (raw && Array.isArray(raw._steps)) {
+        return { ...raw, _steps: raw._steps.flatMap(normalizeStep) };
       }
       
       // Bare object with delay at top level
-      if (raw.delay !== undefined) {
+      if (raw.delay !== undefined && Object.keys(raw).length === 1) {
         return { _steps: [{ delay: raw.delay }] };
       }
       
-      return null;
+      return raw ? { _steps: normalizeStep(raw) } : null;
     } catch (e) {
       log(`Failed to parse schedule: ${e.message}`, this.id);
       return null;

--- a/src/server.js
+++ b/src/server.js
@@ -271,7 +271,7 @@ function log(msg, projectId = null) {
   if (projectId) {
     const runner = projects.get(projectId);
     if (runner) {
-      const logPath = path.join(runner.agentDir, 'orchestrator.log');
+      const logPath = runner.orchestratorLogPath;
       try { fs.appendFileSync(logPath, line + '\n'); } catch {}
     }
   }
@@ -382,11 +382,51 @@ class ProjectRunner {
   }
 
   get agentDir() {
-    return path.join(this.projectDir, 'workspace');
+    return path.join(this.projectDir, 'chats');
   }
 
   get agentsDir() {
-    return path.join(this.agentDir, 'agents');
+    return path.join(this.projectDir, 'agents');
+  }
+
+  get responsesDir() {
+    return path.join(this.projectDir, 'responses');
+  }
+
+  get uploadsDir() {
+    return path.join(this.projectDir, 'uploads');
+  }
+
+  get projectDbPath() {
+    return path.join(this.projectDir, 'project.db');
+  }
+
+  get orchestratorLogPath() {
+    return path.join(this.projectDir, 'orchestrator.log');
+  }
+
+  get statePath() {
+    return path.join(this.projectDir, 'state.json');
+  }
+
+  get stopPath() {
+    return path.join(this.projectDir, 'STOP');
+  }
+
+  getAgentNotesDir(agentName) {
+    return path.join(this.agentsDir, agentName);
+  }
+
+  getOperationalPaths() {
+    return [
+      this.projectDbPath,
+      this.orchestratorLogPath,
+      this.responsesDir,
+      this.agentsDir,
+      this.uploadsDir,
+      this.statePath,
+      this.stopPath,
+    ];
   }
 
   get skillsDir() {
@@ -529,7 +569,7 @@ class ProjectRunner {
   getAgentDetails(agentName) {
     const workersDir = this.workerSkillsDir;
     const managersDir = path.join(ROOT, 'agent', 'managers');
-    const workspaceDir = path.join(this.agentDir, 'workspace', agentName);
+    const agentNotesDir = this.getAgentNotesDir(agentName);
     
     let skillPath = path.join(workersDir, `${agentName}.md`);
     let isManager = false;
@@ -544,10 +584,10 @@ class ProjectRunner {
     
     const skill = fs.readFileSync(skillPath, 'utf-8');
     
-    let workspaceFiles = [];
-    if (fs.existsSync(workspaceDir)) {
-      workspaceFiles = fs.readdirSync(workspaceDir).flatMap(f => {
-        const filePath = path.join(workspaceDir, f);
+    let agentFiles = [];
+    if (fs.existsSync(agentNotesDir)) {
+      agentFiles = fs.readdirSync(agentNotesDir).flatMap(f => {
+        const filePath = path.join(agentNotesDir, f);
         const stat = fs.statSync(filePath);
         if (!stat.isFile()) return [];
         return [{
@@ -562,8 +602,8 @@ class ProjectRunner {
     // Get last response from response log
     let lastResponse = null;
     let lastRawOutput = null;
-    const responseLogPath = path.join(this.agentDir, 'responses', `${agentName}.log`);
-    const rawLogPath = path.join(this.agentDir, 'responses', `${agentName}.raw.log`);
+    const responseLogPath = path.join(this.responsesDir, `${agentName}.log`);
+    const rawLogPath = path.join(this.responsesDir, `${agentName}.raw.log`);
     
     const getLastBlock = (filePath, maxChars = 15000) => {
       if (!fs.existsSync(filePath)) return null;
@@ -597,11 +637,11 @@ class ProjectRunner {
     try { everyone = fs.readFileSync(path.join(ROOT, 'agent', 'everyone.md'), 'utf-8'); } catch {}
     try { roleRules = fs.readFileSync(path.join(ROOT, 'agent', isManager ? 'manager.md' : 'worker.md'), 'utf-8'); } catch {}
 
-    return { name: agentName, isManager, skill, workspaceFiles, lastResponse, lastRawOutput, model, everyone, roleRules };
+    return { name: agentName, isManager, skill, agentFiles, lastResponse, lastRawOutput, model, everyone, roleRules };
   }
 
   getLogs(lines = 50) {
-    const logPath = path.join(this.agentDir, 'orchestrator.log');
+    const logPath = this.orchestratorLogPath;
     if (!fs.existsSync(logPath)) return [];
     const content = fs.readFileSync(logPath, 'utf-8');
     return content.split('\n').filter(l => l.trim()).slice(-lines);
@@ -611,7 +651,7 @@ class ProjectRunner {
     const empty = { totalCost: 0, last24hCost: 0, lastCycleCost: 0, avgCycleCost: 0, lastCycleDuration: 0, avgCycleDuration: 0, agents: {} };
     try {
       const db = this.getDb();
-      // Ensure cost columns exist (migration)
+      // Ensure cost columns exist
       try { db.exec('ALTER TABLE reports ADD COLUMN cost REAL'); } catch {}
       try { db.exec('ALTER TABLE reports ADD COLUMN duration_ms INTEGER'); } catch {}
 
@@ -783,7 +823,7 @@ class ProjectRunner {
   }
 
   getDb() {
-    const dbPath = path.join(this.agentDir, 'project.db');
+    const dbPath = this.projectDbPath;
     const db = new Database(dbPath);
     db.pragma('journal_mode = WAL');
     db.pragma('foreign_keys = ON');
@@ -970,17 +1010,17 @@ class ProjectRunner {
   }
 
   bootstrapPreview() {
-    const workspaceExists = fs.existsSync(this.agentDir);
-    let workspaceContents = [];
-    if (workspaceExists) {
-      workspaceContents = fs.readdirSync(this.agentDir);
+    const projectDataExists = fs.existsSync(this.projectDir);
+    let projectDataContents = [];
+    if (projectDataExists) {
+      projectDataContents = fs.readdirSync(this.projectDir).filter(name => !['repo', 'knowledge', 'skills', 'config.yaml'].includes(name));
     }
     // Read spec.md and check roadmap.md from private knowledge base
     let specContent = null;
     const specPath = path.join(this.knowledgeDir, 'spec.md');
     try { specContent = fs.readFileSync(specPath, 'utf-8'); } catch {}
     const hasRoadmap = fs.existsSync(path.join(this.knowledgeDir, 'roadmap.md'));
-    return { available: true, workspaceEmpty: workspaceContents.length === 0, repo: this.repo, specContent, hasRoadmap };
+    return { available: true, projectDataEmpty: projectDataContents.length === 0, repo: this.repo, specContent, hasRoadmap };
   }
 
   bootstrap(options = {}) {
@@ -1000,12 +1040,13 @@ class ProjectRunner {
     this.currentCycleId = null;
     this.currentSchedule = null;
 
-    // 1. Wipe the entire workspace folder
-    if (fs.existsSync(this.agentDir)) {
-      fs.rmSync(this.agentDir, { recursive: true });
-      log(`Cleared workspace folder`, this.id);
+    // 1. Wipe project operational state only, keep repo/knowledge/skills intact
+    for (const target of this.getOperationalPaths()) {
+      if (!fs.existsSync(target)) continue;
+      fs.rmSync(target, { recursive: true, force: true });
     }
-    fs.mkdirSync(this.agentDir, { recursive: true });
+    log(`Cleared project operational state`, this.id);
+    fs.mkdirSync(this.projectDir, { recursive: true });
 
     // 2. Reset cycle count, phase, and save state
     this.setState({
@@ -1107,58 +1148,44 @@ class ProjectRunner {
     return { reportId: lastId };
   }
 
-  runDoctor() {
-    const startedAt = Date.now();
-    const checks = [];
-    const addCheck = (label, targetPath, type) => {
-      if (!fs.existsSync(targetPath)) {
-        checks.push({ label, ok: false, issue: 'missing' });
-        return;
-      }
-      const stat = fs.statSync(targetPath);
-      const ok = type === 'dir' ? stat.isDirectory() : stat.isFile();
-      checks.push({ label, ok, issue: ok ? null : 'wrong type' });
-    };
-
-    addCheck('repo/', path.join(this.projectDir, 'repo'), 'dir');
-    addCheck('knowledge/', this.knowledgeDir, 'dir');
-    addCheck('skills/', this.skillsDir, 'dir');
-    addCheck('workspace/', this.agentDir, 'dir');
-    addCheck('workspace/project.db', path.join(this.agentDir, 'project.db'), 'file');
-    addCheck('workspace/orchestrator.log', path.join(this.agentDir, 'orchestrator.log'), 'file');
-    addCheck('workspace/responses/', path.join(this.agentDir, 'responses'), 'dir');
-    addCheck('workspace/agents/', this.agentsDir, 'dir');
-
-    const { managers, workers } = this.loadAgents();
-    const agentNames = [...managers, ...workers].map(agent => agent.name).sort();
-    for (const name of agentNames) {
-      addCheck(`workspace/agents/${name}/`, path.join(this.agentsDir, name), 'dir');
-    }
-
-    const issues = checks.filter(check => !check.ok);
-    const lines = [];
-    lines.push('## Doctor Check');
-    lines.push('');
-    lines.push(issues.length === 0
-      ? 'Layout status: OK'
-      : `Layout status: ${issues.length} issue(s) found`);
-    lines.push('');
-    lines.push('### Required paths');
-    lines.push('');
-    for (const check of checks) {
-      lines.push(`- ${check.ok ? 'OK' : 'MISSING'} ${check.label}${check.ok ? '' : ` (${check.issue})`}`);
-    }
-    if (agentNames.length === 0) {
-      lines.push('');
-      lines.push('Note: No active agents found; skipped agent-specific workspace checks.');
-    }
-    lines.push('');
-    lines.push('Doctor is read-only and does not modify files.');
-
-    return this._writeReport('doctor', lines.join('\n'), {
-      success: issues.length === 0,
-      durationMs: Date.now() - startedAt,
-    });
+  async runDoctor() {
+    const config = this.loadConfig();
+    const doctorAgent = { name: 'doctor', isManager: true, rawModel: 'high' };
+    const task = [
+      'Inspect this project and act only as an AI Doctor agent.',
+      '',
+      'Your job is to inspect and repair project layout drift. Do not rely on any built-in deterministic doctor behavior. You are the doctor.',
+      '',
+      'Canonical layout:',
+      '- repo/',
+      '- knowledge/',
+      '- skills/',
+      '- project.db',
+      '- orchestrator.log',
+      '- responses/',
+      '- agents/',
+      '',
+      'Required behavior:',
+      '- Inspect the actual filesystem.',
+      '- Repair missing or misplaced project files when it is safe.',
+      '- Ensure required directories and files exist after repair.',
+      '- If known agent directories under agents/ are missing, create them.',
+      '- Do not change product code in repo/ unless absolutely necessary for the repair itself.',
+      '- Prefer move/rename over copy when safe.',
+      '',
+      'At the end, write a concise doctor report with these sections exactly:',
+      '## Doctor Check',
+      'Layout status: ...',
+      '',
+      '### Required paths',
+      '- ...',
+      '',
+      '### Repair actions',
+      '- ...',
+      '',
+      'If something could not be fixed, say why clearly.',
+    ].join('\n');
+    return await this.runAgent(doctorAgent, config, 'doctor', task, { mode: 'full', issues: [] });
   }
 
   async start() {
@@ -1170,9 +1197,9 @@ class ProjectRunner {
     }
 
     // Ensure project directories exist
-    fs.mkdirSync(this.agentDir, { recursive: true });
+    fs.mkdirSync(this.projectDir, { recursive: true });
     fs.mkdirSync(this.agentsDir, { recursive: true });
-    fs.mkdirSync(path.join(this.agentDir, 'responses'), { recursive: true });
+    fs.mkdirSync(this.responsesDir, { recursive: true });
     fs.mkdirSync(this.skillsDir, { recursive: true });
     fs.mkdirSync(this.knowledgeDir, { recursive: true });
     fs.mkdirSync(path.join(this.knowledgeDir, 'analysis'), { recursive: true });
@@ -1183,12 +1210,12 @@ class ProjectRunner {
     this.loadState();
     
     this.running = true;
-    log(`Starting project runner (data: ${this.agentDir}, cycle: ${this.cycleCount})`, this.id);
+    log(`Starting project runner (data: ${this.projectDir}, cycle: ${this.cycleCount})`, this.id);
     this.runLoop();
   }
 
   loadState() {
-    const statePath = path.join(this.agentDir, 'state.json');
+    const statePath = this.statePath;
     try {
       if (fs.existsSync(statePath)) {
         const state = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
@@ -1228,7 +1255,7 @@ class ProjectRunner {
   }
 
   saveState() {
-    const statePath = path.join(this.agentDir, 'state.json');
+    const statePath = this.statePath;
     try {
       const state = {
         cycleCount: this.cycleCount,
@@ -1397,7 +1424,7 @@ class ProjectRunner {
 
   parseSchedule(resultText) {
     // Parse <!-- SCHEDULE --> ... <!-- /SCHEDULE --> from manager response
-    // Supports both array format (new) and object format (legacy)
+    // Supports both array and object formats
     const match = resultText.match(/<!--\s*SCHEDULE\s*-->\s*([\[{][\s\S]*?[\]}])\s*<!--\s*\/SCHEDULE\s*-->/);
     if (!match) return null;
     try {
@@ -1646,7 +1673,7 @@ class ProjectRunner {
             }
 
             // Check for STOP file
-            if (fs.existsSync(path.join(this.agentDir, 'STOP'))) {
+            if (fs.existsSync(this.stopPath)) {
               log(`STOP file detected — pausing project`, this.id);
               this.setState({ isPaused: true, pauseReason: 'Project stopped by Athena' });
               continue;
@@ -1952,6 +1979,14 @@ class ProjectRunner {
 
   // Build the full prompt for an agent (shared across CLI and API paths)
   _getAgentFilesystemPolicy(agent, visibility = null) {
+    if (agent.name === 'doctor') {
+      return {
+        read: [this.projectDir, this.path],
+        write: [this.projectDir, this.path],
+        denied: [],
+        dbPath: this.projectDbPath,
+      };
+    }
     const visMode = visibility?.mode || 'full';
     const repoDir = this.path;
     const knowledgeDir = this.knowledgeDir;
@@ -1968,15 +2003,15 @@ class ProjectRunner {
       write.push(this.workerSkillsDir);
     }
     const denied = [
-      path.join(this.agentDir, 'workspace'),
-      path.join(this.agentDir, 'responses'),
-      path.join(this.agentDir, 'uploads'),
-      path.join(this.agentDir, 'skills'),
-      path.join(this.agentDir, 'state.json'),
-      path.join(this.agentDir, 'orchestrator.log'),
-      path.join(this.agentDir, 'project.db'),
+      this.agentsDir,
+      this.responsesDir,
+      this.uploadsDir,
+      this.skillsDir,
+      this.statePath,
+      this.orchestratorLogPath,
+      this.projectDbPath,
     ];
-    return { read, write, denied, dbPath: path.join(this.agentDir, 'project.db') };
+    return { read, write, denied, dbPath: this.projectDbPath };
   }
 
   _buildAgentPrompt(agent, task, visibility) {
@@ -2008,12 +2043,12 @@ class ProjectRunner {
             sharedRules += dbContent + '\n\n---\n\n';
           } catch {}
         } else if (visMode === 'focused') {
-          sharedRules += '\n> **You are in focused mode.** You cannot read the issue tracker. Work only from the task, the repository, and your own workspace notes. If needed, you may create a new issue to report a blocker or finding.\n\n---\n\n';
+          sharedRules += '\n> **You are in focused mode.** You cannot read the issue tracker. Work only from the task, the repository, and your own agent notes. If needed, you may create a new issue to report a blocker or finding.\n\n---\n\n';
         } else {
-          sharedRules += '\n> **You are in blind mode.** You cannot read the issue tracker and you cannot rely on any workspace notes, including your own prior notes. Work only from the task and the repository.\n\n---\n\n';
+          sharedRules += '\n> **You are in blind mode.** You cannot read the issue tracker and you cannot rely on any agent notes, including your own prior notes. Work only from the task and the repository.\n\n---\n\n';
         }
       } else {
-        sharedRules += '\n> **You are Themis, final examiner.** You must not read communication history, issue tracker contents, or any workspace notes, including your own. Evaluate only the repository, tests, artifacts, and your own fresh inspection.\n\n---\n\n';
+        sharedRules += '\n> **You are Themis, final examiner.** You must not read communication history, issue tracker contents, or any agent notes, including your own. Evaluate only the repository, tests, artifacts, and your own fresh inspection.\n\n---\n\n';
       }
       const rolePath = path.join(ROOT, 'agent', agent.isManager ? 'manager.md' : 'worker.md');
       sharedRules += fs.readFileSync(rolePath, 'utf-8') + '\n\n---\n\n';
@@ -2026,7 +2061,7 @@ class ProjectRunner {
 
     // Strip YAML frontmatter (---...---) from skill content before building prompt
     skillContent = skillContent.replace(/^---[\s\S]*?---\n*/, '');
-    skillContent = (taskHeader + sharedRules + skillContent).replaceAll('{project_dir}', this.agentDir);
+    skillContent = (taskHeader + sharedRules + skillContent).replaceAll('{project_dir}', this.projectDir);
 
     return skillContent;
   }
@@ -2045,7 +2080,7 @@ class ProjectRunner {
 
     // Log response to agent-specific log file
     try {
-      const responsesDir = path.join(this.agentDir, 'responses');
+      const responsesDir = this.responsesDir;
       fs.mkdirSync(responsesDir, { recursive: true });
       const timestamp = new Date().toLocaleString('sv-SE', { hour12: false }).replace(',', '');
       const header = `\n${'='.repeat(60)}\n[${timestamp}] Cycle ${this.cycleCount} | Success: ${success}\n${'='.repeat(60)}\n`;
@@ -2076,7 +2111,7 @@ class ProjectRunner {
           let partialWork = '';
           if (killedByTimeout) {
             try {
-              const repoDir = path.join(this.agentDir, 'repo');
+              const repoDir = path.join(this.projectDir, 'repo');
               if (fs.existsSync(path.join(repoDir, '.git'))) {
                 const diffStat = execSync('git diff --stat HEAD 2>/dev/null || true', { cwd: repoDir, encoding: 'utf-8', timeout: 10000 }).trim();
                 const stagedStat = execSync('git diff --stat --cached HEAD 2>/dev/null || true', { cwd: repoDir, encoding: 'utf-8', timeout: 10000 }).trim();
@@ -2164,9 +2199,9 @@ class ProjectRunner {
     const modeStr = mode ? ` [${mode}]` : '';
     log(`Running: ${agent.name}${agent.isManager ? ' (manager)' : ''}${modeStr}`, this.id);
 
-    // Ensure workspace directory exists for this agent
-    const workspaceDir = path.join(this.agentDir, 'workspace', agent.name);
-    fs.mkdirSync(workspaceDir, { recursive: true });
+    // Ensure agent notes directory exists for this agent
+    const agentNotesDir = this.getAgentNotesDir(agent.name);
+    fs.mkdirSync(agentNotesDir, { recursive: true });
 
     // Build the prompt (shared between CLI and API paths)
     const skillContent = this._buildAgentPrompt(agent, task, visibility);
@@ -2195,7 +2230,7 @@ class ProjectRunner {
     const resolvedKeyType = keyResult?.type || 'api';
     this.currentAgentKeyId = resolvedKeyId;
 
-    // Fallback: legacy setupToken (for un-migrated configs)
+    // Fallback: setupToken when project key selection is not configured
     if (!resolvedToken && config.setupToken) {
       resolvedToken = config.setupToken;
     }
@@ -2235,7 +2270,7 @@ class ProjectRunner {
 
     const agentEnv = {
       CLAUDE_CODE_ENTRYPOINT: 'cli',
-      TBC_DB: path.join(this.agentDir, 'project.db'),
+      TBC_DB: this.projectDbPath,
       TBC_VISIBILITY: visibility?.mode || 'full',
       TBC_FOCUSED_ISSUES: visibility?.issues?.join(',') || '',
     };
@@ -2811,7 +2846,7 @@ const server = http.createServer(async (req, res) => {
     return;
   }
 
-  // Backward compat: legacy OpenAI Codex endpoints
+  // Backward-compatible OpenAI Codex endpoints
   if (req.method === 'POST' && url.pathname === '/api/openai-codex/login') {
     if (!requireWrite(req, res)) return;
     const projectId = url.searchParams.get('project') || null;
@@ -3049,8 +3084,8 @@ const server = http.createServer(async (req, res) => {
         }
 
         const knowledgeSpecPath = path.join(parsed.projectDir, 'knowledge', 'spec.md');
-        const legacySpecPath = path.join(parsed.repoDir, 'spec.md');
-        const specPath = fs.existsSync(knowledgeSpecPath) ? knowledgeSpecPath : legacySpecPath;
+        const repoSpecPath = path.join(parsed.repoDir, 'spec.md');
+        const specPath = fs.existsSync(knowledgeSpecPath) ? knowledgeSpecPath : repoSpecPath;
         const hasSpec = fs.existsSync(specPath);
         let specContent = null;
         if (hasSpec) {
@@ -3386,7 +3421,7 @@ const server = http.createServer(async (req, res) => {
       return;
     }
 
-    // POST /api/projects/:id/token — set per-project key selection or legacy token
+    // POST /api/projects/:id/token — set per-project key selection or direct token
     if (req.method === 'POST' && subPath === 'token') {
       if (!requireWrite(req, res)) return;
       let body = '';
@@ -3750,7 +3785,7 @@ const server = http.createServer(async (req, res) => {
       req.on('end', async () => {
         try {
           const { title, body: issueBody, creator, assignee, text } = JSON.parse(body);
-          // Support both new format (title/body/creator) and legacy (text)
+          // Support both structured and text input
           if (title) {
             const result = await runner.createIssue(title, issueBody, creator, assignee);
             res.writeHead(200, { 'Content-Type': 'application/json' });
@@ -3781,25 +3816,25 @@ const server = http.createServer(async (req, res) => {
       return;
     }
 
-    // GET /api/projects/:id/download - zip and download workspace
+    // GET /api/projects/:id/download - zip and download project data
     if (req.method === 'GET' && subPath === 'download') {
       try {
-        const workspaceDir = runner.agentDir;
-        if (!fs.existsSync(workspaceDir)) {
+        const projectDataDir = runner.projectDir;
+        if (!fs.existsSync(projectDataDir)) {
           res.writeHead(404, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Workspace not found' }));
+          res.end(JSON.stringify({ error: 'Project data not found' }));
           return;
         }
-        const filename = `${runner.id.replace(/\//g, '-')}-workspace.zip`;
+        const filename = `${runner.id.replace(/\//g, '-')}-project.zip`;
         res.writeHead(200, {
           'Content-Type': 'application/zip',
           'Content-Disposition': `attachment; filename="${filename}"`,
         });
-        const zip = spawn('zip', ['-r', '-q', '-', '.'], { cwd: workspaceDir, stdio: ['ignore', 'pipe', 'ignore'] });
+        const zip = spawn('zip', ['-r', '-q', '-', '.'], { cwd: projectDataDir, stdio: ['ignore', 'pipe', 'ignore'] });
         zip.stdout.pipe(res);
         zip.on('error', () => {
           // Fallback to tar if zip not available
-          const tar = spawn('tar', ['-czf', '-', '-C', workspaceDir, '.'], { stdio: ['ignore', 'pipe', 'ignore'] });
+          const tar = spawn('tar', ['-czf', '-', '-C', projectDataDir, '.'], { stdio: ['ignore', 'pipe', 'ignore'] });
           res.writeHead(200, {
             'Content-Type': 'application/gzip',
             'Content-Disposition': `attachment; filename="${filename.replace('.zip', '.tar.gz')}"`,
@@ -3848,7 +3883,7 @@ const server = http.createServer(async (req, res) => {
       return;
     }
 
-    // POST /api/projects/:id/doctor - check workspace layout
+    // POST /api/projects/:id/doctor - run AI Doctor agent
     if (req.method === 'POST' && subPath === 'doctor') {
       if (!requireWrite(req, res)) return;
       try {
@@ -3857,7 +3892,12 @@ const server = http.createServer(async (req, res) => {
           res.end(JSON.stringify({ error: 'Doctor is only available when the project is fully paused.' }));
           return;
         }
-        const result = runner.runDoctor();
+        const result = await runner.runDoctor();
+        if (!result.success) {
+          res.writeHead(500, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'Doctor agent failed', ...result }));
+          return;
+        }
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ success: true, ...result }));
       } catch (e) {
@@ -4003,8 +4043,8 @@ const server = http.createServer(async (req, res) => {
             return;
           }
 
-          // Save to workspace/uploads/
-          const uploadsDir = path.join(runner.agentDir, 'uploads');
+          // Save to uploads/
+          const uploadsDir = runner.uploadsDir;
           if (!fs.existsSync(uploadsDir)) fs.mkdirSync(uploadsDir, { recursive: true });
           const ext = path.extname(filename) || '.bin';
           const safeName = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}${ext}`;
@@ -4030,7 +4070,7 @@ const server = http.createServer(async (req, res) => {
     const uploadMatch = req.method === 'GET' && subPath.match(/^uploads\/(.+)$/);
     if (uploadMatch) {
       const filename = uploadMatch[1];
-      const filePath = path.join(runner.agentDir, 'uploads', filename);
+      const filePath = path.join(runner.uploadsDir, filename);
       if (!fs.existsSync(filePath)) {
         res.writeHead(404);
         res.end('Not found');

--- a/src/server.js
+++ b/src/server.js
@@ -4135,6 +4135,8 @@ const server = http.createServer(async (req, res) => {
 
           const chatOpts = {
             agentDir: runner.chatsDir,
+            tbcDbPath: runner.projectDbPath,
+            uploadsDir: runner.uploadsDir,
             projectPath: runner.path,
             chatId,
             userMessage: data.message.trim(),

--- a/src/server.js
+++ b/src/server.js
@@ -1428,57 +1428,28 @@ class ProjectRunner {
   }
 
   parseSchedule(resultText) {
-    // Parse <!-- SCHEDULE --> ... <!-- /SCHEDULE --> from manager response
-    // Supports both array and object formats
+    // Parse <!-- SCHEDULE --> ... <!-- /SCHEDULE --> from manager response.
+    // Canonical format only: a JSON array of steps.
     const match = resultText.match(/<!--\s*SCHEDULE\s*-->\s*([\[{][\s\S]*?[\]}])\s*<!--\s*\/SCHEDULE\s*-->/);
     if (!match) return null;
     const normalizeStep = (step) => {
-      if (!step || typeof step !== 'object' || Array.isArray(step)) return [];
-      if (step.delay !== undefined && Object.keys(step).length === 1) {
-        return [{ delay: step.delay }];
+      if (!step || typeof step !== 'object' || Array.isArray(step)) return null;
+      if (step.delay !== undefined) {
+        return Object.keys(step).length === 1 && typeof step.delay === 'number'
+          ? { delay: step.delay }
+          : null;
       }
-      if (typeof step.agent === 'string' && step.agent.trim()) {
-        const { agent, ...rest } = step;
-        return [{ [agent]: rest }];
-      }
-      return [step];
+      if (typeof step.agent !== 'string' || !step.agent.trim()) return null;
+      const { agent, ...rest } = step;
+      if (!Object.prototype.hasOwnProperty.call(rest, 'prompt')) return null;
+      return { [agent]: rest };
     };
     try {
       const raw = JSON.parse(match[1]);
-      
-      // Array format: [{ "delay": 20 }, { "leo": { ... } }, { "agent": "diana", ... }]
-      if (Array.isArray(raw)) {
-        return { _steps: raw.flatMap(normalizeStep) };
-      }
-      
-      // Object format with nested agents map
-      if (raw.agents) {
-        const steps = [];
-        const agents = raw.agents;
-        if (agents.delay) {
-          steps.push({ delay: agents.delay });
-        }
-        for (const [name, value] of Object.entries(agents)) {
-          if (name === 'delay') continue;
-          const payload = typeof value === 'object' && value ? { ...value } : value;
-          const agentDelay = typeof payload === 'object' ? payload.delay : null;
-          if (typeof payload === 'object' && payload) delete payload.delay;
-          steps.push({ [name]: (typeof payload === 'object' && Object.keys(payload).length === 1 && payload.task) ? payload.task : payload });
-          if (agentDelay) steps.push({ delay: agentDelay });
-        }
-        return { _steps: steps.flatMap(normalizeStep) };
-      }
-
-      if (raw && Array.isArray(raw._steps)) {
-        return { ...raw, _steps: raw._steps.flatMap(normalizeStep) };
-      }
-      
-      // Bare object with delay at top level
-      if (raw.delay !== undefined && Object.keys(raw).length === 1) {
-        return { _steps: [{ delay: raw.delay }] };
-      }
-      
-      return raw ? { _steps: normalizeStep(raw) } : null;
+      if (!Array.isArray(raw)) return null;
+      const steps = raw.map(normalizeStep);
+      if (steps.some(step => step === null)) return null;
+      return { _steps: steps };
     } catch (e) {
       log(`Failed to parse schedule: ${e.message}`, this.id);
       return null;

--- a/src/server.js
+++ b/src/server.js
@@ -382,6 +382,10 @@ class ProjectRunner {
   }
 
   get agentDir() {
+    return this.projectDir;
+  }
+
+  get chatsDir() {
     return path.join(this.projectDir, 'chats');
   }
 
@@ -1198,12 +1202,13 @@ class ProjectRunner {
 
     // Ensure project directories exist
     fs.mkdirSync(this.projectDir, { recursive: true });
+    fs.mkdirSync(this.chatsDir, { recursive: true });
     fs.mkdirSync(this.agentsDir, { recursive: true });
     fs.mkdirSync(this.responsesDir, { recursive: true });
     fs.mkdirSync(this.skillsDir, { recursive: true });
     fs.mkdirSync(this.knowledgeDir, { recursive: true });
-    fs.mkdirSync(path.join(this.knowledgeDir, 'analysis'), { recursive: true });
-    fs.mkdirSync(path.join(this.knowledgeDir, 'decisions'), { recursive: true });
+    fs.mkdirSync(path.join(this.projectDir, 'knowledge', 'analysis'), { recursive: true });
+    fs.mkdirSync(path.join(this.projectDir, 'knowledge', 'decisions'), { recursive: true });
     fs.mkdirSync(this.workerSkillsDir, { recursive: true });
     
     // Load persisted state
@@ -1980,12 +1985,7 @@ class ProjectRunner {
   // Build the full prompt for an agent (shared across CLI and API paths)
   _getAgentFilesystemPolicy(agent, visibility = null) {
     if (agent.name === 'doctor') {
-      return {
-        read: [this.projectDir, this.path],
-        write: [this.projectDir, this.path],
-        denied: [],
-        dbPath: this.projectDbPath,
-      };
+      return null;
     }
     const visMode = visibility?.mode || 'full';
     const repoDir = this.path;
@@ -2291,7 +2291,7 @@ class ProjectRunner {
       cwd: this.path,
       timeoutMs: config.agentTimeoutMs || 0,
       env: agentEnv,
-      allowedRepo: this.repo || null,
+      allowedRepo: agent.name === 'doctor' ? null : (this.repo || null),
       allowedPaths: this._getAgentFilesystemPolicy(agent, visibility),
       issuePolicy: { ...(visibility || { mode: 'full', issues: [] }), actor: agent.name },
       abortSignal: runAbortController.signal,
@@ -3871,7 +3871,7 @@ const server = http.createServer(async (req, res) => {
       req.on('end', () => {
         try {
           const options = body ? JSON.parse(body) : {};
-          fs.mkdirSync(runner.agentDir, { recursive: true });
+          fs.mkdirSync(runner.chatsDir, { recursive: true });
           const result = runner.bootstrap(options);
           res.writeHead(200, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ success: true, ...result }));
@@ -3912,7 +3912,7 @@ const server = http.createServer(async (req, res) => {
     // GET /api/projects/:id/chats — list chat sessions
     if (req.method === 'GET' && subPath === 'chats') {
       try {
-        const sessions = chatListSessions(runner.agentDir);
+        const sessions = chatListSessions(runner.chatsDir);
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ sessions }));
       } catch (e) {
@@ -3930,7 +3930,7 @@ const server = http.createServer(async (req, res) => {
       req.on('end', () => {
         try {
           const data = body ? JSON.parse(body) : {};
-          const session = chatCreateSession(runner.agentDir, data.title);
+          const session = chatCreateSession(runner.chatsDir, data.title);
           res.writeHead(201, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ session }));
         } catch (e) {
@@ -3945,7 +3945,7 @@ const server = http.createServer(async (req, res) => {
     const chatDetailMatch = req.method === 'GET' && subPath.match(/^chats\/(\d+)$/);
     if (chatDetailMatch) {
       try {
-        const session = chatGetSession(runner.agentDir, parseInt(chatDetailMatch[1]));
+        const session = chatGetSession(runner.chatsDir, parseInt(chatDetailMatch[1]));
         if (!session) {
           res.writeHead(404, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'Session not found' }));
@@ -3988,7 +3988,7 @@ const server = http.createServer(async (req, res) => {
     if (chatDeleteMatch) {
       if (!requireWrite(req, res)) return;
       try {
-        chatDeleteSession(runner.agentDir, parseInt(chatDeleteMatch[1]));
+        chatDeleteSession(runner.chatsDir, parseInt(chatDeleteMatch[1]));
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ success: true }));
       } catch (e) {
@@ -4124,7 +4124,7 @@ const server = http.createServer(async (req, res) => {
           // Save user message once (before any retry/fallback)
           // Save user message with image references
           const imageUrls = (data.images || []).map(img => `/api/projects/${projectId}/uploads/${img.filename}`);
-          chatSaveMessage(runner.agentDir, chatId, 'user', data.message.trim(), imageUrls.length > 0 ? imageUrls : null);
+          chatSaveMessage(runner.chatsDir, chatId, 'user', data.message.trim(), imageUrls.length > 0 ? imageUrls : null);
 
           // SSE headers
           res.writeHead(200, {
@@ -4134,7 +4134,7 @@ const server = http.createServer(async (req, res) => {
           });
 
           const chatOpts = {
-            agentDir: runner.agentDir,
+            agentDir: runner.chatsDir,
             projectPath: runner.path,
             chatId,
             userMessage: data.message.trim(),

--- a/tests/actor-spoofing-policy.test.js
+++ b/tests/actor-spoofing-policy.test.js
@@ -5,11 +5,11 @@ import path from 'node:path';
 
 function mkProject() {
   const repo = path.resolve('/tmp/project/repo');
-  const workspace = path.resolve('/tmp/project/workspace/workers/leo');
+  const notesDir = path.resolve('/tmp/project/agents/leo');
   return {
     repo,
-    workspace,
-    allowedPaths: [repo, workspace],
+    notesDir,
+    allowedPaths: [repo, notesDir],
     issuePolicy: { mode: 'full', issues: [], actor: 'leo' },
   };
 }

--- a/tests/agent-filesystem-policy.test.js
+++ b/tests/agent-filesystem-policy.test.js
@@ -8,10 +8,10 @@ import { executeRead, executeWrite, executeEdit, executeTool } from '../src/agen
 function mkProject() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tbc-policy-'));
   const repo = path.join(root, 'repo');
-  const workspaceRoot = path.join(root, 'workspace');
-  const own = path.join(workspaceRoot, 'workspace', 'leo');
-  const other = path.join(workspaceRoot, 'workspace', 'nora');
-  const skills = path.join(workspaceRoot, 'skills', 'workers');
+  const projectRoot = root;
+  const own = path.join(projectRoot, 'agents', 'leo');
+  const other = path.join(projectRoot, 'agents', 'nora');
+  const skills = path.join(projectRoot, 'skills', 'workers');
   fs.mkdirSync(repo, { recursive: true });
   fs.mkdirSync(own, { recursive: true });
   fs.mkdirSync(other, { recursive: true });
@@ -20,11 +20,11 @@ function mkProject() {
   fs.writeFileSync(path.join(own, 'note.txt'), 'own ok');
   fs.writeFileSync(path.join(other, 'secret.txt'), 'other secret');
   fs.writeFileSync(path.join(skills, 'nora.md'), 'role: worker');
-  fs.writeFileSync(path.join(workspaceRoot, 'project.db'), 'sqlite');
+  fs.writeFileSync(path.join(projectRoot, 'project.db'), 'sqlite');
   return {
     root,
     repo,
-    workspaceRoot,
+    projectRoot,
     own,
     other,
     skills,
@@ -32,43 +32,43 @@ function mkProject() {
       read: [repo, own],
       write: [repo, own],
       denied: [
-        path.join(workspaceRoot, 'workspace'),
-        path.join(workspaceRoot, 'responses'),
-        path.join(workspaceRoot, 'uploads'),
-        path.join(workspaceRoot, 'skills'),
-        path.join(workspaceRoot, 'state.json'),
-        path.join(workspaceRoot, 'orchestrator.log'),
-        path.join(workspaceRoot, 'project.db'),
+        path.join(projectRoot, 'agents'),
+        path.join(projectRoot, 'responses'),
+        path.join(projectRoot, 'uploads'),
+        path.join(projectRoot, 'skills'),
+        path.join(projectRoot, 'state.json'),
+        path.join(projectRoot, 'orchestrator.log'),
+        path.join(projectRoot, 'project.db'),
       ],
-      dbPath: path.join(workspaceRoot, 'project.db'),
+      dbPath: path.join(projectRoot, 'project.db'),
     },
     allowedBlind: {
       read: [repo],
       write: [repo],
       denied: [
-        path.join(workspaceRoot, 'workspace'),
-        path.join(workspaceRoot, 'responses'),
-        path.join(workspaceRoot, 'uploads'),
-        path.join(workspaceRoot, 'skills'),
-        path.join(workspaceRoot, 'state.json'),
-        path.join(workspaceRoot, 'orchestrator.log'),
-        path.join(workspaceRoot, 'project.db'),
+        path.join(projectRoot, 'agents'),
+        path.join(projectRoot, 'responses'),
+        path.join(projectRoot, 'uploads'),
+        path.join(projectRoot, 'skills'),
+        path.join(projectRoot, 'state.json'),
+        path.join(projectRoot, 'orchestrator.log'),
+        path.join(projectRoot, 'project.db'),
       ],
-      dbPath: path.join(workspaceRoot, 'project.db'),
+      dbPath: path.join(projectRoot, 'project.db'),
     },
     allowedManager: {
       read: [repo, own, skills],
       write: [repo, own, skills],
       denied: [
-        path.join(workspaceRoot, 'workspace'),
-        path.join(workspaceRoot, 'responses'),
-        path.join(workspaceRoot, 'uploads'),
-        path.join(workspaceRoot, 'skills'),
-        path.join(workspaceRoot, 'state.json'),
-        path.join(workspaceRoot, 'orchestrator.log'),
-        path.join(workspaceRoot, 'project.db'),
+        path.join(projectRoot, 'agents'),
+        path.join(projectRoot, 'responses'),
+        path.join(projectRoot, 'uploads'),
+        path.join(projectRoot, 'skills'),
+        path.join(projectRoot, 'state.json'),
+        path.join(projectRoot, 'orchestrator.log'),
+        path.join(projectRoot, 'project.db'),
       ],
-      dbPath: path.join(workspaceRoot, 'project.db'),
+      dbPath: path.join(projectRoot, 'project.db'),
     },
   };
 }
@@ -80,7 +80,7 @@ describe('agent filesystem allowlist', () => {
     assert.match(blocked, /overriding TBC_DB is not allowed/i);
   });
 
-  it('allows reading repo and own workspace but blocks other workspaces', async () => {
+  it('allows reading repo and own agent notes but blocks other agents', async () => {
     const p = mkProject();
     assert.match(executeRead({ file_path: path.join(p.repo, 'repo.txt') }, p.repo, p.allowedWorker), /repo ok/);
     assert.match(executeRead({ file_path: path.join(p.own, 'note.txt') }, p.repo, p.allowedWorker), /own ok/);
@@ -90,7 +90,7 @@ describe('agent filesystem allowlist', () => {
     assert.match(bashResult, /Operation not permitted|Blocked|access denied|Exit code: 1/i);
   });
 
-  it('blocks path traversal into another agent workspace', async () => {
+  it('blocks path traversal into another agent notes directory', async () => {
     const p = mkProject();
     const traversal = path.join(p.own, '..', 'nora', 'secret.txt');
     assert.match(executeRead({ file_path: traversal }, p.repo, p.allowedWorker), /access denied/i);
@@ -111,7 +111,7 @@ describe('agent filesystem allowlist', () => {
     assert.match(managerEdit, /Successfully edited/i);
   });
 
-  it('blind mode cannot read its own workspace notes', async () => {
+  it('blind mode cannot read its own agent notes', async () => {
     const p = mkProject();
     assert.match(executeRead({ file_path: path.join(p.own, 'note.txt') }, p.repo, p.allowedBlind), /access denied/i);
 
@@ -119,7 +119,7 @@ describe('agent filesystem allowlist', () => {
     assert.match(bashResult, /Operation not permitted|Blocked|access denied|Exit code: 1/i);
   });
 
-  it('blocks managers from reading worker private workspace', async () => {
+  it('blocks managers from reading worker private notes', async () => {
     const p = mkProject();
     assert.match(executeRead({ file_path: path.join(p.other, 'secret.txt') }, p.repo, p.allowedManager), /access denied/i);
 
@@ -129,17 +129,17 @@ describe('agent filesystem allowlist', () => {
 
   it('blocks raw project.db access from file tools and bash', async () => {
     const p = mkProject();
-    assert.match(executeRead({ file_path: path.join(p.workspaceRoot, 'project.db') }, p.repo, p.allowedWorker), /project database access is not allowed/i);
+    assert.match(executeRead({ file_path: path.join(p.projectRoot, 'project.db') }, p.repo, p.allowedWorker), /project database access is not allowed/i);
 
-    const bashByPath = await executeTool('Bash', { command: `cat ${JSON.stringify(path.join(p.workspaceRoot, 'project.db'))}` }, p.repo, 0, { TBC_DB: path.join(p.workspaceRoot, 'project.db') }, null, null, p.allowedWorker);
+    const bashByPath = await executeTool('Bash', { command: `cat ${JSON.stringify(path.join(p.projectRoot, 'project.db'))}` }, p.repo, 0, { TBC_DB: path.join(p.projectRoot, 'project.db') }, null, null, p.allowedWorker);
     assert.match(bashByPath, /project database access is not allowed/i);
 
     const envCommand = 'cat "$' + 'TBC_DB"'
-    const bashByEnv = await executeTool('Bash', { command: envCommand }, p.repo, 0, { TBC_DB: path.join(p.workspaceRoot, 'project.db') }, null, null, p.allowedWorker);
+    const bashByEnv = await executeTool('Bash', { command: envCommand }, p.repo, 0, { TBC_DB: path.join(p.projectRoot, 'project.db') }, null, null, p.allowedWorker);
     assert.match(bashByEnv, /project database access is not allowed/i);
   });
 
-  it('allows glob/grep inside own workspace and repo', async () => {
+  it('allows glob/grep inside own agent notes and repo', async () => {
     const p = mkProject();
     const globOwn = await executeTool('Glob', { pattern: '*.txt', path: p.own }, p.repo, 0, null, null, null, p.allowedWorker);
     const grepOwn = await executeTool('Grep', { pattern: 'own', path: p.own }, p.repo, 0, null, null, null, p.allowedWorker);
@@ -150,10 +150,10 @@ describe('agent filesystem allowlist', () => {
     assert.match(globRepo, /repo\.txt/);
   });
 
-  it('blocks glob/grep over denied workspace roots', () => {
+  it('blocks glob/grep over denied agent roots', () => {
     const p = mkProject();
-    const globDenied = executeTool('Glob', { pattern: '*.txt', path: path.join(p.workspaceRoot, 'workspace') }, p.repo, 0, null, null, null, p.allowedWorker);
-    const grepDenied = executeTool('Grep', { pattern: 'secret', path: path.join(p.workspaceRoot, 'workspace') }, p.repo, 0, null, null, null, p.allowedWorker);
+    const globDenied = executeTool('Glob', { pattern: '*.txt', path: path.join(p.projectRoot, 'agents') }, p.repo, 0, null, null, null, p.allowedWorker);
+    const grepDenied = executeTool('Grep', { pattern: 'secret', path: path.join(p.projectRoot, 'agents') }, p.repo, 0, null, null, null, p.allowedWorker);
     return Promise.all([globDenied, grepDenied]).then(([g1, g2]) => {
       assert.match(g1, /access denied/i);
       assert.match(g2, /access denied/i);

--- a/tests/issue-visibility-policy.test.js
+++ b/tests/issue-visibility-policy.test.js
@@ -8,26 +8,26 @@ import { executeTool } from '../src/agent-runner.js';
 function mkProject() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tbc-issue-policy-'));
   const repo = path.join(root, 'repo');
-  const workspaceRoot = path.join(root, 'workspace');
-  const own = path.join(workspaceRoot, 'workspace', 'leo');
+  const projectRoot = root;
+  const own = path.join(projectRoot, 'agents', 'leo');
   fs.mkdirSync(repo, { recursive: true });
   fs.mkdirSync(own, { recursive: true });
   fs.writeFileSync(path.join(repo, 'README.md'), 'repo ok');
-  fs.writeFileSync(path.join(workspaceRoot, 'project.db'), 'sqlite');
+  fs.writeFileSync(path.join(projectRoot, 'project.db'), 'sqlite');
 
   const allowedPaths = {
     read: [repo, own],
     write: [repo, own],
     denied: [
-      path.join(workspaceRoot, 'workspace'),
-      path.join(workspaceRoot, 'responses'),
-      path.join(workspaceRoot, 'uploads'),
-      path.join(workspaceRoot, 'skills'),
-      path.join(workspaceRoot, 'state.json'),
-      path.join(workspaceRoot, 'orchestrator.log'),
-      path.join(workspaceRoot, 'project.db'),
+      path.join(projectRoot, 'agents'),
+      path.join(projectRoot, 'responses'),
+      path.join(projectRoot, 'uploads'),
+      path.join(projectRoot, 'skills'),
+      path.join(projectRoot, 'state.json'),
+      path.join(projectRoot, 'orchestrator.log'),
+      path.join(projectRoot, 'project.db'),
     ],
-    dbPath: path.join(workspaceRoot, 'project.db'),
+    dbPath: path.join(projectRoot, 'project.db'),
   };
 
   return {

--- a/tests/private-knowledge-base.test.js
+++ b/tests/private-knowledge-base.test.js
@@ -16,8 +16,8 @@ describe('private knowledge base for spec, roadmap, and internal analysis docs',
   it('defines a shared knowledge-base path outside the repo root', () => {
     const src = read(serverPath);
     assert.match(src, /get knowledgeDir\(\)/, 'Expected a knowledgeDir getter in server.js');
-    assert.match(src, /path\.join\(this\.agentDir, 'knowledge'\)/,
-      'Expected knowledge base to live under private workspace/knowledge, not the repo root');
+    assert.match(src, /path\.join\(this\.projectDir, 'knowledge'\)/,
+      'Expected knowledge base to live under project knowledge/, not the repo root');
   });
 
   it('bootstrap preview should read spec/roadmap from knowledge base, not repo root', () => {

--- a/tests/schedule-format.test.js
+++ b/tests/schedule-format.test.js
@@ -1,0 +1,94 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import vm from 'node:vm';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const serverPath = path.join(__dirname, '..', 'src', 'server.js');
+const scheduleDiagramPath = path.join(__dirname, '..', 'monitor', 'src', 'components', 'ScheduleDiagram.jsx');
+
+function extractMethod(source, signature) {
+  const start = source.indexOf(signature);
+  assert.notEqual(start, -1, `Could not find ${signature}`);
+  const bodyStart = source.indexOf('{', start);
+  let depth = 0;
+  let end = -1;
+  for (let i = bodyStart; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) {
+        end = i;
+        break;
+      }
+    }
+  }
+  assert.notEqual(end, -1, `Could not extract ${signature}`);
+  return source.slice(start, end + 1);
+}
+
+function extractFunction(source, signature) {
+  const start = source.indexOf(signature);
+  assert.notEqual(start, -1, `Could not find ${signature}`);
+  const bodyStart = source.indexOf('{', start);
+  let depth = 0;
+  let end = -1;
+  for (let i = bodyStart; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) {
+        end = i;
+        break;
+      }
+    }
+  }
+  assert.notEqual(end, -1, `Could not extract ${signature}`);
+  return source.slice(start, end + 1);
+}
+
+function loadServerParseSchedule() {
+  const src = fs.readFileSync(serverPath, 'utf-8');
+  const method = extractMethod(src, 'parseSchedule(resultText)');
+  const fnSource = method.replace('parseSchedule(resultText)', 'function parseSchedule(resultText)');
+  const wrapped = `(() => { ${fnSource}; return parseSchedule; })()`;
+  return vm.runInNewContext(wrapped, { log: () => {} });
+}
+
+function loadFrontendParseScheduleBlock() {
+  const src = fs.readFileSync(scheduleDiagramPath, 'utf-8');
+  const normalizeStep = extractFunction(src, 'function normalizeStep(step)');
+  const normalizeSteps = extractFunction(src, 'function normalizeSteps(schedule)');
+  const parseScheduleBlock = extractFunction(src, 'export function parseScheduleBlock(text)').replace('export function', 'function');
+  const wrapped = `(() => { ${normalizeStep}\n${normalizeSteps}\n${parseScheduleBlock}; return parseScheduleBlock; })()`;
+  return vm.runInNewContext(wrapped, {});
+}
+
+describe('strict schedule directive format', () => {
+  it('accepts only the canonical array-of-steps format in the backend parser', () => {
+    const parseSchedule = loadServerParseSchedule();
+    const canonical = `<!-- SCHEDULE -->\n[\n  {"agent":"diana","issue":2,"title":"Research","prompt":"Do it"},\n  {"delay":20}\n]\n<!-- /SCHEDULE -->`;
+    assert.equal(JSON.stringify(parseSchedule(canonical)), JSON.stringify({
+      _steps: [
+        { diana: { issue: 2, title: 'Research', prompt: 'Do it' } },
+        { delay: 20 },
+      ],
+    }));
+  });
+
+  it('rejects the old object-style schedule format in the backend parser', () => {
+    const parseSchedule = loadServerParseSchedule();
+    const legacy = `<!-- SCHEDULE -->\n{"agents":{"delay":20,"diana":{"issue":2,"title":"Research","prompt":"Do it"}}}\n<!-- /SCHEDULE -->`;
+    assert.equal(parseSchedule(legacy), null);
+  });
+
+  it('rejects the old object-style schedule format in the frontend parser', () => {
+    const parseScheduleBlock = loadFrontendParseScheduleBlock();
+    const legacy = `<!-- SCHEDULE -->\n{"agents":{"delay":20,"diana":{"issue":2,"title":"Research","prompt":"Do it"}}}\n<!-- /SCHEDULE -->`;
+    assert.equal(parseScheduleBlock(legacy), null);
+  });
+});

--- a/tests/worker-skills-path.test.js
+++ b/tests/worker-skills-path.test.js
@@ -14,26 +14,21 @@ function read(file) {
 }
 
 describe('worker skill directory layout', () => {
-  it('stores worker skills under skills/workers instead of the legacy workers dir', () => {
+  it('stores worker skills under skills/workers', () => {
     const src = read(serverPath);
     assert.ok(src.includes("get skillsDir()"), 'Expected skillsDir getter in server.js');
     assert.ok(src.includes("get workerSkillsDir()"), 'Expected workerSkillsDir getter in server.js');
     assert.ok(src.includes("path.join(this.skillsDir, 'workers')"), 'Expected worker skills under skills/workers');
   });
 
-  it('migrates the legacy workspace/workers directory to skills/workers', () => {
-    const src = read(serverPath);
-    assert.ok(src.includes("const legacyDir = path.join(this.agentDir, 'workers')"), 'Expected legacy workers dir reference for migration');
-    assert.ok(src.includes("fs.renameSync(legacyDir, dir)"), 'Expected legacy workers dir migration');
-  });
 
   it('creates the new skills/workers control-plane directories at startup', () => {
     const src = read(serverPath);
-    assert.ok(src.includes("path.join('skills', 'workers')"), 'Expected startup to create skills/workers');
-    assert.ok(src.includes("'workspace'"), 'Expected startup to keep per-agent workspace dir');
+    assert.ok(src.includes("this.workerSkillsDir"), 'Expected startup to create skills/workers');
+    assert.ok(src.includes("this.agentsDir"), 'Expected startup to create agent directories');
   });
 
-  it('updates manager-facing prompts to use skills/workers', () => {
+  it('keeps manager-facing prompts on skills/workers', () => {
     const managerPrompt = read(managerPromptPath);
     const everyonePrompt = read(everyonePromptPath);
     assert.ok(managerPrompt.includes('{project_dir}/skills/workers/'));


### PR DESCRIPTION
## Summary
- convert Doctor from a backend read-only checker into an AI-only Doctor agent
- add a dedicated `agent/managers/doctor.md` skill and route Doctor through the normal agent runner
- align server paths, prompts, UI copy, and tests around the canonical project structure only
- keep Doctor available only when the project is fully paused

## Notes
- Doctor now runs as a real agent and writes a normal agent report
- wording across the repo now assumes the canonical project layout from the start
- targeted validation run:
  - `node --check src/server.js`
  - `node --test tests/tbc-db-actor-policy.test.js`
