### PR TITLE
feat: tighten visibility and expand Themis orchestration

### DIFF
--- a/agent/manager.md
+++ b/agent/manager.md
@@ -148,9 +148,9 @@ Insert `{"delay": N}` steps wherever you need a pause (waiting for CI, builds, e
 You can control what each worker sees by adding `visibility` to each agent step:
 
 **Three levels:**
-- **`full`** (default): Worker can see all issues, comments, and reports via `tbc-db`
-- **`focused`**: Worker can only see issues mentioned in the task (e.g., `#42`). All other issues are hidden. Good for keeping workers on-task without distractions.
-- **`blind`**: Worker cannot access the tracker at all and cannot read agent notes. They only see the task description and the repo code. Good for independent verification — the worker must evaluate on their own without seeing prior discussion. Do not assign an issue to blind workers — they cannot access it.
+- **`full`** (default): Worker can see the issue board, PR board, shared knowledge, and their own notes.
+- **`focused`**: Worker cannot see the issue board or PR board, but can still read shared knowledge and their own notes. They still can create a new issue or TBC PR record if needed.
+- **`blind`**: Worker cannot see the issue board or PR board, cannot read shared knowledge, and cannot read any notes, including their own. They only get the task description and the repo. They still can create a new issue or TBC PR record if needed. Use this for independent verification when you want the worker to reason only from the task and code.
 
 ## PRs
 

--- a/agent/managers/athena.md
+++ b/agent/managers/athena.md
@@ -56,29 +56,36 @@ Feel free to adjust the roadmap as you learn more. If a milestone turns out to b
 
 ## Your Cycle
 
-### Phase 1: Evaluate, Critic, Research, Brainstorm
+### Phase 1: Evaluate Current Status
 
-**First, check the project state yourself:**
+Check the current project state yourself:
 - Run `tbc-db issue-list` to see all open issues — are there stale issues? Misassigned ones? Issues that should be closed?
 - Read worker reports: check `{project_dir}/agents/{agent_name}/note.md` for each worker and `{project_dir}/responses/` for recent agent logs
 - Check open TBC PRs with `tbc-db pr-list` — are there drafts or review items that should be advanced or closed?
 - Check the repo state: `git log --oneline -10`, test results, CI status
 
-Then schedule (and hire) workers to dig deeper into areas that need investigation.
- 
+You should not trust what other agents say. Do your own evaluation.
+
+**Issue closure review workflow:**
+- If you think an open issue may be closable, do **not** close it immediately in the same cycle.
+- In this phase, launch **one blind worker per candidate issue** to independently evaluate whether the issue should be closed.
+- Because the worker cannot see the issue, your task must include the exact closing criteria in the task text: summarize the issue claim, what evidence would count as resolved, what files/tests/behaviors to inspect, and what would keep the issue open.
+- In this closure-review cycle, do **not** provide a milestone yet. Use the cycle to gather blind opinions only.
+- In the **next Athena cycle**, read those blind worker opinions, do your own review, and then decide if the issue can be closed.
+
+### Phase 2: Research and Investigation
+
+If more information is needed, schedule (and hire) workers to investigate specific areas.
+
 Your workers should work in blind mode — set `"visibility": "blind"` on each agent step:
 
 ```json
 {"agent": "leo", "task": "Investigate the auth module", "visibility": "blind"}
 ```
 
-You should also not trust what other agents say. Do your own evaluation.
+If you schedule any agents in the current cycle, you must **not** provide a milestone in that same cycle. Use the cycle to gather information only, then read the reports in a later cycle before deciding the next milestone.
 
-Once you have your own workers' report read worker reports. 
-
-You don't have to output a milestone every cycle — gather info first, then define the immediate milestone when you are fully ready.
-
-### Phase 2: Reconsider Specs and Roadmap
+### Phase 3: Reconsider Specs and Roadmap
 
 Before deciding the next milestone, check if the project's direction needs updating:
 
@@ -87,7 +94,7 @@ Before deciding the next milestone, check if the project's direction needs updat
 
 If nothing changed, move on.
 
-### Phase 3: Decide Next Immediate Milestone
+### Phase 4: Decide Next Immediate Milestone
 
 When you are ready, identify the milestone. But do not output it yet. Create a `tbc-db` issue first. 
 
@@ -95,7 +102,7 @@ Hire workers to write acceptance tests for the milestone if needed. Review their
 
 You do not have to follow the exiting roadmap if you think of a better milestone. Always evaluate the relative position of the current repo and human's eventual goal.
 
-### Phase 4: Output Milestone When You are Fully Ready
+### Phase 5: Output Milestone When You are Fully Ready
 
 When you are ready, output the next milestone for Ares's team. 
 

--- a/agent/managers/themis.md
+++ b/agent/managers/themis.md
@@ -6,11 +6,11 @@ role: Final Examiner
 
 You are Themis, the final project examiner.
 
-A project completion claim has been made. Your job is to decide whether the project is **truly complete**.
+A project completion claim has been made. Your job is to decide whether the project is truly complete.
 
 ## Core Responsibility
 
-Evaluate whether the **entire project** is truly complete.
+Evaluate whether the entire project is truly complete.
 
 Do not only judge whether the explicit human request was roughly met. Judge the whole project:
 - correctness
@@ -21,33 +21,71 @@ Do not only judge whether the explicit human request was roughly met. Judge the 
 - docs/artifacts consistency
 - unfinished rough edges that would make the project not actually done
 
-Your standard is **perfect and flawless**. Only pass the project if it is truly complete, correct, polished, and free of meaningful problems. If there is any meaningful flaw, gap, risk, inconsistency, regression, missing artifact, missing documentation, or unfinished edge, reject completion.
+Your standard is perfect and flawless. Only pass the project if it is truly complete, correct, polished, and free of meaningful problems. If there is any meaningful flaw, gap, risk, inconsistency, regression, missing artifact, missing documentation, or unfinished edge, reject completion.
 
-## Hard Constraints
+Before passing, your team must examine the entire project with exhaustive care, including every relevant file and every relevant line. Do not treat a partial spot check as sufficient evidence for `EXAM_PASS`.
 
-- Do **not** hire workers.
-- Do **not** schedule workers.
-- Do **not** delegate.
-- Do **not** read issue tracker contents.
-- Do **not** rely on communication history.
-- Do **not** inspect other agents' private agent notes.
+## Operating Mode
 
-You work alone.
+- You run in full view, not blind.
+- You may inspect the repository, issue tracker, PR board, shared knowledge, and agent notes.
+- You may hire workers, retune workers, and schedule workers.
+- Only workers with `reports_to: themis` are on your team.
+- Your team is independent from the Athena, Ares, and Apollo teams. Do your own review from primary evidence.
+- You may take multiple cycles to finish the examination. Do not rush to a verdict.
 
-Inspect the repository, tests, generated artifacts, and any obvious project-wide signals available from the repo itself.
+## Examination Cycle
+
+### 1. Assess current evidence
+
+Review the completion claim, repository state, tracker state, reports, tests, and any prior Themis-team findings.
+
+### 2. Build or adjust your team
+
+If you need more coverage, hire or retune workers in `{project_dir}/skills/workers/` and schedule only workers who report to you.
+
+When running a serious completion review, launch dedicated workers to answer these core questions independently:
+- Is the project complete?
+- Is the project production ready?
+- Are all human issues addressed? (use a full-view worker for this question)
+- Are all PRs merged or closed? (use a full-view worker for this question)
+- Are all agent issues addressed and closed? (use a full-view worker for this question)
+- Is CI passing?
+- Are there files that should not be there?
+- Are there code files that suggest the project was written by TBC agents rather than a human? The source code itself should read as if written by a human engineer.
+
+Use at least one worker per question. For blind workers, because they cannot see the issue board, PR board, notes, or shared knowledge, describe the checking criteria directly in each task. Tell them exactly what evidence to inspect in the repo, tests, artifacts, CI signals, user-facing behavior, file layout, and code style, and what findings would count as a fail.
+
+### 3. Decide or continue
+
+When you need more investigation, emit a schedule and stay in examination.
+
+When the project is complete, emit `EXAM_PASS`.
+
+When the project is not complete, emit `EXAM_FAIL` with concrete blockers and issue suggestions when useful.
+
+## If you need more investigation
+
+Return:
+
+<!-- SCHEDULE -->
+[
+  {"agent": "maya", "task": "Blind completion review: determine whether the project is complete. Inspect the repository, tests, and shipped artifacts only. Check every relevant file and every relevant line needed to support your conclusion. Report concrete evidence for anything missing, inconsistent, or unfinished.", "visibility": "blind"},
+  {"agent": "nora", "task": "Blind production-readiness review: determine whether the project is production ready. Inspect implementation quality, error handling, configuration, operational risks, release artifacts, and test evidence. Check every relevant file and every relevant line needed to support your conclusion. Report concrete blockers.", "visibility": "blind"}
+]
+<!-- /SCHEDULE -->
 
 ## If the project is complete
+Only use this if you are fully confident. If you are not fully confident, go back to issuing more agents to check.
+
 Return exactly:
 
 <!-- EXAM_PASS -->
-{"message":"Project completion confirmed."}
+{"message":"My team has checked the whole repo, every relevant file, and every relevant line, and we find it flawless. Not a single line should be improved. The project is fully completed and production ready."}
 <!-- /EXAM_PASS -->
 
 ## If the project is NOT complete
-Do **not** emit `EXAM_PASS`.
-Any non-pass output will be treated as failure.
-
-Explain clearly what is still wrong. If helpful, you may include a structured failure block:
+Return:
 
 <!-- EXAM_FAIL -->
 {
@@ -63,3 +101,14 @@ Explain clearly what is still wrong. If helpful, you may include a structured fa
 <!-- /EXAM_FAIL -->
 
 Only include issues for meaningful blockers. No nits.
+
+## Rules
+
+- Be extremely strict.
+- Do not rely on other teams' conclusions without checking the evidence yourself.
+- Do not schedule workers outside your team.
+- For pass decisions, require exhaustive coverage. If you or your team have not examined the full project deeply enough, keep investigating.
+- If you are not confident saying the full `EXAM_PASS` claim without reservation, do not pass. Go back to scheduling more agents to find issues.
+- Use blind workers for independent judgment questions, and write their tasks so they can evaluate without tracker or note access.
+- If you schedule workers in this cycle, do not also emit `EXAM_PASS` or `EXAM_FAIL` unless you are intentionally overriding the need for more work.
+- Before finishing, make sure your response includes exactly one actionable tag: `<!-- SCHEDULE -->`, `<!-- EXAM_PASS -->`, or `<!-- EXAM_FAIL -->`.

--- a/bin/tbc-db.js
+++ b/bin/tbc-db.js
@@ -145,6 +145,14 @@ function normalizePrStatus(status) {
   throw new Error(`Invalid PR status: ${status}. Allowed: open, merged, closed`);
 }
 
+function resolveAllowedIssueCloser(issueCreator) {
+  if (issueCreator === 'human' || issueCreator === 'chat') {
+    return { allowed: new Set(['human', 'chat']), special: 'chat-human' };
+  }
+
+  return { allowed: new Set([issueCreator, 'athena']), special: 'agent-athena' };
+}
+
 function jsonOut(data) {
   console.log(JSON.stringify(data, null, 2));
 }
@@ -275,13 +283,13 @@ const commands = {
     if (!issue) { console.error(`Issue #${id} not found`); process.exit(1); }
     if (issue.status === 'closed') { console.log(`Issue #${id} already closed`); return; }
     const closer = actor;
-    if (issue.creator === 'human') {
-      if (closer !== 'human') {
-        console.error(`Blocked: issue #${id} was opened by human and can only be closed by human`);
-        process.exit(1);
+    const { allowed, special } = resolveAllowedIssueCloser(issue.creator);
+    if (!allowed.has(closer)) {
+      if (special === 'chat-human') {
+        console.error(`Blocked: issue #${id} was opened by ${issue.creator} and can only be closed by chat or human`);
+      } else {
+        console.error(`Blocked: issue #${id} was opened by ${issue.creator} and can only be closed by ${issue.creator} or athena`);
       }
-    } else if (closer !== issue.creator) {
-      console.error(`Blocked: issue #${id} was opened by ${issue.creator} and can only be closed by that same agent`);
       process.exit(1);
     }
     const now = new Date().toISOString();

--- a/bin/tbc-db.js
+++ b/bin/tbc-db.js
@@ -125,15 +125,14 @@ const args = process.argv.slice(3);
 const visibility = process.env.TBC_VISIBILITY || 'full';
 const focusedIssues = (process.env.TBC_FOCUSED_ISSUES || '').split(',').map(s => s.trim()).filter(Boolean);
 
-if (visibility === 'blind') {
-  // Blind agents cannot use tbc-db at all (except issue-create for escalation)
-  if (command && command !== 'issue-create') {
-    console.error('Access denied: you are in blind mode and cannot query the tracker.');
+if (visibility === 'blind' || visibility === 'focused') {
+  const allowedCommands = new Set(['issue-create', 'pr-create']);
+  if (command && !allowedCommands.has(command)) {
+    const scope = visibility === 'blind' ? 'blind' : 'focused';
+    console.error(`Access denied: you are in ${scope} mode and cannot view the issue tracker or PR board.`);
     process.exit(1);
   }
 }
-
-// For focused mode, we filter after query execution (see below)
 
 const VALID_PR_STATUSES = new Set(['open', 'merged', 'closed']);
 

--- a/src/agent-runner.js
+++ b/src/agent-runner.js
@@ -160,15 +160,13 @@ function checkIssueAccessInCommand(command, issuePolicy = null) {
   if (mode === 'full') return null;
 
   if (mode === 'blind') {
-    if (parsed.kind === 'pr-create' || parsed.kind === 'pr-edit') return null;
-    return 'Blocked: blind mode cannot access the issue tracker. Work only from the task and repository.';
+    if (parsed.kind === 'issue-create' || parsed.kind === 'pr-create') return null;
+    return 'Blocked: blind mode cannot view the issue tracker or PR board. Work only from the task and repository; you may still create a new issue or PR record if needed.';
   }
 
   if (mode === 'focused') {
-    if (parsed.kind === 'issue-create') return null;
-    if (parsed.kind === 'comment' || parsed.kind === 'issue-edit' || parsed.kind === 'issue-close') return null;
-    if (parsed.kind?.startsWith('pr-')) return null;
-    return 'Blocked: focused mode cannot read the issue tracker. Work from the task, repository, and your own notes; comments/edits are allowed, and use issue-create only for new blockers/findings.';
+    if (parsed.kind === 'issue-create' || parsed.kind === 'pr-create') return null;
+    return 'Blocked: focused mode cannot view the issue tracker or PR board. Work from the task, repository, shared knowledge, and your own notes; you may still create a new issue or PR record if needed.';
   }
 
   return null;

--- a/src/server.js
+++ b/src/server.js
@@ -1548,12 +1548,16 @@ class ProjectRunner {
     }
   }
 
-  async executeSchedule(schedule, config) {
+  async executeSchedule(schedule, config, managerName = null) {
     if (!schedule || !schedule._steps) return { total: 0, failures: 0 };
     
     let total = 0;
     let failures = 0;
-    const freshWorkers = this.loadAgents().workers;
+    const ownerName = typeof managerName === 'string' ? managerName.toLowerCase() : null;
+    const freshWorkers = this.loadAgents().workers.filter(worker => {
+      if (!ownerName) return true;
+      return (worker.reportsTo || '').toLowerCase() === ownerName;
+    });
     
     for (const step of schedule._steps) {
       if (!this.running || this.abortCurrentCycle) break;
@@ -1761,7 +1765,7 @@ class ProjectRunner {
           if (schedule) {
             this.currentSchedule = schedule;
             this.saveState(); // Persist schedule before execution so it survives reboot
-            const { total, failures } = await this.executeSchedule(schedule, config);
+            const { total, failures } = await this.executeSchedule(schedule, config, 'athena');
             cycleTotal += total;
             cycleFailures += failures;
           }
@@ -1783,7 +1787,7 @@ class ProjectRunner {
         // Note: don't require completedAgents — schedule may start with a delay step
         if (this.currentSchedule) {
           log(`Resuming interrupted schedule (${this.completedAgents.length} agents already completed${this.completedAgents.length ? ': [' + this.completedAgents.join(', ') + ']' : ''})`, this.id);
-          const { total, failures } = await this.executeSchedule(this.currentSchedule, config);
+          const { total, failures } = await this.executeSchedule(this.currentSchedule, config, 'ares');
           cycleTotal += total;
           cycleFailures += failures;
           this.currentSchedule = null;
@@ -1825,7 +1829,7 @@ class ProjectRunner {
           if (schedule) {
             this.completedAgents = [];
             this.saveState(); // Persist schedule before execution so it survives reboot
-            const { total, failures } = await this.executeSchedule(schedule, config);
+            const { total, failures } = await this.executeSchedule(schedule, config, 'ares');
             cycleTotal += total;
             cycleFailures += failures;
             this.currentSchedule = null;
@@ -1848,7 +1852,7 @@ class ProjectRunner {
         // Resume interrupted verification schedule (e.g. after reboot)
         if (this.currentSchedule && this.completedAgents.length > 0) {
           log(`Resuming interrupted verification schedule (${this.completedAgents.length} agents already completed: [${this.completedAgents.join(', ')}])`, this.id);
-          const { total, failures } = await this.executeSchedule(this.currentSchedule, config);
+          const { total, failures } = await this.executeSchedule(this.currentSchedule, config, 'apollo');
           cycleTotal += total;
           cycleFailures += failures;
           this.currentSchedule = null;
@@ -1893,7 +1897,7 @@ class ProjectRunner {
             this.currentSchedule = schedule;
             this.completedAgents = [];
             this.saveState(); // Persist schedule before execution so it survives reboot
-            const { total, failures } = await this.executeSchedule(schedule, config);
+            const { total, failures } = await this.executeSchedule(schedule, config, 'apollo');
             cycleTotal += total;
             cycleFailures += failures;
             this.currentSchedule = null;
@@ -1934,16 +1938,32 @@ class ProjectRunner {
 
       // ===== PHASE: EXAMINATION (Themis final audit) =====
       else if (this.phase === 'examination') {
+        // Resume interrupted examination schedule (e.g. after reboot)
+        if (this.currentSchedule) {
+          log(`Resuming interrupted examination schedule (${this.completedAgents.length} agents already completed${this.completedAgents.length ? ': [' + this.completedAgents.join(', ') + ']' : ''})`, this.id);
+          const { total, failures } = await this.executeSchedule(this.currentSchedule, config, 'themis');
+          cycleTotal += total;
+          cycleFailures += failures;
+          this.currentSchedule = null;
+          this.completedAgents = [];
+          this.saveState();
+        } else {
         const themis = managers.find(m => m.name === 'themis');
         if (themis) {
           const themisContext = `> **Final completion claim:** ${this.pendingCompletionMessage || 'Project claimed complete'}\n> **Evaluate the entire project, not just the human\'s explicit goal.** Audit correctness, completeness, maintainability, artifacts, tests, docs, and obvious risks.\n\n`;
-          const result = await this.runAgent(themis, config, null, themisContext, { mode: 'blind', issues: [] });
+          const result = await this.runAgent(themis, config, null, themisContext, { mode: 'full', issues: [] });
           cycleTotal++;
           if (!result || !result.success) cycleFailures++;
 
-          let decision = 'fail';
+          let schedule = null;
+          let decision = null;
           let failData = null;
           if (result && result.resultText) {
+            schedule = this.parseSchedule(result.resultText);
+            if (schedule) {
+              log(`Schedule: ${JSON.stringify(schedule)}`, this.id);
+            }
+
             if (result.resultText.includes('<!-- EXAM_PASS -->')) {
               decision = 'pass';
             }
@@ -1954,7 +1974,22 @@ class ProjectRunner {
               } catch {
                 failData = { feedback: 'Themis rejected project completion, but the response could not be parsed.' };
               }
+              decision = 'fail';
+            } else if (!schedule) {
+              decision = 'fail';
             }
+          }
+
+          if (schedule) {
+            this.currentSchedule = schedule;
+            this.completedAgents = [];
+            this.saveState();
+            const { total, failures } = await this.executeSchedule(schedule, config, 'themis');
+            cycleTotal += total;
+            cycleFailures += failures;
+            this.currentSchedule = null;
+            this.completedAgents = [];
+            this.saveState();
           }
 
           if (decision === 'pass') {
@@ -1973,7 +2008,7 @@ class ProjectRunner {
             });
             log(`🏁 PROJECT COMPLETE (validated by Themis): ${message}`, this.id);
             broadcastEvent({ type: 'project-complete', project: this.id, success: true, message });
-          } else {
+          } else if (decision === 'fail') {
             let issues = Array.isArray(failData?.issues) ? failData.issues : [];
             const rawFeedback = (result?.resultText || '').trim();
             if (issues.length === 0) {
@@ -2009,8 +2044,12 @@ class ProjectRunner {
             });
             log(`❌ Themis rejected project completion — returning to Athena`, this.id);
             broadcastEvent({ type: 'phase', project: this.id, phase: 'athena', title: this.milestoneTitle || 'Replanning after Themis rejection' });
+          } else {
+            // No decision yet, stay in examination phase — still save
+            this.saveState();
           }
         }
+        } // end else (no interrupted examination schedule)
       }
 
       // If no agent succeeded, don't count this cycle
@@ -2070,7 +2109,7 @@ class ProjectRunner {
       read.push(ownWorkspaceDir);
       write.push(ownWorkspaceDir);
     }
-    if (agent.isManager && agent.name !== 'themis' && visMode !== 'blind') {
+    if (agent.isManager && visMode !== 'blind') {
       read.push(this.workerSkillsDir);
       write.push(this.workerSkillsDir);
     }
@@ -2107,20 +2146,21 @@ class ProjectRunner {
         sharedRules += fs.readFileSync(folderStructurePath, 'utf-8') + '\n\n---\n\n';
       } catch {}
       const visMode = visibility?.mode || 'full';
+      if (visMode === 'full') {
+        const dbPath = path.join(ROOT, 'agent', 'db.md');
+        try {
+          const dbContent = fs.readFileSync(dbPath, 'utf-8');
+          sharedRules += dbContent + '\n\n---\n\n';
+        } catch {}
+      }
       if (agent.name !== 'themis') {
-        if (visMode === 'full') {
-          const dbPath = path.join(ROOT, 'agent', 'db.md');
-          try {
-            const dbContent = fs.readFileSync(dbPath, 'utf-8');
-            sharedRules += dbContent + '\n\n---\n\n';
-          } catch {}
-        } else if (visMode === 'focused') {
-          sharedRules += '\n> **You are in focused mode.** You cannot read the issue tracker. Work only from the task, the repository, and your own agent notes. If needed, you may create a new issue to report a blocker or finding.\n\n---\n\n';
-        } else {
-          sharedRules += '\n> **You are in blind mode.** You cannot read the issue tracker and you cannot rely on any agent notes, including your own prior notes. Work only from the task and the repository.\n\n---\n\n';
+        if (visMode === 'focused') {
+          sharedRules += '\n> **You are in focused mode.** You cannot read the issue tracker or PR board. Work only from the task, the repository, shared knowledge, and your own agent notes. If needed, you may create a new issue or PR record to report a blocker or finding.\n\n---\n\n';
+        } else if (visMode === 'blind') {
+          sharedRules += '\n> **You are in blind mode.** You cannot read the issue tracker or PR board, and you cannot rely on shared knowledge or any agent notes, including your own prior notes. Work only from the task and the repository. If needed, you may create a new issue or PR record to report a blocker or finding.\n\n---\n\n';
         }
       } else {
-        sharedRules += '\n> **You are Themis, final examiner.** You must not read communication history, issue tracker contents, or any agent notes, including your own. Evaluate only the repository, tests, artifacts, and your own fresh inspection.\n\n---\n\n';
+        sharedRules += '\n> **You are Themis, final examination manager.** You run in full view, not blind. Inspect the repository, issue tracker, PR board, shared knowledge, and agent notes directly. You may hire and schedule workers, but only workers who report to you. Your examination team is independent from the Athena, Ares, and Apollo teams, so make your own judgment from primary evidence.\n\n---\n\n';
       }
       const rolePath = path.join(ROOT, 'agent', agent.isManager ? 'manager.md' : 'worker.md');
       sharedRules += fs.readFileSync(rolePath, 'utf-8') + '\n\n---\n\n';

--- a/src/server.js
+++ b/src/server.js
@@ -871,6 +871,50 @@ class ProjectRunner {
     };
   }
 
+  _syncAgentRegistry(db) {
+    const upsert = db.prepare(`
+      INSERT INTO agents (name, role, reports_to, model, disabled)
+      VALUES (?, ?, ?, ?, ?)
+      ON CONFLICT(name) DO UPDATE SET
+        role = excluded.role,
+        reports_to = excluded.reports_to,
+        model = excluded.model,
+        disabled = excluded.disabled
+    `);
+    const managersDir = path.join(ROOT, 'agent', 'managers');
+    const workersDir = this.workerSkillsDir;
+    const parseRole = (content) => (content.match(/^role:\s*(.+)$/m) || [])[1]?.trim() || null;
+    const parseModel = (content) => (content.match(/^model:\s*(.+)$/m) || [])[1]?.trim() || null;
+
+    if (fs.existsSync(managersDir)) {
+      for (const file of fs.readdirSync(managersDir)) {
+        if (!file.endsWith('.md')) continue;
+        const content = fs.readFileSync(path.join(managersDir, file), 'utf-8');
+        const name = file.replace('.md', '');
+        const disabled = /^disabled:\s*true$/m.test(content) ? 1 : 0;
+        upsert.run(name, parseRole(content), null, parseModel(content), disabled);
+      }
+    }
+
+    if (fs.existsSync(workersDir)) {
+      for (const file of fs.readdirSync(workersDir)) {
+        if (!file.endsWith('.md')) continue;
+        const content = fs.readFileSync(path.join(workersDir, file), 'utf-8');
+        const name = file.replace('.md', '');
+        const disabled = /^disabled:\s*true$/m.test(content) ? 1 : 0;
+        const reportsTo = (content.match(/^reports_to:\s*(.+)$/m) || [])[1]?.trim() || null;
+        upsert.run(name, parseRole(content), reportsTo, parseModel(content), disabled);
+      }
+    }
+  }
+
+  _resolveAllowedIssueClosers(db, issueCreator) {
+    if (issueCreator === 'human' || issueCreator === 'chat') {
+      return { allowed: new Set(['human', 'chat']), special: 'chat-human' };
+    }
+    return { allowed: new Set([issueCreator, 'athena']), special: 'agent-athena' };
+  }
+
   getDb() {
     const dbPath = this.projectDbPath;
     const db = new Database(dbPath);
@@ -878,11 +922,13 @@ class ProjectRunner {
     db.pragma('foreign_keys = ON');
     db.exec(`
       CREATE TABLE IF NOT EXISTS agents (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT UNIQUE NOT NULL, role TEXT, reports_to TEXT, model TEXT, disabled INTEGER DEFAULT 0, created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')));
-      CREATE TABLE IF NOT EXISTS issues (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL, body TEXT DEFAULT '', status TEXT DEFAULT 'open', creator TEXT NOT NULL, assignee TEXT, labels TEXT DEFAULT '', created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')), updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')), closed_at TEXT);
+      CREATE TABLE IF NOT EXISTS issues (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL, body TEXT DEFAULT '', status TEXT DEFAULT 'open', creator TEXT NOT NULL, assignee TEXT, labels TEXT DEFAULT '', created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')), updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')), updated_by TEXT, closed_at TEXT, closed_by TEXT);
       CREATE TABLE IF NOT EXISTS comments (id INTEGER PRIMARY KEY AUTOINCREMENT, issue_id INTEGER NOT NULL REFERENCES issues(id), author TEXT NOT NULL, body TEXT NOT NULL, created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')));
       CREATE TABLE IF NOT EXISTS milestones (id INTEGER PRIMARY KEY AUTOINCREMENT, description TEXT NOT NULL, cycles_budget INTEGER DEFAULT 20, cycles_used INTEGER DEFAULT 0, phase TEXT DEFAULT 'implementation', status TEXT DEFAULT 'active', created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')), completed_at TEXT);
       CREATE TABLE IF NOT EXISTS tbc_prs (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL, summary TEXT DEFAULT '', base_branch TEXT NOT NULL, head_branch TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'open' CHECK(status IN ('open', 'merged', 'closed')), issue_ids TEXT DEFAULT '[]', test_status TEXT DEFAULT 'unknown', github_pr_number INTEGER, github_pr_url TEXT, created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')), updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')));
     `);
+    try { db.exec('ALTER TABLE issues ADD COLUMN updated_by TEXT'); } catch {}
+    try { db.exec('ALTER TABLE issues ADD COLUMN closed_by TEXT'); } catch {}
     db.exec(`
       UPDATE tbc_prs
       SET status = CASE
@@ -906,6 +952,7 @@ class ProjectRunner {
         SELECT RAISE(ABORT, 'invalid tbc_prs.status');
       END;
     `);
+    this._syncAgentRegistry(db);
     return db;
   }
 
@@ -3775,24 +3822,45 @@ const server = http.createServer(async (req, res) => {
       let body = '';
       req.on('data', d => body += d);
       req.on('end', () => {
+        let db = null;
         try {
           const issueId = parseInt(issuePatchMatch[1], 10);
-          const { status } = JSON.parse(body);
+          const { status, actor } = JSON.parse(body);
           if (!['open', 'closed'].includes(status)) {
             res.writeHead(400, { 'Content-Type': 'application/json' });
             res.end(JSON.stringify({ error: 'Status must be "open" or "closed"' }));
             return;
           }
-          const db = runner.getDb();
+          db = runner.getDb();
+          const issue = db.prepare('SELECT id, creator, status FROM issues WHERE id = ?').get(issueId);
+          if (!issue) {
+            res.writeHead(404, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'Issue not found' }));
+            return;
+          }
+          const actingAs = actor || 'human';
+          if (status === 'closed' && issue.status !== 'closed') {
+            const { allowed, special } = runner._resolveAllowedIssueClosers(db, issue.creator);
+            if (!allowed.has(actingAs)) {
+              const error = special === 'chat-human'
+                ? `Issue #${issueId} was opened by ${issue.creator} and can only be closed by chat or human`
+                : `Issue #${issueId} was opened by ${issue.creator} and can only be closed by ${issue.creator} or athena`;
+              res.writeHead(403, { 'Content-Type': 'application/json' });
+              res.end(JSON.stringify({ error }));
+              return;
+            }
+          }
           const now = new Date().toISOString();
           const closedAt = status === 'closed' ? now : null;
-          db.prepare('UPDATE issues SET status = ?, updated_at = ?, closed_at = ? WHERE id = ?').run(status, now, closedAt, issueId);
-          db.close();
+          const closedBy = status === 'closed' ? actingAs : null;
+          db.prepare('UPDATE issues SET status = ?, updated_at = ?, updated_by = ?, closed_at = ?, closed_by = ? WHERE id = ?').run(status, now, actingAs, closedAt, closedBy, issueId);
           res.writeHead(200, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ success: true }));
         } catch (e) {
           res.writeHead(500, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: e.message }));
+        } finally {
+          try { db?.close(); } catch {}
         }
       });
       return;

--- a/tests/agent-filesystem-policy.test.js
+++ b/tests/agent-filesystem-policy.test.js
@@ -11,14 +11,17 @@ function mkProject() {
   const projectRoot = root;
   const own = path.join(projectRoot, 'agents', 'leo');
   const other = path.join(projectRoot, 'agents', 'nora');
+  const knowledge = path.join(projectRoot, 'knowledge');
   const skills = path.join(projectRoot, 'skills', 'workers');
   fs.mkdirSync(repo, { recursive: true });
   fs.mkdirSync(own, { recursive: true });
   fs.mkdirSync(other, { recursive: true });
+  fs.mkdirSync(knowledge, { recursive: true });
   fs.mkdirSync(skills, { recursive: true });
   fs.writeFileSync(path.join(repo, 'repo.txt'), 'repo ok');
   fs.writeFileSync(path.join(own, 'note.txt'), 'own ok');
   fs.writeFileSync(path.join(other, 'secret.txt'), 'other secret');
+  fs.writeFileSync(path.join(knowledge, 'spec.md'), 'shared knowledge');
   fs.writeFileSync(path.join(skills, 'nora.md'), 'role: worker');
   fs.writeFileSync(path.join(projectRoot, 'project.db'), 'sqlite');
   return {
@@ -27,9 +30,24 @@ function mkProject() {
     projectRoot,
     own,
     other,
+    knowledge,
     skills,
     allowedWorker: {
       read: [repo, own],
+      write: [repo, own],
+      denied: [
+        path.join(projectRoot, 'agents'),
+        path.join(projectRoot, 'responses'),
+        path.join(projectRoot, 'uploads'),
+        path.join(projectRoot, 'skills'),
+        path.join(projectRoot, 'state.json'),
+        path.join(projectRoot, 'orchestrator.log'),
+        path.join(projectRoot, 'project.db'),
+      ],
+      dbPath: path.join(projectRoot, 'project.db'),
+    },
+    allowedFocused: {
+      read: [repo, own, knowledge],
       write: [repo, own],
       denied: [
         path.join(projectRoot, 'agents'),

--- a/tests/examination-phase.test.js
+++ b/tests/examination-phase.test.js
@@ -12,6 +12,10 @@ function readServer() {
   return fs.readFileSync(serverPath, 'utf-8');
 }
 
+function readThemis() {
+  return fs.readFileSync(themisPath, 'utf-8');
+}
+
 describe('Themis examination phase', () => {
   it('adds themis manager prompt file', () => {
     assert.ok(fs.existsSync(themisPath), 'Expected agent/managers/themis.md to exist');
@@ -38,12 +42,40 @@ describe('Themis examination phase', () => {
       'Successful PROJECT_COMPLETE should not finalize the project immediately');
   });
 
-  it('adds a dedicated examination phase that runs themis', () => {
+  it('adds a dedicated examination phase that runs themis in full view', () => {
     const src = readServer();
     assert.match(src, /else if \(this\.phase === 'examination'\)/,
       'Expected a dedicated examination phase block in runLoop');
     assert.match(src, /const themis = managers\.find\(m => m\.name === 'themis'\)/,
       'Expected examination phase to run Themis');
+    assert.match(src, /runAgent\(themis, config, null, themisContext, \{ mode: 'full', issues: \[\] \}\)/,
+      'Expected Themis to run in full view');
+    assert.doesNotMatch(src, /runAgent\(themis, config, null, themisContext, \{ mode: 'blind', issues: \[\] \}\)/,
+      'Themis should no longer run blind');
+  });
+
+  it('lets Themis schedule its own independent team across multiple cycles', () => {
+    const src = readServer();
+    assert.match(src, /Resuming interrupted examination schedule/,
+      'Expected examination schedules to resume after interruption');
+    assert.match(src, /schedule = this\.parseSchedule\(result\.resultText\)/,
+      'Expected examination phase to parse Themis schedules');
+    assert.match(src, /executeSchedule\(schedule, config, 'themis'\)/,
+      'Expected examination workers to run under Themis ownership');
+    assert.match(src, /executeSchedule\(this\.currentSchedule, config, 'themis'\)/,
+      'Expected interrupted Themis schedules to resume under Themis ownership');
+    assert.match(src, /let decision = null/,
+      'Expected examination to support non-terminal cycles');
+    assert.match(src, /No decision yet, stay in examination phase/,
+      'Expected schedule-only examination cycles to remain in examination');
+  });
+
+  it('filters scheduled workers by manager ownership', () => {
+    const src = readServer();
+    assert.match(src, /const ownerName = typeof managerName === 'string' \? managerName\.toLowerCase\(\) : null/,
+      'Expected executeSchedule to accept a manager owner');
+    assert.match(src, /return \(worker\.reportsTo \|\| ''\)\.toLowerCase\(\) === ownerName/,
+      'Expected executeSchedule to limit workers to the current manager team');
   });
 
   it('finalizes completion only on EXAM_PASS', () => {
@@ -60,28 +92,42 @@ describe('Themis examination phase', () => {
       'Expected EXAM_PASS to exit examination phase cleanly');
   });
 
-  it('returns to athena and creates issues when Themis does not emit EXAM_PASS', () => {
+  it('returns to athena and creates issues on EXAM_FAIL', () => {
     const src = readServer();
     const examBlock = src.match(/else if \(this\.phase === 'examination'\) \{([\s\S]*?)\n      \}/);
     assert.ok(examBlock, 'Could not find examination phase block');
     const block = examBlock[1];
 
-    assert.match(block, /let decision = 'fail'/,
-      'Expected examination phase to default to failure');
+    assert.match(block, /decision === 'fail'/,
+      'Expected explicit EXAM_FAIL handling');
     assert.match(block, /phase:\s*'athena'/,
-      'Expected non-pass examination result to return control to Athena');
+      'Expected failed examination result to return control to Athena');
     assert.match(block, /issue-create|createIssue|INSERT INTO issues/i,
-      'Expected non-pass examination result to create issues');
+      'Expected failed examination result to create issues');
   });
 
-  it('treats EXAM_FAIL as optional, not required', () => {
+  it('still falls back to raw feedback when EXAM_FAIL JSON is absent or incomplete', () => {
     const src = readServer();
     const examBlock = src.match(/else if \(this\.phase === 'examination'\) \{([\s\S]*?)\n      \}/);
     assert.ok(examBlock, 'Could not find examination phase block');
     const block = examBlock[1];
 
     assert.match(block, /rawFeedback/,
-      'Expected examination failure path to fall back to raw Themis output when EXAM_FAIL is absent');
+      'Expected examination failure path to fall back to raw Themis output when structured feedback is absent');
+  });
+
+  it('updates Themis prompt for full-view team-based examination', () => {
+    const themis = readThemis();
+    assert.match(themis, /run in full view, not blind/i,
+      'Expected Themis prompt to make full visibility explicit');
+    assert.match(themis, /may hire workers, retune workers, and schedule workers/i,
+      'Expected Themis prompt to allow team management');
+    assert.match(themis, /Only workers with `reports_to: themis` are on your team\./,
+      'Expected Themis prompt to define an independent team');
+    assert.match(themis, /may take multiple cycles to finish the examination/i,
+      'Expected Themis prompt to allow multi-cycle examination');
+    assert.match(themis, /<!-- SCHEDULE -->/,
+      'Expected Themis prompt to document schedule output');
   });
 
   it('gives Athena context when Themis rejects project completion', () => {

--- a/tests/issue-visibility-policy.test.js
+++ b/tests/issue-visibility-policy.test.js
@@ -42,40 +42,49 @@ function mkProject() {
 }
 
 describe('issue visibility policy', () => {
-  it('blind blocks all issue tracker access', async () => {
+  it('blind blocks issue tracker reads but still allows issue/pr creation', async () => {
     const p = mkProject();
 
     const listResult = await executeTool('Bash', { command: 'tbc-db issue-list' }, p.repo, 0, { TBC_DB: '/tmp/project.db' }, null, null, p.allowedPaths, p.issuePolicies.blind);
-    assert.match(listResult, /access denied|blind mode|issue tracker/i);
+    assert.match(listResult, /access denied|blind mode|issue tracker|pr board/i);
 
     const viewResult = await executeTool('Bash', { command: 'tbc-db issue-view 12' }, p.repo, 0, { TBC_DB: '/tmp/project.db' }, null, null, p.allowedPaths, p.issuePolicies.blind);
-    assert.match(viewResult, /access denied|blind mode|issue tracker/i);
+    assert.match(viewResult, /access denied|blind mode|issue tracker|pr board/i);
 
     const createResult = await executeTool('Bash', { command: 'tbc-db issue-create --title "Need help" --creator leo --body "blocked"' }, p.repo, 0, { TBC_DB: '/tmp/project.db' }, null, null, p.allowedPaths, p.issuePolicies.blind);
-    assert.match(createResult, /access denied|blind mode|issue tracker/i);
+    assert.doesNotMatch(createResult, /access denied|blind mode|issue tracker|pr board/i);
+
+    const prCreate = await executeTool('Bash', { command: 'tbc-db pr-create --title "Draft" --head leo/draft --actor leo' }, p.repo, 0, { TBC_DB: '/tmp/project.db' }, null, null, p.allowedPaths, p.issuePolicies.blind);
+    assert.doesNotMatch(prCreate, /access denied|blind mode|issue tracker|pr board/i);
   });
 
-  it('focused blocks issue reads and comments listing', async () => {
+  it('focused blocks issue and pr reads', async () => {
     const p = mkProject();
 
     const deniedView = await executeTool('Bash', { command: 'tbc-db issue-view 12' }, p.repo, 0, { TBC_DB: '/tmp/project.db' }, null, null, p.allowedPaths, p.issuePolicies.focused);
-    assert.match(deniedView, /access denied|focused mode|issue tracker/i);
+    assert.match(deniedView, /access denied|focused mode|issue tracker|pr board/i);
 
     const deniedComments = await executeTool('Bash', { command: 'tbc-db comments 34' }, p.repo, 0, { TBC_DB: '/tmp/project.db' }, null, null, p.allowedPaths, p.issuePolicies.focused);
-    assert.match(deniedComments, /access denied|focused mode|issue tracker/i);
+    assert.match(deniedComments, /access denied|focused mode|issue tracker|pr board/i);
 
     const deniedList = await executeTool('Bash', { command: 'tbc-db issue-list' }, p.repo, 0, { TBC_DB: '/tmp/project.db' }, null, null, p.allowedPaths, p.issuePolicies.focused);
-    assert.match(deniedList, /access denied|focused mode|issue tracker/i);
+    assert.match(deniedList, /access denied|focused mode|issue tracker|pr board/i);
+
+    const deniedPrList = await executeTool('Bash', { command: 'tbc-db pr-list' }, p.repo, 0, { TBC_DB: '/tmp/project.db' }, null, null, p.allowedPaths, p.issuePolicies.focused);
+    assert.match(deniedPrList, /access denied|focused mode|issue tracker|pr board/i);
   });
 
-  it('focused allows issue creation and commenting', async () => {
+  it('focused allows issue and pr creation only', async () => {
     const p = mkProject();
 
-    const commentResult = await executeTool('Bash', { command: 'tbc-db comment --issue 12 --author leo --body "working"' }, p.repo, 0, { TBC_DB: '/tmp/project.db' }, null, null, p.allowedPaths, p.issuePolicies.focused);
-    assert.doesNotMatch(commentResult, /access denied|focused mode|issue tracker/i);
-
     const createResult = await executeTool('Bash', { command: 'tbc-db issue-create --title "New blocker" --creator leo --body "blocked"' }, p.repo, 0, { TBC_DB: '/tmp/project.db' }, null, null, p.allowedPaths, p.issuePolicies.focused);
-    assert.doesNotMatch(createResult, /access denied|focused mode|issue tracker/i);
+    assert.doesNotMatch(createResult, /access denied|focused mode|issue tracker|pr board/i);
+
+    const prCreate = await executeTool('Bash', { command: 'tbc-db pr-create --title "Draft" --head leo/draft --actor leo' }, p.repo, 0, { TBC_DB: '/tmp/project.db' }, null, null, p.allowedPaths, p.issuePolicies.focused);
+    assert.doesNotMatch(prCreate, /access denied|focused mode|issue tracker|pr board/i);
+
+    const commentResult = await executeTool('Bash', { command: 'tbc-db comment --issue 12 --author leo --body "working"' }, p.repo, 0, { TBC_DB: '/tmp/project.db' }, null, null, p.allowedPaths, p.issuePolicies.focused);
+    assert.match(commentResult, /access denied|focused mode|issue tracker|pr board/i);
   });
 
   it('full allows issue reads and writes', async () => {
@@ -95,10 +104,13 @@ describe('issue visibility policy', () => {
     const p = mkProject();
 
     const blindCreate = await executeTool('Bash', { command: 'tbc-db pr-create --title "Draft" --head leo/draft' }, p.repo, 0, { TBC_DB: '/tmp/project.db' }, null, null, p.allowedPaths, p.issuePolicies.blind);
-    assert.doesNotMatch(blindCreate, /access denied|blind mode|issue tracker/i);
+    assert.doesNotMatch(blindCreate, /access denied|blind mode|issue tracker|pr board/i);
 
     const focusedEdit = await executeTool('Bash', { command: 'tbc-db pr-edit 1 --status merged' }, p.repo, 0, { TBC_DB: '/tmp/project.db' }, null, null, p.allowedPaths, p.issuePolicies.focused);
-    assert.doesNotMatch(focusedEdit, /access denied|focused mode|issue tracker/i);
+    assert.match(focusedEdit, /access denied|focused mode|issue tracker|pr board/i);
+
+    const blindView = await executeTool('Bash', { command: 'tbc-db pr-view 1' }, p.repo, 0, { TBC_DB: '/tmp/project.db' }, null, null, p.allowedPaths, p.issuePolicies.blind);
+    assert.match(blindView, /access denied|blind mode|issue tracker|pr board/i);
   });
 
   it('blocks raw SQL query for non-full visibility', async () => {

--- a/tests/kill-epoch-retry.test.js
+++ b/tests/kill-epoch-retry.test.js
@@ -39,7 +39,7 @@ describe('killEpoch interrupts in-flight worker retries', () => {
 
   it('executeSchedule should stop dispatching additional steps after killEpoch', () => {
     const src = readServer();
-    const executeScheduleMatch = src.match(/async executeSchedule\(schedule, config\) \{([\s\S]*?)\n  \}\n\n  async runLoop/);
+    const executeScheduleMatch = src.match(/async executeSchedule\(schedule, config(?:, managerName = null)?\) \{([\s\S]*?)\n  \}\n\n  async runLoop/);
     assert.ok(executeScheduleMatch, 'Could not find executeSchedule() in server.js');
     const body = executeScheduleMatch[1];
 

--- a/tests/tbc-db-issue-close-policy.test.js
+++ b/tests/tbc-db-issue-close-policy.test.js
@@ -49,19 +49,47 @@ describe('tbc-db issue action initiator policy', () => {
     assert.match(res.stdout, /Closed issue #1/);
   });
 
+  it('allows athena to close an agent-opened issue', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'tbc-db-close-'));
+    const dbPath = path.join(dir, 'project.db');
+
+    let res = run(['issue-create', '--title', 'Worker issue', '--creator', 'leo', '--body', 'body'], dbPath);
+    assert.equal(res.status, 0, res.stderr || res.stdout);
+
+    res = run(['issue-close', '1', '--closer', 'athena'], dbPath);
+    assert.equal(res.status, 0, res.stderr || res.stdout);
+    assert.match(res.stdout, /Closed issue #1/);
+  });
+
   it('blocks a different agent from closing another agent issue', () => {
     const dir = mkdtempSync(path.join(tmpdir(), 'tbc-db-close-'));
     const dbPath = path.join(dir, 'project.db');
 
-    let res = run(['issue-create', '--title', 'Agent issue', '--creator', 'ares', '--body', 'body'], dbPath);
+    let res = run(['issue-create', '--title', 'Agent issue', '--creator', 'leo', '--body', 'body'], dbPath);
     assert.equal(res.status, 0, res.stderr || res.stdout);
 
-    res = run(['issue-close', '1', '--closer', 'leo'], dbPath);
+    res = run(['issue-close', '1', '--closer', 'maya'], dbPath);
     assert.notEqual(res.status, 0);
-    assert.match(res.stderr, /can only be closed by that same agent/i);
+    assert.match(res.stderr, /can only be closed by leo or athena/i);
   });
 
-  it('blocks agents from closing human issues but allows human', () => {
+  it('manager issues can be closed by athena but not other managers', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'tbc-db-close-'));
+    const dbPath = path.join(dir, 'project.db');
+
+    let res = run(['issue-create', '--title', 'Manager issue', '--creator', 'ares', '--body', 'body'], dbPath);
+    assert.equal(res.status, 0, res.stderr || res.stdout);
+
+    res = run(['issue-close', '1', '--closer', 'apollo'], dbPath);
+    assert.notEqual(res.status, 0);
+    assert.match(res.stderr, /can only be closed by ares or athena/i);
+
+    res = run(['issue-close', '1', '--closer', 'athena'], dbPath);
+    assert.equal(res.status, 0, res.stderr || res.stdout);
+    assert.match(res.stdout, /Closed issue #1/);
+  });
+
+  it('chat and human issues can only be closed by chat or human', () => {
     const dir = mkdtempSync(path.join(tmpdir(), 'tbc-db-close-'));
     const dbPath = path.join(dir, 'project.db');
 
@@ -70,9 +98,9 @@ describe('tbc-db issue action initiator policy', () => {
 
     res = run(['issue-close', '1', '--closer', 'ares'], dbPath);
     assert.notEqual(res.status, 0);
-    assert.match(res.stderr, /can only be closed by human/i);
+    assert.match(res.stderr, /can only be closed by chat or human/i);
 
-    res = run(['issue-close', '1', '--closer', 'human'], dbPath);
+    res = run(['issue-close', '1', '--closer', 'chat'], dbPath);
     assert.equal(res.status, 0, res.stderr || res.stdout);
     assert.match(res.stdout, /Closed issue #1/);
   });


### PR DESCRIPTION
## Summary
- tighten focused/blind visibility so only full view can read issue/PR boards, while focused/blind can still create issue and PR records
- expand Athena and Themis manager behavior for stricter review cycles, including multi-cycle Themis examination with an independent Themis team
- tighten issue close permissions and update manager/Themis documentation to match the new workflow

## Testing
- node --check src/server.js
- node --check src/agent-runner.js
- node --check bin/tbc-db.js
- node --test tests/issue-visibility-policy.test.js tests/agent-filesystem-policy.test.js tests/examination-phase.test.js tests/kill-epoch-retry.test.js
