### PR TITLE
fix: cap agent tool memory usage

### DIFF
--- a/agent/everyone.md
+++ b/agent/everyone.md
@@ -4,6 +4,13 @@
 
 **Complete the project with passing standard quality, with minimum human involvement.** Work autonomously. Make decisions. Solve problems.
 
+## Your Task
+
+1. **Review your own open issues.** Check whether they have already been resolved or are no longer relevant, and close them when appropriate.
+2. **Do the work assigned to you.** Follow the responsibilities in your own skill file and prompt.
+3. **Stay engaged on issues you are involved in.** If you check status, comment. If you make progress, comment. If you have questions, comment.
+4. **Raise new issues when needed.** If you suspect a problem, create an issue.
+
 ## Shared Knowledge
 
 - There is a private shared knowledge base under `knowledge/`.

--- a/agent/manager.md
+++ b/agent/manager.md
@@ -71,6 +71,8 @@ List `{project_dir}/skills/workers/`. Only workers with `reports_to: <your_name>
 
 Read `{project_dir}/agents/{agent_name}/note.md` for each of your workers to understand their current state before assigning tasks.
 
+Also check for open issues created by your team members. Even if an agent has no current task, ask them to review the status of their own open issues, unless you already know the issue could not reasonably have been addressed yet.
+
 ### Manage Your Team
 
 If the team lacks skills or a worker is ineffective, you can:

--- a/src/agent-runner.js
+++ b/src/agent-runner.js
@@ -326,6 +326,8 @@ function globFiles(pattern, cwd) {
 // ---------------------------------------------------------------------------
 // Grep implementation
 // ---------------------------------------------------------------------------
+const MAX_TEXT_TOOL_FILE_BYTES = 2 * 1024 * 1024;
+
 function grepFiles(pattern, searchPath, options = {}) {
   const results = [];
   const isDir = fs.statSync(searchPath).isDirectory();
@@ -333,6 +335,10 @@ function grepFiles(pattern, searchPath, options = {}) {
 
   function searchFile(filePath) {
     try {
+      const stat = fs.statSync(filePath);
+      if (!stat.isFile() || stat.size > MAX_TEXT_TOOL_FILE_BYTES) {
+        return;
+      }
       const content = fs.readFileSync(filePath, 'utf-8');
       const lines = content.split('\n');
       for (let i = 0; i < lines.length; i++) {
@@ -526,11 +532,11 @@ function executeBash(input, cwd, remainingMs = 0, bashEnv = null, runtime = null
     proc.unref();  // don't keep the event loop alive
     runtime?.registerProcess?.(proc);
 
-    let stdout = '';
-    let stderr = '';
+    const stdout = createCappedOutputBuffer();
+    const stderr = createCappedOutputBuffer();
     let settled = false;
-    proc.stdout.on('data', (d) => { stdout += d; });
-    proc.stderr.on('data', (d) => { stderr += d; });
+    proc.stdout.on('data', (d) => { stdout.append(d); });
+    proc.stderr.on('data', (d) => { stderr.append(d); });
 
     const killProc = (signal) => {
       // Kill the entire process group (negative pid) to catch grandchildren
@@ -554,13 +560,12 @@ function executeBash(input, cwd, remainingMs = 0, bashEnv = null, runtime = null
       runtime?.signal?.removeEventListener('abort', onAbort);
       runtime?.unregisterProcess?.(proc);
       let result = '';
-      if (stdout) result += stdout;
-      if (stderr) result += (result ? '\n' : '') + stderr;
+      const stdoutText = stdout.toString();
+      const stderrText = stderr.toString();
+      if (stdoutText) result += stdoutText;
+      if (stderrText) result += (result ? '\n' : '') + stderrText;
       if (code !== 0 && code !== null) {
         result += `\nExit code: ${code}`;
-      }
-      if (result.length > 100000) {
-        result = result.slice(0, 50000) + '\n\n... (output truncated) ...\n\n' + result.slice(-50000);
       }
       if (sandboxProfilePath) {
         try { fs.rmSync(path.dirname(sandboxProfilePath), { recursive: true, force: true }); } catch {}
@@ -596,6 +601,74 @@ function executeBash(input, cwd, remainingMs = 0, bashEnv = null, runtime = null
   });
 }
 
+const MAX_BASH_STREAM_OUTPUT_CHARS = 100000;
+const BASH_OUTPUT_HEAD_CHARS = 50000;
+const BASH_OUTPUT_TAIL_CHARS = 50000;
+const BASH_OUTPUT_TRUNCATION_MARKER = '\n\n... (output truncated) ...\n\n';
+const MAX_TOOL_RESULT_MESSAGE_CHARS = 12000;
+const TOOL_RESULT_DISPLAY_CHARS = 4000;
+
+function truncateForModel(text, maxChars = MAX_TOOL_RESULT_MESSAGE_CHARS) {
+  if (typeof text !== 'string') return JSON.stringify(text);
+  if (text.length <= maxChars) return text;
+  const headChars = Math.ceil(maxChars * 0.6);
+  const tailChars = Math.max(0, maxChars - headChars);
+  return `${text.slice(0, headChars)}${BASH_OUTPUT_TRUNCATION_MARKER}${tailChars > 0 ? text.slice(-tailChars) : ''}`;
+}
+
+function createCappedOutputBuffer(maxChars = MAX_BASH_STREAM_OUTPUT_CHARS) {
+  const headChars = Math.min(BASH_OUTPUT_HEAD_CHARS, maxChars);
+  const tailChars = Math.max(0, maxChars - headChars);
+  let full = '';
+  let head = '';
+  let tail = '';
+  let truncated = false;
+
+  return {
+    append(chunk) {
+      if (!chunk) return;
+      const text = typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+      if (!text) return;
+
+      if (!truncated) {
+        if (full.length + text.length <= maxChars) {
+          full += text;
+          return;
+        }
+
+        truncated = true;
+        head = full.slice(0, headChars);
+        const headFromChunk = Math.max(0, headChars - head.length);
+        if (headFromChunk > 0) {
+          head += text.slice(0, headFromChunk);
+        }
+        if (tailChars > 0) {
+          if (text.length >= tailChars) {
+            tail = text.slice(-tailChars);
+          } else {
+            const carry = Math.max(0, tailChars - text.length);
+            tail = full.slice(-carry) + text;
+          }
+        }
+        full = '';
+        return;
+      }
+
+      if (tailChars <= 0) return;
+      if (text.length >= tailChars) {
+        tail = text.slice(-tailChars);
+        return;
+      }
+      const carry = Math.max(0, tailChars - text.length);
+      tail = tail.slice(-carry) + text;
+    },
+    toString() {
+      if (!truncated) return full;
+      return `${head}${BASH_OUTPUT_TRUNCATION_MARKER}${tail}`;
+    },
+  };
+}
+
 function executeRead(input, cwd, allowedPaths = null) {
   let filePath = input.file_path;
   if (!filePath || typeof filePath !== 'string') return 'Error: file_path is required and must be a string';
@@ -603,6 +676,11 @@ function executeRead(input, cwd, allowedPaths = null) {
   if (isRawDbPath(filePath, allowedPaths)) return 'Error: raw project database access is not allowed. Use tbc-db CLI.';
   if (!isPathAllowed(filePath, allowedPaths, 'read')) return `Error: access denied for ${filePath}`;
   try {
+    const stat = fs.statSync(filePath);
+    if (!stat.isFile()) return `Error reading file: ${filePath} is not a regular file`;
+    if (stat.size > MAX_TEXT_TOOL_FILE_BYTES) {
+      return `Error reading file: ${filePath} is too large for the Read tool (${stat.size} bytes > ${MAX_TEXT_TOOL_FILE_BYTES} byte limit)`;
+    }
     const content = fs.readFileSync(filePath, 'utf-8');
     const lines = content.split('\n');
     const offset = (input.offset || 1) - 1;
@@ -1101,8 +1179,9 @@ export async function runAgentWithAPI(opts) {
 
           const remainingMs = timeoutMs > 0 ? Math.max(0, timeoutMs - (Date.now() - startTime)) : 0;
           const normalized = await executeToolDetailed(tc.name, tc.input, cwd, remainingMs, bashEnv, runtime, allowedRepo, allowedPaths, issuePolicy);
-          toolResults.push({ toolCallId: tc.id, toolName: tc.name, content: normalized.output });
-          const displayOutput = normalized.output.length > 4000 ? normalized.output.slice(0, 4000) + '\n... (truncated)' : normalized.output;
+          const modelOutput = truncateForModel(normalized.output);
+          toolResults.push({ toolCallId: tc.id, toolName: tc.name, content: modelOutput });
+          const displayOutput = modelOutput.length > TOOL_RESULT_DISPLAY_CHARS ? modelOutput.slice(0, TOOL_RESULT_DISPLAY_CHARS) + '\n... (truncated)' : modelOutput;
           onEvent({ type: 'tool_result', id: tc.id, name: tc.name, output: displayOutput, exitCode: normalized.exitCode, ok: normalized.ok });
         }
 

--- a/tests/bash-output-buffer-cap.test.js
+++ b/tests/bash-output-buffer-cap.test.js
@@ -1,0 +1,40 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { executeToolDetailed } from '../src/agent-runner.js';
+
+const TRUNCATION_MARKER = '\n\n... (output truncated) ...\n\n';
+
+describe('bash output buffering', () => {
+  it('caps stdout while streaming and preserves head and tail output', async () => {
+    const result = await executeToolDetailed(
+      'Bash',
+      {
+        command: `node -e "process.stdout.write('A'.repeat(60000)); process.stdout.write('B'.repeat(60000));"`,
+      },
+      process.cwd(),
+    );
+
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.ok, true);
+    assert.equal(result.output.length, 50000 + TRUNCATION_MARKER.length + 50000);
+    assert.ok(result.output.startsWith('A'.repeat(50000)));
+    assert.ok(result.output.includes(TRUNCATION_MARKER));
+    assert.ok(result.output.endsWith('B'.repeat(50000)));
+  });
+
+  it('preserves stdout then stderr formatting and appends exit code after capped stderr', async () => {
+    const result = await executeToolDetailed(
+      'Bash',
+      {
+        command: `node -e "process.stdout.write('stdout-head'); process.stderr.write('E'.repeat(60000)); process.stderr.write('F'.repeat(60000)); process.exit(7);"`,
+      },
+      process.cwd(),
+    );
+
+    assert.equal(result.exitCode, 7);
+    assert.equal(result.ok, false);
+    assert.ok(result.output.startsWith(`stdout-head\n${'E'.repeat(50000)}`));
+    assert.ok(result.output.includes(TRUNCATION_MARKER));
+    assert.ok(result.output.endsWith(`${'F'.repeat(50000)}\nExit code: 7`));
+  });
+});


### PR DESCRIPTION
## Summary
- cap Bash tool stdout/stderr buffering while streaming
- cap tool results before they are replayed into model context
- refuse oversized Read/Grep file loads and add regression tests

## Testing
- node --test tests/bash-output-buffer-cap.test.js