### PR TITLE
feat: persist key cooldown state across restarts

### DIFF
--- a/monitor/package-lock.json
+++ b/monitor/package-lock.json
@@ -8,6 +8,9 @@
       "name": "thebotcompany-monitor",
       "version": "1.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@radix-ui/react-scroll-area": "^1.0.5",
         "@radix-ui/react-slot": "^1.0.2",
         "@tailwindcss/typography": "^0.5.19",
@@ -325,6 +328,59 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -4279,6 +4335,12 @@
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/unified": {
       "version": "11.0.5",

--- a/monitor/package.json
+++ b/monitor/package.json
@@ -11,6 +11,9 @@
     "test:ui": "playwright test --ui"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@radix-ui/react-scroll-area": "^1.0.5",
     "@radix-ui/react-slot": "^1.0.2",
     "@tailwindcss/typography": "^0.5.19",

--- a/monitor/src/components/panels/SettingsPanel.jsx
+++ b/monitor/src/components/panels/SettingsPanel.jsx
@@ -1033,24 +1033,31 @@ export default function SettingsPanel({
 
           {/* Credential list */}
           <div className="space-y-1">
-            {keys.map((key, idx) => (
-                  <SortableCredentialRow
-                    key={key.id}
-                    keyItem={key}
-                    idx={idx}
-                    keysLength={keys.length}
-                    editingLabel={editingLabel}
-                    editLabelValue={editLabelValue}
-                    setEditLabelValue={setEditLabelValue}
-                    handleSaveLabel={handleSaveLabel}
-                    setEditingLabel={setEditingLabel}
-                    setEditingCustomKey={setEditingCustomKey}
-                    handleReorder={handleReorder}
-                    handleToggleEnabled={handleToggleEnabled}
-                    handleRemoveKey={handleRemoveKey}
-                  />
-                ))}
-                {keys.length === 0 && (
+            {keys.length > 0 ? (
+              <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+                <SortableContext items={keys.map(key => key.id)} strategy={verticalListSortingStrategy}>
+                  <div className="space-y-2">
+                    {keys.map((key, idx) => (
+                      <SortableCredentialRow
+                        key={key.id}
+                        keyItem={key}
+                        idx={idx}
+                        keysLength={keys.length}
+                        editingLabel={editingLabel}
+                        editLabelValue={editLabelValue}
+                        setEditLabelValue={setEditLabelValue}
+                        handleSaveLabel={handleSaveLabel}
+                        setEditingLabel={setEditingLabel}
+                        setEditingCustomKey={setEditingCustomKey}
+                        handleReorder={handleReorder}
+                        handleToggleEnabled={handleToggleEnabled}
+                        handleRemoveKey={handleRemoveKey}
+                      />
+                    ))}
+                  </div>
+                </SortableContext>
+              </DndContext>
+            ) : (
               <p className="text-xs text-neutral-400 dark:text-neutral-500 py-2">No credentials configured. Click "Add Credential" above to get started.</p>
             )}
           </div>

--- a/monitor/src/components/panels/SettingsPanel.jsx
+++ b/monitor/src/components/panels/SettingsPanel.jsx
@@ -1,5 +1,8 @@
 import React, { useState, useEffect } from 'react'
-import { Sun, Moon, Monitor, Info, ChevronUp, ChevronDown, Trash2, Plus, X, ChevronRight, ArrowLeft } from 'lucide-react'
+import { DndContext, PointerSensor, TouchSensor, KeyboardSensor, closestCenter, useSensor, useSensors } from '@dnd-kit/core'
+import { SortableContext, useSortable, arrayMove, verticalListSortingStrategy, sortableKeyboardCoordinates } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { Sun, Moon, Monitor, Info, ChevronUp, ChevronDown, Trash2, Plus, X, ChevronRight, ArrowLeft, GripVertical } from 'lucide-react'
 import { Panel, PanelHeader, PanelContent } from '@/components/ui/panel'
 import ProviderSelector, { PROVIDERS, ProviderBadge } from '@/components/ui/ProviderSelector'
 
@@ -21,6 +24,142 @@ function formatCooldown(cooldownMs) {
   if (hours > 0) return `${hours}h ${minutes}m left`
   if (minutes > 0) return `${minutes}m ${seconds}s left`
   return `${seconds}s left`
+}
+
+function SortableCredentialRow({
+  keyItem,
+  idx,
+  keysLength,
+  editingLabel,
+  editLabelValue,
+  setEditLabelValue,
+  handleSaveLabel,
+  setEditingLabel,
+  setEditingCustomKey,
+  handleReorder,
+  handleToggleEnabled,
+  handleRemoveKey,
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: keyItem.id })
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  }
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`rounded-xl border p-3 ${
+        keyItem.enabled
+          ? keyItem.rateLimited
+            ? 'border-amber-300 dark:border-amber-800 bg-amber-50/60 dark:bg-amber-950/20'
+            : 'border-neutral-200 dark:border-neutral-700 bg-neutral-50 dark:bg-neutral-800/50'
+          : 'border-neutral-200 dark:border-neutral-700 bg-neutral-100/50 dark:bg-neutral-900/50 opacity-70'
+      } ${isDragging ? 'shadow-lg ring-2 ring-blue-400/40' : ''}`}
+    >
+      <div className="flex items-start gap-2">
+        <button
+          type="button"
+          className="mt-0.5 p-1 -ml-1 rounded text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300 touch-none cursor-grab active:cursor-grabbing shrink-0"
+          aria-label={`Reorder ${keyItem.label}`}
+          {...attributes}
+          {...listeners}
+        >
+          <GripVertical className="w-4 h-4" />
+        </button>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2 min-w-0">
+                <span className="text-xs text-neutral-400 dark:text-neutral-500 shrink-0">{idx + 1}.</span>
+                <span className={`w-2.5 h-2.5 rounded-full shrink-0 ${
+                  !keyItem.enabled ? 'bg-neutral-300 dark:bg-neutral-600' :
+                  keyItem.rateLimited ? 'bg-amber-400 animate-pulse' :
+                  'bg-green-400'
+                }`} />
+                {editingLabel === keyItem.id ? (
+                  <input
+                    type="text"
+                    value={editLabelValue}
+                    onChange={e => setEditLabelValue(e.target.value)}
+                    onBlur={() => handleSaveLabel(keyItem.id)}
+                    onKeyDown={e => { if (e.key === 'Enter') handleSaveLabel(keyItem.id); if (e.key === 'Escape') setEditingLabel(null) }}
+                    autoFocus
+                    className="text-sm font-medium w-full px-2 py-1 bg-white dark:bg-neutral-700 border border-blue-400 rounded"
+                  />
+                ) : (
+                  <button
+                    onClick={() => { setEditingLabel(keyItem.id); setEditLabelValue(keyItem.label) }}
+                    className="text-sm font-medium text-neutral-800 dark:text-neutral-200 hover:text-blue-500 dark:hover:text-blue-400 truncate block text-left"
+                    title="Click to edit label"
+                  >
+                    {keyItem.label}
+                  </button>
+                )}
+              </div>
+
+              <div className="flex flex-wrap items-center gap-1.5 mt-2">
+                <ProviderBadge provider={keyItem.provider} />
+                <span className={`text-xs font-medium px-1.5 py-0.5 rounded ${
+                  keyItem.type === 'oauth'
+                    ? 'text-sky-600 dark:text-sky-400 bg-sky-100 dark:bg-sky-900/30'
+                    : 'text-neutral-500 dark:text-neutral-400 bg-neutral-100 dark:bg-neutral-800'
+                }`}>
+                  {keyItem.type === 'oauth' ? 'OAuth' : 'API Key'}
+                </span>
+                <code className="text-xs text-neutral-400 dark:text-neutral-500 break-all sm:truncate">{keyItem.preview}</code>
+              </div>
+
+              <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
+                <span className={keyItem.enabled ? 'text-green-600 dark:text-green-400' : 'text-neutral-500 dark:text-neutral-400'}>
+                  {keyItem.enabled ? 'Enabled' : 'Disabled'}
+                </span>
+                {keyItem.rateLimited && (
+                  <span className="text-amber-600 dark:text-amber-400 font-medium">
+                    Rate limited{keyItem.cooldownMs ? `, ${formatCooldown(keyItem.cooldownMs)}` : ''}
+                  </span>
+                )}
+              </div>
+
+              {keyItem.provider === 'custom' && keyItem.customConfig && (
+                <div className="mt-2 text-[11px] text-neutral-500 dark:text-neutral-400 break-all sm:truncate">
+                  {keyItem.customConfig.apiStyle} · {keyItem.customConfig.baseUrl} · {keyItem.customConfig.defaultModel}
+                </div>
+              )}
+            </div>
+
+            <div className="flex items-center gap-1 shrink-0 pt-0.5">
+              <button onClick={() => handleReorder(keyItem.id, 'up')} disabled={idx === 0} className="p-1.5 text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300 disabled:opacity-30" title="Move up"><ChevronUp className="w-4 h-4" /></button>
+              <button onClick={() => handleReorder(keyItem.id, 'down')} disabled={idx === keysLength - 1} className="p-1.5 text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300 disabled:opacity-30" title="Move down"><ChevronDown className="w-4 h-4" /></button>
+              <button onClick={() => handleRemoveKey(keyItem.id)} className="p-1.5 text-red-400 hover:text-red-600 dark:hover:text-red-300" title="Remove"><Trash2 className="w-4 h-4" /></button>
+            </div>
+          </div>
+
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            {keyItem.provider === 'custom' && (
+              <button
+                onClick={() => setEditingCustomKey(keyItem)}
+                className="px-2.5 py-1 text-xs rounded-md border border-cyan-200 text-cyan-700 hover:text-cyan-800 dark:border-cyan-800 dark:text-cyan-300 dark:hover:text-cyan-200"
+              >
+                Edit
+              </button>
+            )}
+            <button
+              onClick={() => handleToggleEnabled(keyItem.id, !keyItem.enabled)}
+              className={`px-2.5 py-1 text-xs rounded-md border ${
+                keyItem.enabled
+                  ? 'border-amber-200 text-amber-700 hover:text-amber-800 dark:border-amber-800 dark:text-amber-400'
+                  : 'border-green-200 text-green-700 hover:text-green-800 dark:border-green-800 dark:text-green-400'
+              }`}
+            >
+              {keyItem.enabled ? 'Disable' : 'Enable'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
 }
 
 function CustomCredentialFields({
@@ -665,6 +804,11 @@ export default function SettingsPanel({
   const [keys, setKeys] = useState([])
   const [, setNowTick] = useState(0)
   const [allowCustomProvider, setAllowCustomProvider] = useState(true)
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 150, tolerance: 8 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  )
   const [showWizard, setShowWizard] = useState(false)
   const [editingCustomKey, setEditingCustomKey] = useState(null)
   const [editingLabel, setEditingLabel] = useState(null)
@@ -711,28 +855,42 @@ export default function SettingsPanel({
     } catch {}
   }
 
+  const persistReorder = async (nextKeys, fallbackKeys = keys) => {
+    setKeys(nextKeys)
+    try {
+      const res = await authFetch('/api/keys/reorder', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ orderedIds: nextKeys.map(k => k.id) })
+      })
+      if (res.ok) {
+        const d = await res.json()
+        setKeys(d.keys || [])
+      } else {
+        throw new Error()
+      }
+    } catch {
+      setKeys(fallbackKeys)
+    }
+  }
+
   const handleReorder = async (id, direction) => {
     const idx = keys.findIndex(k => k.id === id)
     if (idx < 0) return
     const swapIdx = direction === 'up' ? idx - 1 : idx + 1
     if (swapIdx < 0 || swapIdx >= keys.length) return
-    const newOrder = [...keys]
-    const tmp = newOrder[idx]
-    newOrder[idx] = newOrder[swapIdx]
-    newOrder[swapIdx] = tmp
-    const orderedIds = newOrder.map(k => k.id)
-    setKeys(newOrder)
-    try {
-      const res = await authFetch('/api/keys/reorder', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ orderedIds })
-      })
-      if (res.ok) {
-        const d = await res.json()
-        setKeys(d.keys || [])
-      }
-    } catch {}
+    const nextKeys = arrayMove(keys, idx, swapIdx)
+    await persistReorder(nextKeys, keys)
+  }
+
+  const handleDragEnd = async (event) => {
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+    const oldIndex = keys.findIndex(k => k.id === active.id)
+    const newIndex = keys.findIndex(k => k.id === over.id)
+    if (oldIndex < 0 || newIndex < 0) return
+    const nextKeys = arrayMove(keys, oldIndex, newIndex)
+    await persistReorder(nextKeys, keys)
   }
 
   const handleSaveLabel = async (id) => {
@@ -876,79 +1034,23 @@ export default function SettingsPanel({
           {/* Credential list */}
           <div className="space-y-1">
             {keys.map((key, idx) => (
-              <div
-                key={key.id}
-                className={`flex items-center gap-2 p-2 rounded-lg border ${
-                  key.enabled
-                    ? key.rateLimited
-                      ? 'border-amber-200 dark:border-amber-800 bg-amber-50/50 dark:bg-amber-950/20'
-                      : 'border-neutral-200 dark:border-neutral-700 bg-neutral-50 dark:bg-neutral-800/50'
-                    : 'border-neutral-200 dark:border-neutral-700 bg-neutral-100/50 dark:bg-neutral-900/50 opacity-60'
-                }`}
-              >
-                <span className="text-xs text-neutral-400 dark:text-neutral-500 w-4 text-right shrink-0">{idx + 1}.</span>
-                <span className={`w-2 h-2 rounded-full shrink-0 ${
-                  !key.enabled ? 'bg-neutral-300 dark:bg-neutral-600' :
-                  key.rateLimited ? 'bg-amber-400 animate-pulse' :
-                  'bg-green-400'
-                }`} />
-                <div className="flex-1 min-w-0">
-                  {editingLabel === key.id ? (
-                    <input
-                      type="text"
-                      value={editLabelValue}
-                      onChange={e => setEditLabelValue(e.target.value)}
-                      onBlur={() => handleSaveLabel(key.id)}
-                      onKeyDown={e => { if (e.key === 'Enter') handleSaveLabel(key.id); if (e.key === 'Escape') setEditingLabel(null); }}
-                      autoFocus
-                      className="text-xs font-medium w-full px-1 py-0.5 bg-white dark:bg-neutral-700 border border-blue-400 rounded"
-                    />
-                  ) : (
-                    <button
-                      onClick={() => { setEditingLabel(key.id); setEditLabelValue(key.label); }}
-                      className="text-xs font-medium text-neutral-700 dark:text-neutral-300 hover:text-blue-500 dark:hover:text-blue-400 truncate block text-left"
-                      title="Click to edit label"
-                    >
-                      {key.label}
-                    </button>
-                  )}
-                  <div className="flex items-center gap-1.5 mt-0.5">
-                    <ProviderBadge provider={key.provider} />
-                    <span className={`text-xs font-medium px-1.5 py-0.5 rounded ${
-                      key.type === 'oauth'
-                        ? 'text-sky-600 dark:text-sky-400 bg-sky-100 dark:bg-sky-900/30'
-                        : 'text-neutral-500 dark:text-neutral-400 bg-neutral-100 dark:bg-neutral-800'
-                    }`}>
-                      {key.type === 'oauth' ? 'OAuth' : 'API Key'}
-                    </span>
-                    <code className="text-xs text-neutral-400 dark:text-neutral-500 truncate">{key.preview}</code>
-                    {key.rateLimited && (
-                      <span className="text-xs text-amber-500">rate limited{key.cooldownMs ? `, ${formatCooldown(key.cooldownMs)}` : ''}</span>
-                    )}
-                  </div>
-                  {key.provider === 'custom' && key.customConfig && (
-                    <div className="mt-1 text-[11px] text-neutral-500 dark:text-neutral-400 truncate">
-                      {key.customConfig.apiStyle} · {key.customConfig.baseUrl} · {key.customConfig.defaultModel}
-                    </div>
-                  )}
-                </div>
-                <div className="flex items-center gap-0.5 shrink-0">
-                  {key.provider === 'custom' && (
-                    <button
-                      onClick={() => setEditingCustomKey(key)}
-                      className="px-2 py-0.5 text-xs rounded text-cyan-700 hover:text-cyan-800 dark:text-cyan-300 dark:hover:text-cyan-200"
-                    >
-                      Edit
-                    </button>
-                  )}
-                  <button onClick={() => handleReorder(key.id, 'up')} disabled={idx === 0} className="p-1 text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300 disabled:opacity-30" title="Move up"><ChevronUp className="w-3.5 h-3.5" /></button>
-                  <button onClick={() => handleReorder(key.id, 'down')} disabled={idx === keys.length - 1} className="p-1 text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300 disabled:opacity-30" title="Move down"><ChevronDown className="w-3.5 h-3.5" /></button>
-                  <button onClick={() => handleToggleEnabled(key.id, !key.enabled)} className={`px-2 py-0.5 text-xs rounded ${key.enabled ? 'text-amber-600 hover:text-amber-700 dark:text-amber-400' : 'text-green-600 hover:text-green-700 dark:text-green-400'}`}>{key.enabled ? 'Disable' : 'Enable'}</button>
-                  <button onClick={() => handleRemoveKey(key.id)} className="p-1 text-red-400 hover:text-red-600 dark:hover:text-red-300" title="Remove"><Trash2 className="w-3.5 h-3.5" /></button>
-                </div>
-              </div>
-            ))}
-            {keys.length === 0 && (
+                  <SortableCredentialRow
+                    key={key.id}
+                    keyItem={key}
+                    idx={idx}
+                    keysLength={keys.length}
+                    editingLabel={editingLabel}
+                    editLabelValue={editLabelValue}
+                    setEditLabelValue={setEditLabelValue}
+                    handleSaveLabel={handleSaveLabel}
+                    setEditingLabel={setEditingLabel}
+                    setEditingCustomKey={setEditingCustomKey}
+                    handleReorder={handleReorder}
+                    handleToggleEnabled={handleToggleEnabled}
+                    handleRemoveKey={handleRemoveKey}
+                  />
+                ))}
+                {keys.length === 0 && (
               <p className="text-xs text-neutral-400 dark:text-neutral-500 py-2">No credentials configured. Click "Add Credential" above to get started.</p>
             )}
           </div>

--- a/monitor/src/components/panels/SettingsPanel.jsx
+++ b/monitor/src/components/panels/SettingsPanel.jsx
@@ -11,6 +11,18 @@ import { useToast } from '@/contexts/ToastContext'
 // Add Credential Wizard
 // ---------------------------------------------------------------------------
 
+function formatCooldown(cooldownMs) {
+  const ms = Math.max(0, Number(cooldownMs) || 0)
+  if (!ms) return null
+  const totalSeconds = Math.ceil(ms / 1000)
+  const hours = Math.floor(totalSeconds / 3600)
+  const minutes = Math.floor((totalSeconds % 3600) / 60)
+  const seconds = totalSeconds % 60
+  if (hours > 0) return `${hours}h ${minutes}m left`
+  if (minutes > 0) return `${minutes}m ${seconds}s left`
+  return `${seconds}s left`
+}
+
 function CustomCredentialFields({
   token,
   setToken,
@@ -651,6 +663,7 @@ export default function SettingsPanel({
   const { showToast } = useToast()
 
   const [keys, setKeys] = useState([])
+  const [, setNowTick] = useState(0)
   const [allowCustomProvider, setAllowCustomProvider] = useState(true)
   const [showWizard, setShowWizard] = useState(false)
   const [editingCustomKey, setEditingCustomKey] = useState(null)
@@ -665,6 +678,13 @@ export default function SettingsPanel({
   }
 
   useEffect(() => { fetchKeys() }, [])
+
+  useEffect(() => {
+    const hasCooldown = keys.some(key => (key.cooldownMs || 0) > 0)
+    if (!hasCooldown) return
+    const id = window.setInterval(() => setNowTick(tick => tick + 1), 1000)
+    return () => window.clearInterval(id)
+  }, [keys])
 
   const handleRemoveKey = async (id) => {
     try {
@@ -903,7 +923,7 @@ export default function SettingsPanel({
                     </span>
                     <code className="text-xs text-neutral-400 dark:text-neutral-500 truncate">{key.preview}</code>
                     {key.rateLimited && (
-                      <span className="text-xs text-amber-500">rate limited</span>
+                      <span className="text-xs text-amber-500">rate limited{key.cooldownMs ? `, ${formatCooldown(key.cooldownMs)}` : ''}</span>
                     )}
                   </div>
                   {key.provider === 'custom' && key.customConfig && (

--- a/src/key-pool.js
+++ b/src/key-pool.js
@@ -18,27 +18,98 @@ const POOL_PATH = path.join(TBC_HOME, 'key-pool.json');
 // In-memory rate limit tracking
 // ---------------------------------------------------------------------------
 
-/** @type {Map<string, number>} keyId → cooldown-until timestamp */
+const MAX_UNKNOWN_BACKOFF_MS = 24 * 60 * 60_000;
+const UNKNOWN_BACKOFF_FIB_MINUTES = [5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610, 987, 1440];
+
+/** @type {Map<string, { retryAt: number, unknownCount: number }>} */
 const _rateLimits = new Map();
 
-export function markRateLimited(keyId, cooldownMs = 5 * 60_000) {
-  _rateLimits.set(keyId, Date.now() + cooldownMs);
+function getUnknownBackoffMs(unknownCount = 0) {
+  const index = Math.max(0, Math.min(unknownCount, UNKNOWN_BACKOFF_FIB_MINUTES.length - 1));
+  return Math.min(UNKNOWN_BACKOFF_FIB_MINUTES[index] * 60_000, MAX_UNKNOWN_BACKOFF_MS);
+}
+
+function readKeyPoolRaw() {
+  try {
+    const raw = fs.readFileSync(POOL_PATH, 'utf-8');
+    const pool = JSON.parse(raw);
+    if (!Array.isArray(pool.keys)) pool.keys = [];
+    if (!pool.rateLimits || typeof pool.rateLimits !== 'object') pool.rateLimits = {};
+    return pool;
+  } catch {
+    return { keys: [], rateLimits: {} };
+  }
+}
+
+function persistRateLimits() {
+  const pool = readKeyPoolRaw();
+  const serialized = {};
+  for (const [keyId, entry] of _rateLimits.entries()) {
+    if ((entry.retryAt || 0) > Date.now() || (entry.unknownCount || 0) > 0) {
+      serialized[keyId] = {
+        retryAt: entry.retryAt || 0,
+        unknownCount: entry.unknownCount || 0,
+      };
+    }
+  }
+  pool.rateLimits = serialized;
+  saveKeyPool(pool);
+}
+
+function hydrateRateLimits(pool) {
+  _rateLimits.clear();
+  const saved = pool?.rateLimits && typeof pool.rateLimits === 'object' ? pool.rateLimits : {};
+  for (const [keyId, entry] of Object.entries(saved)) {
+    if (!entry || typeof entry !== 'object') continue;
+    const retryAt = Number(entry.retryAt) || 0;
+    const unknownCount = Number(entry.unknownCount) || 0;
+    if (retryAt > Date.now() || unknownCount > 0) {
+      _rateLimits.set(keyId, { retryAt, unknownCount });
+    }
+  }
+}
+
+function getRateLimitEntry(keyId) {
+  const entry = _rateLimits.get(keyId);
+  if (!entry) return null;
+  if (Date.now() >= entry.retryAt) {
+    if (entry.unknownCount > 0) {
+      _rateLimits.set(keyId, { retryAt: 0, unknownCount: entry.unknownCount });
+    } else {
+      _rateLimits.delete(keyId);
+    }
+    persistRateLimits();
+    return null;
+  }
+  return entry;
+}
+
+export function markRateLimited(keyId, cooldownMs = null) {
+  const existing = _rateLimits.get(keyId) || { retryAt: 0, unknownCount: 0 };
+  const parsed = Number(cooldownMs);
+  const hasKnownCooldown = Number.isFinite(parsed) && parsed > 0;
+  const effectiveMs = hasKnownCooldown ? Math.max(1000, parsed) : getUnknownBackoffMs(existing.unknownCount || 0);
+  const retryAt = Math.max(existing.retryAt || 0, Date.now() + effectiveMs);
+  _rateLimits.set(keyId, {
+    retryAt,
+    unknownCount: hasKnownCooldown ? (existing.unknownCount || 0) : (existing.unknownCount || 0) + 1,
+  });
+  persistRateLimits();
+}
+
+export function markKeySucceeded(keyId) {
+  _rateLimits.delete(keyId);
+  persistRateLimits();
 }
 
 export function isRateLimited(keyId) {
-  const until = _rateLimits.get(keyId);
-  if (!until) return false;
-  if (Date.now() >= until) {
-    _rateLimits.delete(keyId);
-    return false;
-  }
-  return true;
+  return !!getRateLimitEntry(keyId);
 }
 
 export function getRateLimitCooldown(keyId) {
-  const until = _rateLimits.get(keyId);
-  if (!until || Date.now() >= until) return 0;
-  return until - Date.now();
+  const entry = getRateLimitEntry(keyId);
+  if (!entry) return 0;
+  return Math.max(0, entry.retryAt - Date.now());
 }
 
 // ---------------------------------------------------------------------------
@@ -46,20 +117,19 @@ export function getRateLimitCooldown(keyId) {
 // ---------------------------------------------------------------------------
 
 export function loadKeyPool() {
-  try {
-    const raw = fs.readFileSync(POOL_PATH, 'utf-8');
-    const pool = JSON.parse(raw);
-    if (!Array.isArray(pool.keys)) pool.keys = [];
-    return pool;
-  } catch {
-    return { keys: [] };
-  }
+  const pool = readKeyPoolRaw();
+  hydrateRateLimits(pool);
+  return pool;
 }
 
 export function saveKeyPool(pool) {
   fs.mkdirSync(TBC_HOME, { recursive: true });
   const tmp = POOL_PATH + '.tmp';
-  fs.writeFileSync(tmp, JSON.stringify(pool, null, 2), { mode: 0o600 });
+  const data = {
+    ...pool,
+    rateLimits: pool.rateLimits && typeof pool.rateLimits === 'object' ? pool.rateLimits : {},
+  };
+  fs.writeFileSync(tmp, JSON.stringify(data, null, 2), { mode: 0o600 });
   fs.renameSync(tmp, POOL_PATH);
 }
 

--- a/src/server.js
+++ b/src/server.js
@@ -20,7 +20,7 @@ import { buildCustomTierMap, resolveProviderRuntime } from './providers/custom-c
 import { startOAuthLogin, submitManualCode, checkOAuthStatus, getAccessToken as getOAuthAccessToken, clearCredentials as clearOAuthCredentials, listOAuthProviders, loadCredentials as loadOAuthCredentials } from './oauth.js';
 import {
   loadKeyPool, addKey, addOAuthKey, removeKey, updateKey, reorderKeys,
-  getKeyPoolSafe, resolveKeyForProject, markRateLimited, migrateFromEnv,
+  getKeyPoolSafe, resolveKeyForProject, markRateLimited, markKeySucceeded, migrateFromEnv,
   detectTokenProvider as detectTokenProviderFromPool,
 } from './key-pool.js';
 import webpush from 'web-push';
@@ -2331,6 +2331,10 @@ class ProjectRunner {
         this.currentAgentUsage = usage;
       },
     });
+
+    if (result.success && resolvedKeyId) {
+      markKeySucceeded(resolvedKeyId);
+    }
 
     return this._postProcessAgentRun(agent, config, {
       resultText: result.resultText,

--- a/tests/key-pool.test.js
+++ b/tests/key-pool.test.js
@@ -20,6 +20,7 @@ const {
   getKeyPoolSafe,
   resolveKeyForProject,
   markRateLimited,
+  markKeySucceeded,
   isRateLimited,
   getRateLimitCooldown,
   detectTokenProvider,
@@ -31,6 +32,7 @@ describe('Key Pool', () => {
   beforeEach(() => {
     // Clean pool file before each test
     try { fs.unlinkSync(poolPath); } catch {}
+    loadKeyPool();
   });
 
   afterEach(() => {
@@ -40,7 +42,7 @@ describe('Key Pool', () => {
   describe('loadKeyPool / saveKeyPool', () => {
     it('returns empty pool when file does not exist', () => {
       const pool = loadKeyPool();
-      assert.deepStrictEqual(pool, { keys: [] });
+      assert.deepStrictEqual(pool, { keys: [], rateLimits: {} });
     });
 
     it('round-trips a pool', () => {
@@ -148,11 +150,62 @@ describe('Key Pool', () => {
     });
 
     it('expires rate limits', () => {
-      markRateLimited('key-2', 1); // 1ms cooldown
-      // wait a tick
-      const start = Date.now();
-      while (Date.now() - start < 5) {} // busy wait 5ms
-      assert.strictEqual(isRateLimited('key-2'), false);
+      const originalNow = Date.now;
+      let now = 1_000_000;
+      Date.now = () => now;
+      try {
+        markRateLimited('key-2', 1_000);
+        assert.strictEqual(isRateLimited('key-2'), true);
+        now += 1_001;
+        assert.strictEqual(isRateLimited('key-2'), false);
+      } finally {
+        Date.now = originalNow;
+      }
+    });
+
+    it('uses Fibonacci backoff capped at one day when retry time is unknown', () => {
+      markRateLimited('key-fib', null);
+      const first = getRateLimitCooldown('key-fib');
+      markRateLimited('key-fib', null);
+      const second = getRateLimitCooldown('key-fib');
+      markRateLimited('key-fib', null);
+      const third = getRateLimitCooldown('key-fib');
+
+      assert.ok(first > 295_000 && first <= 301_000);
+      assert.ok(second > 475_000 && second <= 481_000);
+      assert.ok(third > 775_000 && third <= 781_000);
+
+      for (let i = 0; i < 20; i++) markRateLimited('key-fib', null);
+      const capped = getRateLimitCooldown('key-fib');
+      assert.ok(capped > 23 * 60 * 60_000);
+      assert.ok(capped <= 24 * 60 * 60_000);
+    });
+
+    it('never shortens an existing cooldown and resets after success', () => {
+      markRateLimited('key-sticky', 10 * 60_000);
+      const original = getRateLimitCooldown('key-sticky');
+      markRateLimited('key-sticky', 60_000);
+      const afterShorterRetry = getRateLimitCooldown('key-sticky');
+
+      assert.ok(afterShorterRetry >= original - 1_000);
+      assert.strictEqual(isRateLimited('key-sticky'), true);
+
+      markKeySucceeded('key-sticky');
+      assert.strictEqual(isRateLimited('key-sticky'), false);
+      assert.strictEqual(getRateLimitCooldown('key-sticky'), 0);
+    });
+
+    it('persists retry state in key-pool.json', () => {
+      markRateLimited('key-persist', null);
+      const saved = JSON.parse(fs.readFileSync(poolPath, 'utf-8'));
+      const persisted = saved.rateLimits['key-persist'];
+      assert.ok(persisted);
+      assert.ok(persisted.retryAt > Date.now());
+      assert.strictEqual(persisted.unknownCount, 1);
+
+      markKeySucceeded('key-persist');
+      const cleared = JSON.parse(fs.readFileSync(poolPath, 'utf-8'));
+      assert.strictEqual(cleared.rateLimits['key-persist'], undefined);
     });
   });
 

--- a/tests/summarize-fallback.test.js
+++ b/tests/summarize-fallback.test.js
@@ -109,9 +109,18 @@ describe('Summarize fallback', () => {
     });
 
     it('key becomes available after cooldown expires', () => {
-      const key = addKey({ label: 'Test', token: 'sk-proj-test', provider: 'openai-codex' });
-      markRateLimited(key.id, 0);
-      assert.ok(!isRateLimited(key.id), 'Key should NOT be rate-limited after 0ms cooldown');
+      const originalNow = Date.now;
+      let now = 1_000_000;
+      Date.now = () => now;
+      try {
+        const key = addKey({ label: 'Test', token: 'sk-proj-test', provider: 'openai-codex' });
+        markRateLimited(key.id, 1_000);
+        assert.ok(isRateLimited(key.id), 'Key should be rate-limited during cooldown');
+        now += 1_001;
+        assert.ok(!isRateLimited(key.id), 'Key should NOT be rate-limited after cooldown expires');
+      } finally {
+        Date.now = originalNow;
+      }
     });
   });
 


### PR DESCRIPTION
## Summary
- persist per-key cooldown and unknown backoff state in key-pool.json
- use Fibonacci fallback starting at 5 minutes when retry time is unknown
- show cooldown time remaining in the global Settings key panel

## Testing
- node --test tests/key-pool.test.js tests/agent-retry.test.js
- npm run build