### PR TITLE
docs: clarify canonical project folder structure

### DIFF
--- a/agent/folder_structure.md
+++ b/agent/folder_structure.md
@@ -1,20 +1,34 @@
 # Folder Structure
 
-Treat the project directory as having four top-level areas:
+Use this canonical project layout:
 
-- `repo/` — the git repository and all tracked source files
-- `knowledge/` — private project knowledge, such as `spec.md`, `roadmap.md`, decisions, and analysis
+```text
+<project>/
+├── repo/
+├── knowledge/
+│   ├── spec.md
+│   ├── roadmap.md
+│   ├── analysis/
+│   └── decisions/
+├── skills/
+│   └── workers/
+└── workspace/
+    ├── project.db
+    ├── orchestrator.log
+    ├── responses/
+    └── agents/
+        ├── athena/
+        ├── ares/
+        ├── apollo/
+        └── <other-agent>/
+```
+
+## Meaning
+
+- `repo/` — the git repository and tracked source files
+- `knowledge/` — private project knowledge, including `spec.md`, `roadmap.md`, analysis, and decisions
 - `skills/` — private project skills and worker skill material
-- `workspace/` — operational state and agent scratch space
-
-## Workspace Layout
-
-Inside `workspace/`:
-
-- `project.db` — the canonical TBC project database
-- `orchestrator.log` — project orchestration log
-- `responses/` — saved response artifacts
-- `agents/<agent_name>/` — the personal notes and files for each agent
+- `workspace/` — operational state, logs, responses, and per-agent personal files
 
 ## Rules
 
@@ -22,3 +36,6 @@ Inside `workspace/`:
 - Do not create or expect `spec.md` at repo root
 - Per-agent personal files belong in `workspace/agents/<agent_name>/`
 - Project-wide operational state belongs directly under `workspace/`
+- If the structure is already canonical, keep using it
+- If you are only allowed to modify your own area, do not move another agent's files just to clean up layout drift
+- If broader layout drift exists outside your permissions, report it instead of forcing a move

--- a/agent/folder_structure.md
+++ b/agent/folder_structure.md
@@ -12,15 +12,14 @@ Use this canonical project layout:
 │   └── decisions/
 ├── skills/
 │   └── workers/
-└── workspace/
-    ├── project.db
-    ├── orchestrator.log
-    ├── responses/
-    └── agents/
-        ├── athena/
-        ├── ares/
-        ├── apollo/
-        └── <other-agent>/
+├── project.db
+├── orchestrator.log
+├── responses/
+└── agents/
+    ├── athena/
+    ├── ares/
+    ├── apollo/
+    └── <other-agent>/
 ```
 
 ## Meaning
@@ -28,14 +27,17 @@ Use this canonical project layout:
 - `repo/` — the git repository and tracked source files
 - `knowledge/` — private project knowledge, including `spec.md`, `roadmap.md`, analysis, and decisions
 - `skills/` — private project skills and worker skill material
-- `workspace/` — operational state, logs, responses, and per-agent personal files
+- `project.db` — the canonical TBC project database
+- `orchestrator.log` — project orchestration log
+- `responses/` — saved response artifacts
+- `agents/<agent_name>/` — per-agent personal notes and files
 
 ## Rules
 
 - Do not treat `knowledge/` or `skills/` as part of the git repo
 - Do not create or expect `spec.md` at repo root
-- Per-agent personal files belong in `workspace/agents/<agent_name>/`
-- Project-wide operational state belongs directly under `workspace/`
+- Per-agent personal files belong in `agents/<agent_name>/`
+- Project-wide operational state belongs directly under the project root
 - If the structure is already canonical, keep using it
 - If you are only allowed to modify your own area, do not move another agent's files just to clean up layout drift
 - If broader layout drift exists outside your permissions, report it instead of forcing a move

--- a/agent/folder_structure.md
+++ b/agent/folder_structure.md
@@ -8,8 +8,6 @@ Use this canonical project layout:
 ├── knowledge/
 │   ├── spec.md
 │   ├── roadmap.md
-│   ├── analysis/
-│   └── decisions/
 ├── skills/
 │   └── workers/
 ├── project.db
@@ -25,7 +23,7 @@ Use this canonical project layout:
 ## Meaning
 
 - `repo/` — the git repository and tracked source files
-- `knowledge/` — private project knowledge, including `spec.md`, `roadmap.md`, analysis, and decisions
+- `knowledge/` — private project knowledge, including `spec.md` and `roadmap.md`
 - `skills/` — private project skills and worker skill material
 - `project.db` — the canonical TBC project database
 - `orchestrator.log` — project orchestration log

--- a/agent/folder_structure.md
+++ b/agent/folder_structure.md
@@ -23,7 +23,7 @@ Use this canonical project layout:
 ## Meaning
 
 - `repo/` — the git repository and tracked source files
-- `knowledge/` — private project knowledge, including `spec.md` and `roadmap.md`
+- `knowledge/` — private project knowledge, including `spec.md`, `roadmap.md`, and optional supporting documents
 - `skills/` — private project skills and worker skill material
 - `project.db` — the canonical TBC project database
 - `orchestrator.log` — project orchestration log


### PR DESCRIPTION
## Summary
- update folder_structure.md to match the agreed canonical layout
- add an explicit code block showing the full directory tree
- clarify the roles of repo, knowledge, skills, and workspace
- clarify that agents should only reorganize files within their permissions