### PR TITLE
fix: preserve chat scroll position during polling

### DIFF
--- a/monitor/src/components/panels/ChatPanel.jsx
+++ b/monitor/src/components/panels/ChatPanel.jsx
@@ -94,6 +94,13 @@ function formatSendErrorMessage({ error, statusCode, source, cooldownMs }) {
   return error || 'Failed to send message.'
 }
 
+function normalizeSessionSelection(session) {
+  return {
+    selectedKeyId: session?.selected_key_id || 'auto',
+    selectedModel: session?.selected_model || 'auto',
+  }
+}
+
 function mergeServerMessages(serverMessages = [], localMessages = []) {
   const getServerImages = (server) => {
     if (server?.images) return server.images
@@ -162,6 +169,7 @@ export default function ChatPanel({ open, onClose, selectedProject, chatSession,
   const messagesEndRef = useRef(null)
   const inputRef = useRef(null)
   const shouldStickToBottomRef = useRef(true)
+  const hydratedSessionIdRef = useRef(null)
   const keyOptions = (chatConfig.keyPool?.keys || []).filter(key => key.enabled)
   const selectedKey = selectedKeyId !== 'auto' ? keyOptions.find(key => key.id === selectedKeyId) || null : null
   const modelOptions = getModelOptionsForKey(selectedKey, chatConfig.availableModels)
@@ -170,10 +178,12 @@ export default function ChatPanel({ open, onClose, selectedProject, chatSession,
   useEffect(() => {
     if (!chatSession || !selectedProject) {
       setMessages([])
+      hydratedSessionIdRef.current = null
       return
     }
     if (chatSession._temp) {
       setMessages([])
+      hydratedSessionIdRef.current = null
       return
     }
     let cancelled = false
@@ -183,6 +193,12 @@ export default function ChatPanel({ open, onClose, selectedProject, chatSession,
         if (cancelled) return
         const data = await res.json()
         if (data.session?.messages) setMessages(prev => mergeServerMessages(data.session.messages, prev))
+        if (hydratedSessionIdRef.current !== chatSession.id && data.session) {
+          const persistedSelection = normalizeSessionSelection(data.session)
+          setSelectedKeyId(persistedSelection.selectedKeyId)
+          setSelectedModel(persistedSelection.selectedModel)
+          hydratedSessionIdRef.current = chatSession.id
+        }
 
         // If backend is NOT streaming, ensure frontend streaming state is cleared
         if (!data.streaming) {
@@ -405,29 +421,49 @@ export default function ChatPanel({ open, onClose, selectedProject, chatSession,
     scrollToBottom()
   }, [messages, streamingText, streamingToolCalls, scrollToBottom])
 
-  // Reset streaming state and chat selectors when panel opens
+  // Reset streaming state when panel opens, but keep persisted chat selectors
   useEffect(() => {
     if (open) {
       setStreaming(false)
       setStreamingBlocks([])
       setStreamingText(''); setStreamingToolCalls([])
-      setSelectedKeyId('auto')
-      setSelectedModel('auto')
+      if (chatSession?._temp) {
+        setSelectedKeyId('auto')
+        setSelectedModel('auto')
+      } else if (chatSession) {
+        const persistedSelection = normalizeSessionSelection(chatSession)
+        setSelectedKeyId(persistedSelection.selectedKeyId)
+        setSelectedModel(persistedSelection.selectedModel)
+      }
       shouldStickToBottomRef.current = true
       requestAnimationFrame(() => scrollToBottom())
       if (inputRef.current) setTimeout(() => inputRef.current?.focus(), 350)
     }
-  }, [open, chatSession?.id, scrollToBottom])
+  }, [open, chatSession?.id, chatSession?.selected_key_id, chatSession?.selected_model, chatSession?._temp, scrollToBottom])
 
   useEffect(() => {
     if (selectedKeyId === 'auto') {
       if (selectedModel !== 'auto') setSelectedModel('auto')
       return
     }
-    if (selectedModel !== 'auto' && !modelOptions.some(model => model.id === selectedModel)) {
+    if (selectedModel !== 'auto' && modelOptions.length > 0 && !modelOptions.some(model => model.id === selectedModel)) {
       setSelectedModel('auto')
     }
   }, [selectedKeyId, selectedModel, modelOptions])
+
+  const persistSelection = useCallback(async (nextKeyId, nextModel) => {
+    if (!chatSession || chatSession._temp || !selectedProject) return
+    try {
+      await authFetch(`/api/projects/${selectedProject.id}/chats/${chatSession.id}/preferences`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          selectedKeyId: nextKeyId !== 'auto' ? nextKeyId : null,
+          selectedModel: nextModel !== 'auto' ? nextModel : null,
+        }),
+      })
+    } catch {}
+  }, [authFetch, chatSession, selectedProject])
 
   const handleFileSelect = async (e) => {
     const files = Array.from(e.target.files || [])
@@ -481,7 +517,10 @@ export default function ChatPanel({ open, onClose, selectedProject, chatSession,
         const res = await authFetch(`/api/projects/${selectedProject.id}/chats`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({}),
+          body: JSON.stringify({
+            selectedKeyId: selectedKeyId !== 'auto' ? selectedKeyId : null,
+            selectedModel: selectedModel !== 'auto' ? selectedModel : null,
+          }),
         })
         if (!res.ok) return
         const data = await res.json()
@@ -822,7 +861,13 @@ export default function ChatPanel({ open, onClose, selectedProject, chatSession,
               <div className="min-w-0 flex-1 flex items-center gap-2">
                 <select
                   value={selectedKeyId}
-                  onChange={(e) => setSelectedKeyId(e.target.value)}
+                  onChange={(e) => {
+                    const nextKeyId = e.target.value
+                    setSelectedKeyId(nextKeyId)
+                    const nextModel = nextKeyId === 'auto' ? 'auto' : selectedModel
+                    if (nextKeyId === 'auto') setSelectedModel('auto')
+                    persistSelection(nextKeyId, nextModel)
+                  }}
                   className="min-w-0 flex-1 px-3 py-2 text-xs bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-600 rounded-full text-neutral-700 dark:text-neutral-200 focus:outline-none focus:ring-1 focus:ring-blue-500"
                   title="Key"
                   aria-label="Key"
@@ -834,7 +879,11 @@ export default function ChatPanel({ open, onClose, selectedProject, chatSession,
                 </select>
                 <select
                   value={selectedModel}
-                  onChange={(e) => setSelectedModel(e.target.value)}
+                  onChange={(e) => {
+                    const nextModel = e.target.value
+                    setSelectedModel(nextModel)
+                    persistSelection(selectedKeyId, nextModel)
+                  }}
                   disabled={selectedKeyId === 'auto'}
                   className="min-w-0 flex-1 px-3 py-2 text-xs bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-600 rounded-full text-neutral-700 dark:text-neutral-200 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:opacity-50"
                   title="Model"

--- a/monitor/src/components/panels/ChatPanel.jsx
+++ b/monitor/src/components/panels/ChatPanel.jsx
@@ -95,9 +95,6 @@ function formatSendErrorMessage({ error, statusCode, source, cooldownMs }) {
 }
 
 function mergeServerMessages(serverMessages = [], localMessages = []) {
-  const pendingMessages = localMessages.filter(msg => msg?.pending)
-  if (pendingMessages.length === 0) return serverMessages
-
   const getServerImages = (server) => {
     if (server?.images) return server.images
     if (Array.isArray(server?.tool_calls)) return server.tool_calls
@@ -111,6 +108,28 @@ function mergeServerMessages(serverMessages = [], localMessages = []) {
     return []
   }
 
+  const normalizeMessage = (msg) => ({
+    role: msg?.role || '',
+    content: msg?.content || '',
+    images: msg?.images || getServerImages(msg),
+    pending: !!msg?.pending,
+    failed: !!msg?.failed,
+    error: msg?.error || null,
+  })
+
+  const messagesEqual = (a = [], b = []) => {
+    if (a.length !== b.length) return false
+    for (let i = 0; i < a.length; i++) {
+      if (JSON.stringify(normalizeMessage(a[i])) !== JSON.stringify(normalizeMessage(b[i]))) return false
+    }
+    return true
+  }
+
+  const pendingMessages = localMessages.filter(msg => msg?.pending)
+  if (pendingMessages.length === 0) {
+    return messagesEqual(serverMessages, localMessages) ? localMessages : serverMessages
+  }
+
   const unreconciledPending = pendingMessages.filter(pending => {
     return !serverMessages.some(server => {
       if (server?.role !== pending?.role) return false
@@ -122,8 +141,8 @@ function mergeServerMessages(serverMessages = [], localMessages = []) {
     })
   })
 
-  if (unreconciledPending.length === 0) return serverMessages
-  return [...serverMessages, ...unreconciledPending]
+  const mergedMessages = unreconciledPending.length === 0 ? serverMessages : [...serverMessages, ...unreconciledPending]
+  return messagesEqual(mergedMessages, localMessages) ? localMessages : mergedMessages
 }
 
 export default function ChatPanel({ open, onClose, selectedProject, chatSession, onSessionCreated, chatConfig = {} }) {

--- a/monitor/src/components/panels/ChatPanel.jsx
+++ b/monitor/src/components/panels/ChatPanel.jsx
@@ -176,9 +176,13 @@ export default function ChatPanel({ open, onClose, selectedProject, chatSession,
 
   // Load messages when session changes
   useEffect(() => {
-    if (!chatSession || !selectedProject) {
-      setMessages([])
-      hydratedSessionIdRef.current = null
+    if (!open || !chatSession || !selectedProject) {
+      if (!open || !chatSession) {
+        hydratedSessionIdRef.current = null
+      }
+      if (!chatSession || !selectedProject) {
+        setMessages([])
+      }
       return
     }
     if (chatSession._temp) {
@@ -193,7 +197,7 @@ export default function ChatPanel({ open, onClose, selectedProject, chatSession,
         if (cancelled) return
         const data = await res.json()
         if (data.session?.messages) setMessages(prev => mergeServerMessages(data.session.messages, prev))
-        if (hydratedSessionIdRef.current !== chatSession.id && data.session) {
+        if (data.session) {
           const persistedSelection = normalizeSessionSelection(data.session)
           setSelectedKeyId(persistedSelection.selectedKeyId)
           setSelectedModel(persistedSelection.selectedModel)
@@ -271,7 +275,7 @@ export default function ChatPanel({ open, onClose, selectedProject, chatSession,
     }
     load()
     return () => { cancelled = true }
-  }, [chatSession?.id, selectedProject?.id])
+  }, [open, chatSession?.id, selectedProject?.id])
 
   // Poll for new messages (syncs across devices, picks up background completions)
   useEffect(() => {

--- a/monitor/src/components/panels/ChatPanel.jsx
+++ b/monitor/src/components/panels/ChatPanel.jsx
@@ -336,7 +336,7 @@ export default function ChatPanel({ open, onClose, selectedProject, chatSession,
     const isNearBottom = distanceFromBottom <= 12
     const hasOverflow = container.scrollHeight > container.clientHeight + 12
     shouldStickToBottomRef.current = isNearBottom
-    setShowScrollToBottom(hasOverflow)
+    setShowScrollToBottom(hasOverflow && !isNearBottom)
   }, [])
 
   const scrollToBottom = useCallback(() => {
@@ -351,11 +351,53 @@ export default function ChatPanel({ open, onClose, selectedProject, chatSession,
     const container = messagesContainerRef.current
     if (!container) return
 
+    let touchStartY = null
+
     const handleScroll = () => updateScrollToBottomVisibility()
+    const handleWheel = (event) => {
+      if (event.deltaY < 0) {
+        shouldStickToBottomRef.current = false
+        setShowScrollToBottom(true)
+      }
+    }
+    const handlePointerDown = () => {
+      const distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight
+      if (distanceFromBottom > 12) {
+        shouldStickToBottomRef.current = false
+      }
+    }
+    const handleTouchStart = (event) => {
+      touchStartY = event.touches?.[0]?.clientY ?? null
+    }
+    const handleTouchMove = (event) => {
+      const touchY = event.touches?.[0]?.clientY
+      if (touchStartY !== null && touchY !== undefined && touchY > touchStartY + 4) {
+        shouldStickToBottomRef.current = false
+        setShowScrollToBottom(true)
+      }
+    }
+    const handleTouchEnd = () => {
+      touchStartY = null
+    }
+
     container.addEventListener('scroll', handleScroll, { passive: true })
+    container.addEventListener('wheel', handleWheel, { passive: true })
+    container.addEventListener('pointerdown', handlePointerDown, { passive: true })
+    container.addEventListener('touchstart', handleTouchStart, { passive: true })
+    container.addEventListener('touchmove', handleTouchMove, { passive: true })
+    container.addEventListener('touchend', handleTouchEnd, { passive: true })
+    container.addEventListener('touchcancel', handleTouchEnd, { passive: true })
     updateScrollToBottomVisibility()
 
-    return () => container.removeEventListener('scroll', handleScroll)
+    return () => {
+      container.removeEventListener('scroll', handleScroll)
+      container.removeEventListener('wheel', handleWheel)
+      container.removeEventListener('pointerdown', handlePointerDown)
+      container.removeEventListener('touchstart', handleTouchStart)
+      container.removeEventListener('touchmove', handleTouchMove)
+      container.removeEventListener('touchend', handleTouchEnd)
+      container.removeEventListener('touchcancel', handleTouchEnd)
+    }
   }, [open, chatSession?.id, updateScrollToBottomVisibility])
 
   useEffect(() => {

--- a/monitor/tests/chat-scroll-autoscroll-repro.spec.js
+++ b/monitor/tests/chat-scroll-autoscroll-repro.spec.js
@@ -1,0 +1,79 @@
+import { test, expect } from '@playwright/test'
+import { setupMocks, PROJECT_PATH, PROJECT_REPO } from './helpers.js'
+
+const CHAT_ID = 'chat-1'
+
+function makeMessages(count) {
+  const messages = []
+  for (let i = 1; i <= count; i++) {
+    messages.push({ role: 'user', content: `Question ${i}` })
+    messages.push({ role: 'assistant', content: `Answer ${i} `.repeat(12) })
+  }
+  return messages
+}
+
+test('chat panel should not jump to bottom while reading older messages', async ({ page }) => {
+  await setupMocks(page)
+
+  let pollCount = 0
+  const baseMessages = makeMessages(30)
+
+  await page.route(`**/api/projects/${PROJECT_REPO}/chats`, route =>
+    route.fulfill({
+      json: {
+        sessions: [
+          {
+            id: CHAT_ID,
+            title: 'Scroll repro',
+            updated_at: new Date().toISOString(),
+            message_count: baseMessages.length,
+          },
+        ],
+      },
+    })
+  )
+
+  await page.route(`**/api/projects/${PROJECT_REPO}/chats/${CHAT_ID}`, route => {
+    pollCount++
+    route.fulfill({
+      json: {
+        session: {
+          id: CHAT_ID,
+          title: 'Scroll repro',
+          messages: baseMessages,
+        },
+        streaming: false,
+      },
+    })
+  })
+
+  await page.goto(`${PROJECT_PATH}/chat/${CHAT_ID}`)
+  await page.waitForLoadState('networkidle')
+
+  await expect(page.locator('button[aria-label="Send"]').last()).toBeVisible({ timeout: 5000 })
+
+  const container = page.locator('.h-full.overflow-y-auto.overflow-x-hidden.p-4.space-y-1.overscroll-contain').last()
+  await expect(container).toBeVisible({ timeout: 5000 })
+
+  await expect.poll(async () => {
+    const dims = await container.evaluate(el => ({ scrollHeight: el.scrollHeight, clientHeight: el.clientHeight }))
+    return dims.scrollHeight > dims.clientHeight
+  }).toBe(true)
+
+  await container.evaluate(el => {
+    el.scrollTop = 0
+    el.dispatchEvent(new Event('scroll'))
+  })
+  await page.waitForTimeout(300)
+
+  const before = await container.evaluate(el => el.scrollTop)
+  expect(before).toBe(0)
+
+  const pollsBefore = pollCount
+  await page.waitForTimeout(7000)
+  expect(pollCount).toBeGreaterThan(pollsBefore)
+
+  const after = await container.evaluate(el => el.scrollTop)
+
+  expect(after).toBeLessThan(20)
+})

--- a/monitor/tests/chat-session-selection-persistence.spec.js
+++ b/monitor/tests/chat-session-selection-persistence.spec.js
@@ -1,0 +1,108 @@
+import { test, expect } from '@playwright/test'
+import { setupMocks, PROJECT_PATH, PROJECT_REPO } from './helpers.js'
+
+const CHAT_ID = 7
+const KEY_ID = 'anthropic-key-1'
+const KEY_ID_2 = 'anthropic-key-2'
+
+const KEY_POOL = {
+  keys: [
+    { id: KEY_ID, label: 'Primary Anthropic', provider: 'anthropic', enabled: true },
+    { id: KEY_ID_2, label: 'Backup Anthropic', provider: 'anthropic', enabled: true },
+  ],
+}
+
+const AVAILABLE_MODELS = {
+  anthropic: [
+    { id: 'claude-sonnet-4-6', name: 'claude-sonnet-4-6' },
+    { id: 'claude-opus-4-6', name: 'claude-opus-4-6' },
+  ],
+}
+
+test.describe('Chat session key/model persistence', () => {
+  test('restores persisted key/model and saves changes back to the backend', async ({ page }) => {
+    await setupMocks(page)
+
+    let savedPreferences = null
+
+    await page.route(`**/api/projects/${PROJECT_REPO}/config`, route =>
+      route.fulfill({
+        json: {
+          config: { cycleIntervalMs: 0, agentTimeoutMs: 600000, model: 'mid', budgetPer24h: 100 },
+          keyPool: KEY_POOL,
+          availableModels: AVAILABLE_MODELS,
+        },
+      })
+    )
+
+    await page.route(`**/api/projects/${PROJECT_REPO}/chats`, route =>
+      route.fulfill({
+        json: {
+          sessions: [
+            {
+              id: CHAT_ID,
+              title: 'Persisted chat',
+              updated_at: new Date().toISOString(),
+              message_count: 2,
+              selected_key_id: KEY_ID,
+              selected_model: 'claude-sonnet-4-6',
+            },
+          ],
+        },
+      })
+    )
+
+    await page.route(`**/api/projects/${PROJECT_REPO}/chats/${CHAT_ID}`, route =>
+      route.fulfill({
+        json: {
+          session: {
+            id: CHAT_ID,
+            title: 'Persisted chat',
+            selected_key_id: KEY_ID,
+            selected_model: 'claude-sonnet-4-6',
+            messages: [
+              { role: 'user', content: 'hello' },
+              { role: 'assistant', content: 'hi' },
+            ],
+          },
+          streaming: false,
+        },
+      })
+    )
+
+    await page.route(`**/api/projects/${PROJECT_REPO}/chats/${CHAT_ID}/preferences`, async route => {
+      savedPreferences = await route.request().postDataJSON()
+      await route.fulfill({
+        json: {
+          session: {
+            id: CHAT_ID,
+            title: 'Persisted chat',
+            selected_key_id: savedPreferences.selectedKeyId,
+            selected_model: savedPreferences.selectedModel,
+          },
+        },
+      })
+    })
+
+    await page.goto(`${PROJECT_PATH}/chat/${CHAT_ID}`)
+    await page.waitForLoadState('networkidle')
+
+    const keySelect = page.locator('select[aria-label="Key"]').last()
+    const modelSelect = page.locator('select[aria-label="Model"]').last()
+
+    await expect(keySelect).toHaveValue(KEY_ID)
+    await expect(modelSelect).toHaveValue('claude-sonnet-4-6')
+
+    await keySelect.selectOption(KEY_ID_2)
+    await expect.poll(() => savedPreferences).toEqual({
+      selectedKeyId: KEY_ID_2,
+      selectedModel: 'claude-sonnet-4-6',
+    })
+
+    await modelSelect.selectOption('claude-opus-4-6')
+    await expect.poll(() => savedPreferences).toEqual({
+      selectedKeyId: KEY_ID_2,
+      selectedModel: 'claude-opus-4-6',
+    })
+  })
+})

--- a/monitor/tests/chat-session-selection-persistence.spec.js
+++ b/monitor/tests/chat-session-selection-persistence.spec.js
@@ -24,6 +24,14 @@ test.describe('Chat session key/model persistence', () => {
     await setupMocks(page)
 
     let savedPreferences = null
+    const session = {
+      id: CHAT_ID,
+      title: 'Persisted chat',
+      updated_at: new Date().toISOString(),
+      message_count: 2,
+      selected_key_id: KEY_ID,
+      selected_model: 'claude-sonnet-4-6',
+    }
 
     await page.route(`**/api/projects/${PROJECT_REPO}/config`, route =>
       route.fulfill({
@@ -36,30 +44,14 @@ test.describe('Chat session key/model persistence', () => {
     )
 
     await page.route(`**/api/projects/${PROJECT_REPO}/chats`, route =>
-      route.fulfill({
-        json: {
-          sessions: [
-            {
-              id: CHAT_ID,
-              title: 'Persisted chat',
-              updated_at: new Date().toISOString(),
-              message_count: 2,
-              selected_key_id: KEY_ID,
-              selected_model: 'claude-sonnet-4-6',
-            },
-          ],
-        },
-      })
+      route.fulfill({ json: { sessions: [session] } })
     )
 
     await page.route(`**/api/projects/${PROJECT_REPO}/chats/${CHAT_ID}`, route =>
       route.fulfill({
         json: {
           session: {
-            id: CHAT_ID,
-            title: 'Persisted chat',
-            selected_key_id: KEY_ID,
-            selected_model: 'claude-sonnet-4-6',
+            ...session,
             messages: [
               { role: 'user', content: 'hello' },
               { role: 'assistant', content: 'hi' },
@@ -72,16 +64,9 @@ test.describe('Chat session key/model persistence', () => {
 
     await page.route(`**/api/projects/${PROJECT_REPO}/chats/${CHAT_ID}/preferences`, async route => {
       savedPreferences = await route.request().postDataJSON()
-      await route.fulfill({
-        json: {
-          session: {
-            id: CHAT_ID,
-            title: 'Persisted chat',
-            selected_key_id: savedPreferences.selectedKeyId,
-            selected_model: savedPreferences.selectedModel,
-          },
-        },
-      })
+      session.selected_key_id = savedPreferences.selectedKeyId
+      session.selected_model = savedPreferences.selectedModel
+      await route.fulfill({ json: { session } })
     })
 
     await page.goto(`${PROJECT_PATH}/chat/${CHAT_ID}`)
@@ -104,5 +89,11 @@ test.describe('Chat session key/model persistence', () => {
       selectedKeyId: KEY_ID_2,
       selectedModel: 'claude-opus-4-6',
     })
+
+    await page.reload()
+    await page.waitForLoadState('networkidle')
+
+    await expect(page.locator('select[aria-label="Key"]').last()).toHaveValue(KEY_ID_2)
+    await expect(page.locator('select[aria-label="Model"]').last()).toHaveValue('claude-opus-4-6')
   })
 })

--- a/src/chat.js
+++ b/src/chat.js
@@ -509,12 +509,17 @@ export async function streamChatMessage(opts) {
               if (/rate.limit|usage.limit|quota|429/i.test(errMsg)) {
                 throw new Error(errMsg);
               }
-              if (fullAssistantText || assistantText) {
-                saveMessage(agentDir, chatId, 'assistant',
-                  (fullAssistantText + assistantText).trim() + `\n\n⚠️ Error: ${errMsg}`,
-                  allToolCalls.length > 0 ? allToolCalls : null,
-                  { success: false });
-              }
+              const errorContent = (fullAssistantText || assistantText)
+                ? (fullAssistantText + assistantText).trim() + `\n\n⚠️ Error: ${errMsg}`
+                : `⚠️ Error: ${errMsg}`;
+              saveMessage(
+                agentDir,
+                chatId,
+                'assistant',
+                errorContent,
+                allToolCalls.length > 0 ? allToolCalls : null,
+                { success: false }
+              );
               sseWrite({ type: 'error', content: errMsg });
               sseWrite({ type: 'done' });
               activeStreams.delete(chatId);

--- a/src/chat.js
+++ b/src/chat.js
@@ -90,6 +90,8 @@ function getChatDb(agentDir) {
     CREATE TABLE IF NOT EXISTS chat_sessions (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       title TEXT NOT NULL DEFAULT 'New Chat',
+      selected_key_id TEXT DEFAULT NULL,
+      selected_model TEXT DEFAULT NULL,
 
       created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
       updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
@@ -106,6 +108,12 @@ function getChatDb(agentDir) {
   `);
   try {
     db.prepare('ALTER TABLE chat_messages ADD COLUMN success INTEGER DEFAULT NULL').run();
+  } catch {}
+  try {
+    db.prepare('ALTER TABLE chat_sessions ADD COLUMN selected_key_id TEXT DEFAULT NULL').run();
+  } catch {}
+  try {
+    db.prepare('ALTER TABLE chat_sessions ADD COLUMN selected_model TEXT DEFAULT NULL').run();
   } catch {}
 
   return db;
@@ -130,10 +138,16 @@ export function listSessions(agentDir) {
   }
 }
 
-export function createSession(agentDir, title) {
+export function createSession(agentDir, title, opts = {}) {
   const db = getChatDb(agentDir);
   try {
-    const result = db.prepare('INSERT INTO chat_sessions (title) VALUES (?)').run(title || 'New Chat');
+    const selectedKeyId = typeof opts.selectedKeyId === 'string' && opts.selectedKeyId.trim() ? opts.selectedKeyId.trim() : null;
+    const selectedModel = typeof opts.selectedModel === 'string' && opts.selectedModel.trim() ? opts.selectedModel.trim() : null;
+    const result = db.prepare('INSERT INTO chat_sessions (title, selected_key_id, selected_model) VALUES (?, ?, ?)').run(
+      title || 'New Chat',
+      selectedKeyId,
+      selectedModel,
+    );
     return db.prepare('SELECT * FROM chat_sessions WHERE id = ?').get(result.lastInsertRowid);
   } finally {
     db.close();
@@ -157,6 +171,24 @@ export function deleteSession(agentDir, chatId) {
   try {
     db.prepare('DELETE FROM chat_messages WHERE session_id = ?').run(chatId);
     db.prepare('DELETE FROM chat_sessions WHERE id = ?').run(chatId);
+  } finally {
+    db.close();
+  }
+}
+
+export function updateSessionPreferences(agentDir, chatId, opts = {}) {
+  const db = getChatDb(agentDir);
+  try {
+    const selectedKeyId = typeof opts.selectedKeyId === 'string' && opts.selectedKeyId.trim() ? opts.selectedKeyId.trim() : null;
+    const selectedModel = typeof opts.selectedModel === 'string' && opts.selectedModel.trim() ? opts.selectedModel.trim() : null;
+    db.prepare(`
+      UPDATE chat_sessions
+      SET selected_key_id = ?,
+          selected_model = ?,
+          updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+      WHERE id = ?
+    `).run(selectedKeyId, selectedModel, chatId);
+    return db.prepare('SELECT * FROM chat_sessions WHERE id = ?').get(chatId);
   } finally {
     db.close();
   }

--- a/src/providers/pi-ai-adapter.js
+++ b/src/providers/pi-ai-adapter.js
@@ -72,7 +72,14 @@ export function resolveModel(rawModel, providerOverride = null) {
       providerName: 'custom',
     };
   }
-  const { provider, modelId } = parseTBCModel(rawModel);
+
+  const hasExplicitProviderPrefix = ['openai-codex/', 'openai/', 'google/', 'minimax/', 'anthropic/']
+    .some(prefix => rawModel.startsWith(prefix));
+
+  const { provider, modelId } = hasExplicitProviderPrefix || !providerOverride
+    ? parseTBCModel(rawModel)
+    : { provider: providerOverride, modelId: rawModel };
+
   const piModel = getModel(provider, modelId);
   return { piModel, providerName: provider };
 }

--- a/src/server.js
+++ b/src/server.js
@@ -14,7 +14,7 @@ import { spawn, execSync } from 'child_process';
 import yaml from 'js-yaml';
 import Database from 'better-sqlite3';
 import { runAgentWithAPI } from './agent-runner.js';
-import { listSessions as chatListSessions, createSession as chatCreateSession, getSession as chatGetSession, deleteSession as chatDeleteSession, streamChatMessage, getActiveStream, isStreaming as isChatStreaming, saveMessage as chatSaveMessage } from './chat.js';
+import { listSessions as chatListSessions, createSession as chatCreateSession, getSession as chatGetSession, deleteSession as chatDeleteSession, updateSessionPreferences as chatUpdateSessionPreferences, streamChatMessage, getActiveStream, isStreaming as isChatStreaming, saveMessage as chatSaveMessage } from './chat.js';
 import { resolveModel, callModel, buildUserMessage, getModels as getPiModels } from './providers/index.js';
 import { buildCustomTierMap, resolveProviderRuntime } from './providers/custom-config.js';
 import { startOAuthLogin, submitManualCode, checkOAuthStatus, getAccessToken as getOAuthAccessToken, clearCredentials as clearOAuthCredentials, listOAuthProviders, loadCredentials as loadOAuthCredentials } from './oauth.js';
@@ -3959,7 +3959,10 @@ const server = http.createServer(async (req, res) => {
       req.on('end', () => {
         try {
           const data = body ? JSON.parse(body) : {};
-          const session = chatCreateSession(runner.chatsDir, data.title);
+          const session = chatCreateSession(runner.chatsDir, data.title, {
+            selectedKeyId: typeof data.selectedKeyId === 'string' ? data.selectedKeyId : null,
+            selectedModel: typeof data.selectedModel === 'string' ? data.selectedModel : null,
+          });
           res.writeHead(201, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ session }));
         } catch (e) {
@@ -3992,6 +3995,35 @@ const server = http.createServer(async (req, res) => {
         res.writeHead(500, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ error: e.message }));
       }
+      return;
+    }
+
+    // PATCH /api/projects/:id/chats/:chatId/preferences — persist session key/model selection
+    const chatPreferencesMatch = req.method === 'PATCH' && subPath.match(/^chats\/(\d+)\/preferences$/);
+    if (chatPreferencesMatch) {
+      if (!requireWrite(req, res)) return;
+      let body = '';
+      req.on('data', chunk => body += chunk);
+      req.on('end', () => {
+        try {
+          const data = body ? JSON.parse(body) : {};
+          const chatId = parseInt(chatPreferencesMatch[1]);
+          const session = chatUpdateSessionPreferences(runner.chatsDir, chatId, {
+            selectedKeyId: typeof data.selectedKeyId === 'string' && data.selectedKeyId !== 'auto' ? data.selectedKeyId : null,
+            selectedModel: typeof data.selectedModel === 'string' && data.selectedModel !== 'auto' ? data.selectedModel : null,
+          });
+          if (!session) {
+            res.writeHead(404, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'Session not found' }));
+            return;
+          }
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ session }));
+        } catch (e) {
+          res.writeHead(500, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: e.message }));
+        }
+      });
       return;
     }
 
@@ -4158,6 +4190,11 @@ const server = http.createServer(async (req, res) => {
           const selectedKeySafe = explicitKeyId
             ? (getKeyPoolSafe().keys || []).find(key => key.id === explicitKeyId) || null
             : null;
+
+          chatUpdateSessionPreferences(runner.chatsDir, chatId, {
+            selectedKeyId: explicitKeyId,
+            selectedModel: explicitModel,
+          });
           if (explicitKeyId && !selectedKeySafe) {
             respondChatError(404, { error: 'Selected API key was not found.', errorType: 'key_not_found', source: 'local_selection' });
             return;


### PR DESCRIPTION
## Summary
- avoid replacing chat message state when poll responses are display-equivalent
- preserve the user's current scroll position while background chat polling runs
- add a Playwright regression test for the chat panel scroll jump

## Testing
- npm test -- chat-scroll-autoscroll-repro.spec.js chat-to-issue-panel-switch.spec.js disabled-key-warning.spec.js