### PR TITLE
fix: resolve models after selecting fallback keys

### DIFF
--- a/monitor/src/components/panels/ProjectSettingsPanel.jsx
+++ b/monitor/src/components/panels/ProjectSettingsPanel.jsx
@@ -43,6 +43,19 @@ export default function ProjectSettingsPanel({
   // Detect stale pinned key (disabled or deleted)
   const pinnedKeyStale = selectedKeyId && (!selectedKey || !selectedKey.enabled)
   const effectiveKey = (selectedKey && selectedKey.enabled) ? selectedKey : defaultKey
+  const hasModelOverrides = (models = {}) => !!(models.high || models.mid || models.low || models.xlow)
+
+  const clearModelOverrides = async () => {
+    const res = await authFetch(projectApi('/models'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ models: {} })
+    })
+    if (!res.ok) return false
+    const d = await res.json()
+    if (d.config) setSelectedProject(prev => ({ ...prev, config: d.config }))
+    return true
+  }
 
   const handleKeyChange = async (keyId) => {
     setSaving(true)
@@ -58,7 +71,12 @@ export default function ProjectSettingsPanel({
       if (res.ok) {
         const d = await res.json()
         setKeySelection(d.keySelection || null)
-        setToast(keyId ? 'Key selection updated' : 'Using global default')
+        if (!keyId) {
+          await clearModelOverrides()
+          setToast('Using global default, model overrides cleared')
+        } else {
+          setToast('Key selection updated')
+        }
       }
     } catch {}
     setSaving(false)

--- a/monitor/src/components/panels/SettingsPanel.jsx
+++ b/monitor/src/components/panels/SettingsPanel.jsx
@@ -169,7 +169,7 @@ function EditCustomCredentialCard({ credential, authFetch, onComplete, onCancel 
 }
 
 function AddCredentialWizard({ onComplete, onCancel, authFetch, excludeProviders }) {
-  const [step, setStep] = useState('provider') // provider → method → action → label
+  const [step, setStep] = useState('provider') // provider → method → action → oauth_callback → label
   const [selectedProvider, setSelectedProvider] = useState(null)
   const [selectedMethod, setSelectedMethod] = useState(null) // 'api_key' | 'oauth'
   const [token, setToken] = useState('')
@@ -344,6 +344,7 @@ function AddCredentialWizard({ onComplete, onCancel, authFetch, excludeProviders
     if (selectedMethod === 'oauth') {
       const startOAuth = async () => {
         setOauthState('starting')
+        setPasteUrl('')
         try {
           // Open blank window synchronously for popup blocker avoidance
           const authWindow = window.open('about:blank', '_blank')
@@ -357,6 +358,7 @@ function AddCredentialWizard({ onComplete, onCancel, authFetch, excludeProviders
           setFlowId(data.flowId)
           setAuthUrl(data.authorization_url)
           setOauthState('waiting')
+          setStep('oauth_callback')
 
           if (authWindow && data.authorization_url) {
             authWindow.location.href = data.authorization_url
@@ -378,38 +380,9 @@ function AddCredentialWizard({ onComplete, onCancel, authFetch, excludeProviders
           setTimeout(() => {
             clearInterval(pollInterval)
             setOauthState(prev => prev === 'success' ? prev : prev === 'waiting' ? 'paste' : prev)
-          }, 30000) // After 30s, suggest paste
+          }, 30000)
         } catch {
           setOauthState('error')
-        }
-      }
-
-      const submitPasteUrl = async () => {
-        if (!pasteUrl || !flowId) return
-        setSaving(true)
-        try {
-          const res = await authFetch('/api/oauth/submit-code', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ flowId, code: pasteUrl })
-          })
-          const data = await res.json()
-          if (data.success) {
-            setOauthState('success')
-          } else {
-            setOauthState('error')
-          }
-        } catch {
-          setOauthState('error')
-        }
-        setSaving(false)
-      }
-
-      // If OAuth completed, go to label step
-      if (oauthState === 'success') {
-        // Small delay then move to label
-        if (step === 'action') {
-          setTimeout(() => setStep('label'), 500)
         }
       }
 
@@ -421,87 +394,150 @@ function AddCredentialWizard({ onComplete, onCancel, authFetch, excludeProviders
                 setOauthState('idle')
                 providerDef?.methods.length > 1 ? setStep('method') : setStep('provider')
               }} className="text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300"><ArrowLeft className="w-4 h-4" /></button>
-              <h4 className="text-xs font-semibold text-neutral-600 dark:text-neutral-300 uppercase">Step 3: {providerDef?.label} — OAuth Sign-In</h4>
+              <h4 className="text-xs font-semibold text-neutral-600 dark:text-neutral-300 uppercase">Step 3: {providerDef?.label} — Open Sign-In Page</h4>
             </div>
             <button onClick={onCancel} className="text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300"><X className="w-4 h-4" /></button>
           </div>
 
-          {oauthState === 'idle' && (
-            <button
-              onClick={startOAuth}
-              className="w-full px-3 py-2 text-sm font-medium bg-blue-500 text-white rounded-lg hover:bg-blue-600"
-            >
-              Open Sign-In Page
-            </button>
-          )}
+          <div className="space-y-3">
+            <div className="p-3 rounded-lg bg-neutral-100 dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 text-xs text-neutral-600 dark:text-neutral-400 space-y-2">
+              <p>What to expect:</p>
+              <ol className="list-decimal ml-4 space-y-1">
+                <li>A browser tab will open to OpenAI sign-in.</li>
+                <li>Sign in with the ChatGPT account that has the subscription.</li>
+                <li>After approval, OpenAI will redirect to a <code className="bg-white dark:bg-neutral-700 px-1 rounded">http://localhost...</code> URL.</li>
+                <li>If you are using TBC remotely, copy that full localhost URL, then paste it in the next step.</li>
+              </ol>
+              <p className="text-neutral-500 dark:text-neutral-500">Seeing a localhost page fail to load is expected. We only need the final URL.</p>
+            </div>
 
-          {oauthState === 'starting' && (
-            <p className="text-sm text-blue-500 animate-pulse">Starting sign-in...</p>
-          )}
+            {oauthState === 'starting' ? (
+              <p className="text-sm text-blue-500 animate-pulse">Starting sign-in...</p>
+            ) : (
+              <button
+                onClick={startOAuth}
+                className="w-full px-3 py-2 text-sm font-medium bg-blue-500 text-white rounded-lg hover:bg-blue-600"
+              >
+                Open Sign-In Page
+              </button>
+            )}
+
+            {oauthState === 'error' && (
+              <div className="p-2 rounded-lg bg-red-100 dark:bg-red-900/30 border border-red-200 dark:border-red-800">
+                <p className="text-xs text-red-700 dark:text-red-300">Failed to start sign-in. Please try again.</p>
+              </div>
+            )}
+          </div>
+        </div>
+      )
+    }
+  }
+
+  if (step === 'oauth_callback') {
+    const submitPasteUrl = async () => {
+      if (!pasteUrl || !flowId) return
+      setSaving(true)
+      try {
+        const res = await authFetch('/api/oauth/submit-code', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ flowId, code: pasteUrl })
+        })
+        const data = await res.json()
+        if (data.success) {
+          setOauthState('success')
+          setTimeout(() => setStep('label'), 300)
+        } else {
+          setOauthState('error')
+        }
+      } catch {
+        setOauthState('error')
+      }
+      setSaving(false)
+    }
+
+    return (
+      <div className="border border-blue-200 dark:border-blue-800 rounded-lg p-3 bg-blue-50/50 dark:bg-blue-950/20">
+        <div className="flex items-center justify-between mb-3">
+          <div className="flex items-center gap-2">
+            <button onClick={() => setStep('action')} className="text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300"><ArrowLeft className="w-4 h-4" /></button>
+            <h4 className="text-xs font-semibold text-neutral-600 dark:text-neutral-300 uppercase">Step 4: {providerDef?.label} — Paste Callback URL</h4>
+          </div>
+          <button onClick={onCancel} className="text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300"><X className="w-4 h-4" /></button>
+        </div>
+
+        <div className="space-y-3">
+          <div className="p-2 rounded-lg bg-blue-100 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-800">
+            <p className="text-xs text-blue-700 dark:text-blue-300 mb-1">
+              Finish sign-in in the browser, then paste the full redirect URL from the address bar here.
+            </p>
+            {authUrl && (
+              <p className="text-xs text-blue-500 dark:text-blue-400">
+                If no window opened, <a href={authUrl} target="_blank" rel="noopener noreferrer" className="underline">click here</a>.
+              </p>
+            )}
+          </div>
+
+          <div className="p-3 rounded-lg bg-neutral-100 dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 text-xs text-neutral-600 dark:text-neutral-400 space-y-2">
+            <p><strong>Paste the final URL</strong> that starts with <code className="bg-white dark:bg-neutral-700 px-1 rounded">http://localhost</code>.</p>
+            <p>If the localhost page shows an error, that's fine. Copy the URL anyway.</p>
+          </div>
+
+          <div className="flex gap-2">
+            <input
+              type="text"
+              placeholder="Paste redirect URL here..."
+              value={pasteUrl}
+              onChange={e => setPasteUrl(e.target.value)}
+              autoFocus
+              className="flex-1 min-w-0 px-3 py-1.5 text-sm border rounded-lg bg-white dark:bg-neutral-800 border-neutral-300 dark:border-neutral-600 text-neutral-800 dark:text-neutral-200"
+            />
+            <button
+              onClick={submitPasteUrl}
+              disabled={!pasteUrl || saving || !flowId}
+              className="px-3 py-1.5 text-sm font-medium bg-blue-500 text-white rounded-lg hover:bg-blue-600 disabled:opacity-50 whitespace-nowrap"
+            >
+              {saving ? 'Verifying...' : 'Submit'}
+            </button>
+          </div>
 
           {(oauthState === 'waiting' || oauthState === 'paste') && (
-            <div className="space-y-3">
-              <div className="p-2 rounded-lg bg-blue-100 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-800">
-                <p className="text-xs text-blue-700 dark:text-blue-300 mb-1">
-                  A browser tab should have opened. Complete sign-in there.
-                </p>
-                {authUrl && (
-                  <p className="text-xs text-blue-500 dark:text-blue-400">
-                    If no window opened,{' '}
-                    <a href={authUrl} target="_blank" rel="noopener noreferrer" className="underline">click here</a>.
-                  </p>
-                )}
-              </div>
-
-              <div className="border-t border-neutral-200 dark:border-neutral-700 pt-3">
-                <p className="text-xs text-neutral-500 dark:text-neutral-400 mb-2">
-                  <strong>Remote access?</strong> After signing in, copy the URL from the browser address bar (it will start with <code className="bg-neutral-100 dark:bg-neutral-700 px-1 rounded">http://localhost</code> and may show an error — that's OK) and paste it below:
-                </p>
-                <div className="flex gap-2">
-                  <input
-                    type="text"
-                    placeholder="Paste redirect URL here..."
-                    value={pasteUrl}
-                    onChange={e => setPasteUrl(e.target.value)}
-                    className="flex-1 min-w-0 px-3 py-1.5 text-sm border rounded-lg bg-white dark:bg-neutral-800 border-neutral-300 dark:border-neutral-600 text-neutral-800 dark:text-neutral-200"
-                  />
-                  <button
-                    onClick={submitPasteUrl}
-                    disabled={!pasteUrl || saving}
-                    className="px-3 py-1.5 text-sm font-medium bg-blue-500 text-white rounded-lg hover:bg-blue-600 disabled:opacity-50 whitespace-nowrap"
-                  >
-                    {saving ? 'Verifying...' : 'Submit'}
-                  </button>
-                </div>
-              </div>
-            </div>
+            <p className="text-xs text-neutral-500 dark:text-neutral-400">Waiting for sign-in completion. You can either paste the callback URL now or wait for automatic detection.</p>
           )}
 
           {oauthState === 'success' && (
-            <div className="p-2 rounded-lg bg-green-100 dark:bg-green-900/30 border border-green-200 dark:border-green-800">
-              <p className="text-sm text-green-700 dark:text-green-300">Sign-in successful! Setting up credential...</p>
+            <div className="space-y-2">
+              <div className="p-2 rounded-lg bg-green-100 dark:bg-green-900/30 border border-green-200 dark:border-green-800">
+                <p className="text-sm text-green-700 dark:text-green-300">Sign-in successful. Continue when you're ready.</p>
+              </div>
+              <button
+                onClick={() => setStep('label')}
+                className="w-full px-3 py-1.5 text-sm font-medium bg-blue-500 text-white rounded-lg hover:bg-blue-600"
+              >
+                Continue
+              </button>
             </div>
           )}
 
           {oauthState === 'error' && (
             <div className="space-y-2">
               <div className="p-2 rounded-lg bg-red-100 dark:bg-red-900/30 border border-red-200 dark:border-red-800">
-                <p className="text-xs text-red-700 dark:text-red-300">Sign-in failed. Please try again.</p>
+                <p className="text-xs text-red-700 dark:text-red-300">Sign-in failed. Please check the pasted URL and try again.</p>
               </div>
               <button
-                onClick={() => { setOauthState('idle'); setPasteUrl('') }}
+                onClick={() => { setOauthState('waiting'); setPasteUrl('') }}
                 className="w-full px-3 py-1.5 text-sm font-medium bg-blue-500 text-white rounded-lg hover:bg-blue-600"
               >
-                Retry
+                Retry Paste
               </button>
             </div>
           )}
         </div>
-      )
-    }
+      </div>
+    )
   }
 
-  // Step 4: Label + save
+  // Step 4/5: Label + save
   if (step === 'label') {
     const handleSave = async () => {
       setSaving(true)
@@ -561,8 +597,8 @@ function AddCredentialWizard({ onComplete, onCancel, authFetch, excludeProviders
       <div className="border border-blue-200 dark:border-blue-800 rounded-lg p-3 bg-blue-50/50 dark:bg-blue-950/20">
         <div className="flex items-center justify-between mb-3">
           <div className="flex items-center gap-2">
-            <button onClick={() => setStep('action')} className="text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300"><ArrowLeft className="w-4 h-4" /></button>
-            <h4 className="text-xs font-semibold text-neutral-600 dark:text-neutral-300 uppercase">Step 4: Name This Credential</h4>
+            <button onClick={() => setStep(selectedMethod === 'oauth' ? 'oauth_callback' : 'action')} className="text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300"><ArrowLeft className="w-4 h-4" /></button>
+            <h4 className="text-xs font-semibold text-neutral-600 dark:text-neutral-300 uppercase">Step {selectedMethod === 'oauth' ? '5' : '4'}: Name This Credential</h4>
           </div>
           <button onClick={onCancel} className="text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300"><X className="w-4 h-4" /></button>
         </div>

--- a/monitor/tests/disabled-key-warning.spec.js
+++ b/monitor/tests/disabled-key-warning.spec.js
@@ -175,4 +175,72 @@ test.describe('Project pinned to disabled key', () => {
     const selectedText = await select.evaluate(el => el.options[el.selectedIndex]?.text || '')
     expect(selectedText).toContain('DisabledKey')
   })
+
+  test('clears model overrides when switching from fixed key to global default', async ({ page }) => {
+    await setupMocks(page)
+
+    let savedModelsBody = null
+
+    await page.route('**/api/keys', route =>
+      route.fulfill({ json: { keys: [ENABLED_KEY], allowCustomProvider: false } })
+    )
+
+    const projBase = `**/api/projects/${PROJECT_REPO}`
+    await page.route(`${projBase}/chats`, route =>
+      route.fulfill({ json: { sessions: [] } })
+    )
+    await page.route(`${projBase}/config`, route =>
+      route.fulfill({
+        json: {
+          config: {
+            cycleIntervalMs: 0,
+            agentTimeoutMs: 600000,
+            model: 'mid',
+            budgetPer24h: 100,
+            models: { high: 'claude-opus-4-6', mid: 'claude-sonnet-4-6' },
+          },
+          keySelection: { keyId: ENABLED_KEY.id, fallback: false },
+          provider: 'anthropic',
+          tiers: { high: 'claude-opus-4-6', mid: 'claude-sonnet-4-6' },
+          allTiers: { anthropic: { high: 'claude-opus-4-6', mid: 'claude-sonnet-4-6' } },
+          availableModels: { anthropic: ['claude-opus-4-6', 'claude-sonnet-4-6'] },
+          keyPool: { keys: [ENABLED_KEY] },
+        }
+      })
+    )
+    await page.route(`${projBase}/token`, async route => {
+      await route.request().postDataJSON()
+      await route.fulfill({ json: { keySelection: null } })
+    })
+    await page.route(`${projBase}/models`, async route => {
+      savedModelsBody = await route.request().postDataJSON()
+      await route.fulfill({
+        json: {
+          config: {
+            cycleIntervalMs: 0,
+            agentTimeoutMs: 600000,
+            model: 'mid',
+            budgetPer24h: 100,
+            models: {},
+          }
+        }
+      })
+    })
+
+    await page.goto(`/github.com/${PROJECT_ID}`)
+    await page.waitForLoadState('networkidle')
+
+    const settingsButton = page.locator('button[title="Project Settings"]')
+    await settingsButton.waitFor({ timeout: 10000 })
+    await settingsButton.click()
+
+    await expect(page.getByRole('heading', { name: 'Project Settings' })).toBeVisible({ timeout: 5000 })
+
+    const select = page.locator('select').filter({ has: page.locator('option', { hasText: 'WorkingKey' }) }).last()
+    await expect(select).toBeVisible({ timeout: 5000 })
+    await select.selectOption('')
+
+    await expect.poll(() => savedModelsBody).not.toBeNull()
+    expect(savedModelsBody).toEqual({ models: {} })
+  })
 })

--- a/src/agent-runner.js
+++ b/src/agent-runner.js
@@ -965,50 +965,23 @@ export async function runAgentWithAPI(opts) {
           }
           const status = err.status || err.code || 0;
           const isRetryable = status === 429 || status === 503 || status === 401 || /rate.limit|usage.limit|overloaded|unavailable|quota|authentication_error|invalid.*api.key/i.test(err.message);
-          if (isRetryable && attempt < MAX_RETRIES) {
-            // Parse cooldown from error message (supports "~162 min", "30s", "2 hours", etc.)
+          if (isRetryable) {
+            // Mark the current key unavailable, then fail this agent call.
+            // The outer orchestrator retry loop will start fresh from the top
+            // of the globally ordered key pool and skip cooled-down keys.
             const cooldownMs = parseRetryCooldown(err.message);
 
-            // Mark key as rate-limited with actual cooldown duration
             if (onRateLimited && keyId) {
               onRateLimited(keyId, cooldownMs);
               log(`Key ${keyId} rate-limited for ${Math.ceil(cooldownMs / 60_000)}m`);
             }
 
-            // Try to get a new token from the key pool (will skip rate-limited keys)
-            if (resolveNewToken) {
-              try {
-                const newKey = await resolveNewToken();
-                if (newKey?.token && newKey.token !== token) {
-                  token = newKey.token;
-                  keyId = newKey.keyId;
-                  if (keyId && !keysUsed.includes(keyId)) keysUsed.push(keyId);
-                  isOAuth = newKey.type === 'oauth';
-                  customConfig = newKey.customConfig || null;
-                  // If the fallback key resolved a different model (provider change), update
-                  if (newKey.model) {
-                    const { piModel: newPiModel } = resolveModel(newKey.model, newKey.provider);
-                    piModel = newPiModel;
-                    if (newKey.reasoningEffort !== undefined) reasoningEffort = newKey.reasoningEffort;
-                    keyProvider = newKey.provider;
-                    log(`Rotated to key ${keyId} (${newKey.provider}), model → ${newKey.model}`);
-                  } else {
-                    log(`Rotated to key ${keyId} after rate limit`);
-                  }
-                  continue; // retry immediately with new key — no sleep needed
-                }
-              } catch {}
-            }
-
-            // No fallback key available — wait out the cooldown (capped at 5 min per retry)
-            const waitMs = Math.min(cooldownMs, 5 * 60_000);
-            const waitSec = Math.ceil(waitMs / 1000);
-            log(`No fallback key, retrying in ${waitSec}s (attempt ${attempt + 1}/${MAX_RETRIES})...`);
-            await new Promise(r => setTimeout(r, waitMs));
-            if (aborted) {
-              return makeResult(false, lastResultText || (abortReason === 'timeout' ? 'Agent timed out' : 'Agent was terminated'), { timedOut: abortReason === 'timeout' });
-            }
-            continue;
+            return makeResult(false, err.message, {
+              provider: keyProvider || provider,
+              keyId,
+              keyIdTried: keyId,
+              retryable: true,
+            });
           }
           // Context length exceeded — emergency compact and retry once
           const isContextError = /context_length_exceeded|context.window|too.many.tokens|maximum.context/i.test(err.message);

--- a/src/key-pool.js
+++ b/src/key-pool.js
@@ -196,72 +196,54 @@ export function getKeyPoolSafe() {
  * Resolve the API key to use for a project.
  *
  * @param {object} projectConfig - Project config from config.yaml
- * @param {string|null} providerHint - Detected provider from model/env
+ * @param {string|null} providerHint - Retained for compatibility; pool selection follows global key order
  * @param {function|null} getOAuthToken - Async fn to get OAuth access token: (authFile) => token
  * @returns {Promise<{token: string, provider: string, keyId: string}|null>}
  */
-export async function resolveKeyForProject(projectConfig, providerHint, getOAuthToken) {
+export async function resolveKeyForProject(projectConfig, _providerHint, getOAuthToken) {
   const pool = loadKeyPool();
   const sorted = pool.keys
-    .filter(k => k.enabled)
+    .slice()
     .sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
 
   const keySelection = projectConfig?.keySelection;
+  const pinnedKeyId = keySelection?.keyId || null;
 
   // If project references a specific key from the pool, try it first
-  if (keySelection?.keyId) {
-    const selected = sorted.find(k => k.id === keySelection.keyId);
-    if (selected && !isRateLimited(selected.id)) {
-      const token = await resolveToken(selected, getOAuthToken);
-      if (token) {
-        return {
-          token,
-          provider: selected.provider,
-          keyId: selected.id,
-          type: selected.type || 'api_key',
-          customConfig: selected.provider === 'custom' ? selected.customConfig : undefined,
-        };
-      }
+  if (pinnedKeyId) {
+    const selected = sorted.find(k => k.id === pinnedKeyId);
+    if (selected && selected.enabled && !isRateLimited(selected.id)) {
+      const resolved = await resolveKeyEntry(selected, getOAuthToken);
+      if (resolved) return resolved;
     }
     // If fallback is disabled, return null (project waits)
     if (keySelection.fallback === false) return null;
   }
 
-  // Use global pool order — prefer keys matching provider hint, then any available
-  const candidates = sorted.filter(k => !isRateLimited(k.id) && !(keySelection?.keyId && k.id === keySelection.keyId));
-
-  // First pass: prefer keys matching the provider hint
-  if (providerHint) {
-    for (const key of candidates) {
-      if (key.provider !== providerHint) continue;
-      const token = await resolveToken(key, getOAuthToken);
-      if (token) {
-        return {
-          token,
-          provider: key.provider,
-          keyId: key.id,
-          type: key.type || 'api_key',
-          customConfig: key.provider === 'custom' ? key.customConfig : undefined,
-        };
-      }
-    }
-  }
-
-  // Second pass: any available key (cross-provider fallback)
-  for (const key of candidates) {
-    const token = await resolveToken(key, getOAuthToken);
-    if (token) {
-      return {
-        token,
-        provider: key.provider,
-        keyId: key.id,
-        type: key.type || 'api_key',
-        customConfig: key.provider === 'custom' ? key.customConfig : undefined,
-      };
-    }
+  // Use global pool order for both initial selection and retries.
+  // Disabled and cooled-down keys are skipped; retries simply re-enter the pool
+  // from the top so the next available key wins regardless of provider.
+  for (const key of sorted) {
+    if (!key.enabled) continue;
+    if (isRateLimited(key.id)) continue;
+    if (pinnedKeyId && key.id === pinnedKeyId) continue;
+    const resolved = await resolveKeyEntry(key, getOAuthToken);
+    if (resolved) return resolved;
   }
 
   return null;
+}
+
+async function resolveKeyEntry(key, getOAuthToken) {
+  const token = await resolveToken(key, getOAuthToken);
+  if (!token) return null;
+  return {
+    token,
+    provider: key.provider,
+    keyId: key.id,
+    type: key.type || 'api_key',
+    customConfig: key.provider === 'custom' ? key.customConfig : undefined,
+  };
 }
 
 async function resolveToken(key, getOAuthToken) {

--- a/src/server.js
+++ b/src/server.js
@@ -96,17 +96,36 @@ const MODEL_TIERS = {
   },
 };
 
+function inferProviderFromModel(model) {
+  const raw = String(model || '').trim().toLowerCase();
+  if (!raw) return null;
+  if (raw.startsWith('openai-codex/')) return 'openai-codex';
+  if (raw.startsWith('openai/')) return 'openai';
+  if (raw.startsWith('anthropic/')) return 'anthropic';
+  if (raw.startsWith('google/') || raw.startsWith('gemini/')) return 'google';
+  if (raw.startsWith('minimax/')) return 'minimax';
+  if (raw.startsWith('claude-')) return 'anthropic';
+  if (raw.startsWith('gpt-') || raw.startsWith('o1') || raw.startsWith('o3') || raw.startsWith('o4')) return 'openai';
+  if (raw.startsWith('gemini-')) return 'google';
+  return null;
+}
+
 function resolveModelTier(tierOrModel, provider, projectModels) {
   const tier = (tierOrModel || '').toLowerCase().trim();
-  // Project-level model overrides take priority
+  // Project-level model overrides take priority only when compatible with the
+  // currently selected provider.
   if (projectModels && projectModels[tier]) {
     const override = projectModels[tier];
-    // Support "model@effort" format (e.g. "gpt-5.3-codex@xhigh")
-    if (override.includes('@')) {
-      const [model, reasoningEffort] = override.split('@', 2);
-      return { model, reasoningEffort };
+    const overrideModel = override.includes('@') ? override.split('@', 2)[0] : override;
+    const overrideProvider = inferProviderFromModel(overrideModel);
+    if (!overrideProvider || overrideProvider === provider) {
+      // Support "model@effort" format (e.g. "gpt-5.3-codex@xhigh")
+      if (override.includes('@')) {
+        const [model, reasoningEffort] = override.split('@', 2);
+        return { model, reasoningEffort };
+      }
+      return { model: override };
     }
-    return { model: override };
   }
   const tiers = MODEL_TIERS[provider];
   if (tiers && tiers[tier]) {
@@ -2278,7 +2297,7 @@ class ProjectRunner {
       keyId: resolvedKeyId,
       onRateLimited: (kid, cooldownMs) => markRateLimited(kid, cooldownMs || 5 * 60_000),
       resolveNewToken: async () => {
-        const newKey = await resolveKeyForProject(config, providerHint, oauthTokenGetter);
+        const newKey = await resolveKeyForProject(config, null, oauthTokenGetter);
         if (newKey?.provider) {
           const newRuntimeSelection = getProviderRuntimeSelection({
             provider: newKey.provider,

--- a/tests/key-pool.test.js
+++ b/tests/key-pool.test.js
@@ -13,6 +13,7 @@ const {
   loadKeyPool,
   saveKeyPool,
   addKey,
+  addOAuthKey,
   removeKey,
   updateKey,
   reorderKeys,
@@ -211,13 +212,57 @@ describe('Key Pool', () => {
       assert.strictEqual(result.keyId, enabled.id);
     });
 
-    it('matches provider hint', async () => {
-      addKey({ label: 'Anthropic', token: 'sk-ant-ant', provider: 'anthropic' });
-      const openai = addKey({ label: 'OpenAI', token: 'sk-proj-oai', provider: 'openai' });
-      const result = await resolveKeyForProject({}, 'openai', null);
+    it('retries from the top of the global pool across providers', async () => {
+      const disabled = addKey({ label: 'Disabled', token: 'sk-ant-disabled', provider: 'anthropic' });
+      const anthropic = addKey({ label: 'Anthropic', token: 'sk-ant-live', provider: 'anthropic' });
+      const openai = addKey({ label: 'OpenAI Codex', token: 'sk-proj-oai', provider: 'openai-codex' });
+
+      updateKey(disabled.id, { enabled: false });
+
+      const first = await resolveKeyForProject({}, null, null);
+      assert.ok(first);
+      assert.strictEqual(first.keyId, anthropic.id);
+
+      markRateLimited(anthropic.id, 60_000);
+
+      // Simulate a retry after the anthropic key failed. The selector should
+      // re-scan from the beginning of the pool and land on the next available key.
+      const result = await resolveKeyForProject({}, 'anthropic', null);
       assert.ok(result);
       assert.strictEqual(result.keyId, openai.id);
-      assert.strictEqual(result.provider, 'openai');
+      assert.strictEqual(result.provider, 'openai-codex');
+    });
+
+    it('skips cooled-down keys without attempting to resolve them', async () => {
+      const cooled = addOAuthKey({ label: 'OAuth key', provider: 'openai-codex', authFile: '/tmp/oauth.json' });
+      const fallback = addKey({ label: 'Fallback', token: 'sk-ant-fallback', provider: 'anthropic' });
+
+      markRateLimited(cooled.id, 60_000);
+
+      let oauthAttempts = 0;
+      const result = await resolveKeyForProject({}, null, async () => {
+        oauthAttempts++;
+        return 'oauth-token';
+      });
+
+      assert.ok(result);
+      assert.strictEqual(result.keyId, fallback.id);
+      assert.strictEqual(oauthAttempts, 0);
+    });
+
+    it('preserves explicit key pinning even when an earlier global key exists', async () => {
+      addKey({ label: 'Global First', token: 'sk-ant-global', provider: 'anthropic' });
+      const pinned = addKey({ label: 'Pinned OpenAI', token: 'sk-proj-pinned', provider: 'openai-codex' });
+
+      const result = await resolveKeyForProject(
+        { keySelection: { keyId: pinned.id, fallback: true } },
+        'anthropic',
+        null
+      );
+
+      assert.ok(result);
+      assert.strictEqual(result.keyId, pinned.id);
+      assert.strictEqual(result.provider, 'openai-codex');
     });
   });
 


### PR DESCRIPTION
## Summary
- preserve global key-order fallback while removing in-call key rotation
- resolve project model tiers and overrides against the selected key provider
- clear project model overrides when switching from a fixed key back to the global default

## Testing
- node --test tests/key-pool.test.js tests/agent-retry.test.js tests/auth-rotation.test.js
- npx playwright test tests/disabled-key-warning.spec.js -g "clears model overrides when switching from fixed key to global default"
- npm run build