### PR TITLE
feat: add mobile-break settings toggle

### DIFF
--- a/monitor/src/App.jsx
+++ b/monitor/src/App.jsx
@@ -28,6 +28,7 @@ function App() {
 
   // Dark mode / theme
   const [theme, setTheme] = useState(() => localStorage.getItem('theme') || 'system')
+  const [breakMobileExperience, setBreakMobileExperience] = useState(() => localStorage.getItem('breakMobileExperience') === 'true')
 
   useEffect(() => {
     const apply = () => {
@@ -42,6 +43,24 @@ function App() {
       return () => mq.removeEventListener('change', apply)
     }
   }, [theme])
+
+  useEffect(() => {
+    localStorage.setItem('breakMobileExperience', String(breakMobileExperience))
+    document.documentElement.classList.toggle('break-mobile-experience', breakMobileExperience)
+    document.body?.classList.toggle('break-mobile-experience', breakMobileExperience)
+
+    const viewportMeta = document.querySelector('meta[name="viewport"]')
+    if (viewportMeta) {
+      viewportMeta.setAttribute(
+        'content',
+        breakMobileExperience
+          ? 'width=1024, initial-scale=1'
+          : 'width=device-width, initial-scale=1'
+      )
+    }
+
+    window.dispatchEvent(new CustomEvent('tbc:break-mobile-experience-changed', { detail: breakMobileExperience }))
+  }, [breakMobileExperience])
 
   // Register service worker (production only)
   useEffect(() => {
@@ -258,6 +277,8 @@ function App() {
           setNotifCenter={setNotifCenter}
           theme={theme}
           setTheme={setTheme}
+          breakMobileExperience={breakMobileExperience}
+          setBreakMobileExperience={setBreakMobileExperience}
         />
       }>
         <Route index element={null} />
@@ -278,6 +299,8 @@ function App() {
           setNotifCenter={setNotifCenter}
           theme={theme}
           setTheme={setTheme}
+          breakMobileExperience={breakMobileExperience}
+          setBreakMobileExperience={setBreakMobileExperience}
           onAgentChangeRef={onAgentChangeRef}
         />
       } />

--- a/monitor/src/components/layout/ProjectListPage.jsx
+++ b/monitor/src/components/layout/ProjectListPage.jsx
@@ -23,6 +23,8 @@ export default function ProjectListPage({
   setNotifCenter,
   theme,
   setTheme,
+  breakMobileExperience,
+  setBreakMobileExperience,
 }) {
   const { isWriteMode, handleLogout, setLoginModal, loginModal, loginInput, setLoginInput, handleLogin, authFetch } = useAuth()
   const { unreadCount } = useNotifications()
@@ -381,6 +383,8 @@ export default function ProjectListPage({
         onClose={closeSettingsPanel}
         theme={theme}
         setTheme={setTheme}
+        breakMobileExperience={breakMobileExperience}
+        setBreakMobileExperience={setBreakMobileExperience}
         setShowApiKeyHelp={setShowApiKeyHelp}
       />
 

--- a/monitor/src/components/layout/ProjectView.jsx
+++ b/monitor/src/components/layout/ProjectView.jsx
@@ -80,6 +80,8 @@ export default function ProjectView({
   setNotifCenter,
   theme,
   setTheme,
+  breakMobileExperience,
+  setBreakMobileExperience,
   onAgentChangeRef,
 }) {
   const { isWriteMode, handleLogout, setLoginModal, loginModal, loginInput, setLoginInput, handleLogin, authFetch } = useAuth()
@@ -1374,6 +1376,8 @@ export default function ProjectView({
         onClose={closeSettingsPanel}
         theme={theme}
         setTheme={setTheme}
+        breakMobileExperience={breakMobileExperience}
+        setBreakMobileExperience={setBreakMobileExperience}
         setShowApiKeyHelp={setShowApiKeyHelp}
       />
       <ProjectSettingsPanel

--- a/monitor/src/components/panels/SettingsPanel.jsx
+++ b/monitor/src/components/panels/SettingsPanel.jsx
@@ -795,6 +795,8 @@ export default function SettingsPanel({
   onClose,
   theme,
   setTheme,
+  breakMobileExperience,
+  setBreakMobileExperience,
   setShowApiKeyHelp,
 }) {
   const { authFetch } = useAuth()
@@ -909,6 +911,13 @@ export default function SettingsPanel({
   }
 
   const notifSupported = typeof window !== 'undefined' && 'Notification' in window
+
+  const updateBreakMobileExperience = (next) => {
+    setBreakMobileExperience(next)
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('breakMobileExperience', String(next))
+    }
+  }
   const notifPermission = notifSupported ? Notification.permission : 'default'
 
   return (
@@ -940,6 +949,25 @@ export default function SettingsPanel({
               </button>
             </div>
           </div>
+          <label className="flex items-center justify-between py-2 mt-1 gap-4 cursor-pointer select-none">
+            <div>
+              <span className="text-sm text-neutral-700 dark:text-neutral-300">Intentionally break mobile experience</span>
+              <p className="text-xs text-neutral-400 dark:text-neutral-500 mt-0.5">
+                Do not work 2am in the bed with your phone.
+              </p>
+            </div>
+            <span className="relative inline-flex items-center shrink-0 h-6 w-11">
+              <input
+                type="checkbox"
+                checked={breakMobileExperience}
+                onChange={(e) => updateBreakMobileExperience(e.target.checked)}
+                className="peer absolute inset-0 z-10 h-full w-full cursor-pointer opacity-0"
+                aria-label="Intentionally break mobile experience"
+              />
+              <span className="pointer-events-none h-6 w-11 rounded-full bg-neutral-300 transition-colors peer-checked:bg-red-500 dark:bg-neutral-600" />
+              <span className="pointer-events-none absolute left-0.5 top-0.5 h-5 w-5 rounded-full bg-white shadow transition-transform peer-checked:translate-x-5" />
+            </span>
+          </label>
         </div>
         <div className="border-t border-neutral-200 dark:border-neutral-700 pt-5 pb-5">
           <h3 className="text-sm font-semibold text-neutral-500 dark:text-neutral-400 uppercase tracking-wider mb-3">Notifications</h3>

--- a/monitor/src/components/ui/panel.jsx
+++ b/monitor/src/components/ui/panel.jsx
@@ -67,6 +67,11 @@ function usePanelState() {
 /**
  * Panel portals its children into the PanelSlot DOM node.
  */
+function mobileExperienceBroken() {
+  if (typeof window === 'undefined') return false
+  return window.localStorage.getItem('breakMobileExperience') === 'true'
+}
+
 function Panel({ open, onClose, children, id: propId }) {
   const idRef = React.useRef(propId || Math.random().toString(36).slice(2))
   const id = idRef.current
@@ -76,7 +81,7 @@ function Panel({ open, onClose, children, id: propId }) {
   onCloseRef.current = onClose
   const [isMobileViewport, setIsMobileViewport] = React.useState(() => {
     if (typeof window === 'undefined') return false
-    return window.innerWidth < 768
+    return window.innerWidth < 768 && !mobileExperienceBroken()
   })
 
   const { renderedKey, animate, activePanelKey } = usePanelState()
@@ -85,7 +90,7 @@ function Panel({ open, onClose, children, id: propId }) {
     if (open) {
       _register(key, id, () => onCloseRef.current?.())
       // Lock body scroll on mobile when panel is open (full-screen overlay)
-      const isMobile = window.innerWidth < 768
+      const isMobile = window.innerWidth < 768 && !mobileExperienceBroken()
       if (isMobile) document.body.style.overflow = 'hidden'
     } else {
       _unregister(key)
@@ -102,10 +107,15 @@ function Panel({ open, onClose, children, id: propId }) {
 
   React.useEffect(() => {
     if (typeof window === 'undefined') return
-    const handleResize = () => setIsMobileViewport(window.innerWidth < 768)
+    const handleResize = () => setIsMobileViewport(window.innerWidth < 768 && !mobileExperienceBroken())
     handleResize()
+    const handleToggle = () => handleResize()
     window.addEventListener('resize', handleResize)
-    return () => window.removeEventListener('resize', handleResize)
+    window.addEventListener('tbc:break-mobile-experience-changed', handleToggle)
+    return () => {
+      window.removeEventListener('resize', handleResize)
+      window.removeEventListener('tbc:break-mobile-experience-changed', handleToggle)
+    }
   }, [])
 
   const isActive = renderedKey === key

--- a/monitor/src/index.css
+++ b/monitor/src/index.css
@@ -154,3 +154,8 @@ body {
 .dark *:hover {
   scrollbar-color: rgba(255, 255, 255, 0.2) transparent;
 }
+
+html.break-mobile-experience body,
+html.break-mobile-experience #root {
+  min-width: 1024px;
+}

--- a/monitor/tests/break-mobile-experience-toggle.spec.js
+++ b/monitor/tests/break-mobile-experience-toggle.spec.js
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test'
+import { setupMocks } from './helpers.js'
+
+test.describe('Break mobile experience toggle', () => {
+  test('can be toggled from global settings on a mobile viewport', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 })
+    await setupMocks(page)
+
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+
+    const gearButton = page.locator('button[title="Settings"]')
+    await expect(gearButton).toBeVisible({ timeout: 10000 })
+    await gearButton.click()
+
+    const panelHeader = page.getByRole('heading', { name: 'Settings' })
+    await expect(panelHeader).toBeVisible({ timeout: 3000 })
+
+    const toggle = page.getByLabel('Intentionally break mobile experience', { exact: true })
+    await expect(toggle).toBeVisible()
+    await expect(toggle).not.toBeChecked()
+
+    await toggle.check()
+
+    await expect(toggle).toBeChecked()
+    await expect.poll(async () => page.evaluate(() => localStorage.getItem('breakMobileExperience'))).toBe('true')
+    await expect.poll(async () => page.locator('meta[name="viewport"]').getAttribute('content')).toBe('width=1024, initial-scale=1')
+  })
+})


### PR DESCRIPTION
## Summary
- add a global settings toggle to intentionally break the mobile experience by forcing desktop-style behavior
- wire the setting through both project list and project view settings panels
- add Playwright coverage for toggling the setting on a mobile viewport

## Testing
- npm --prefix monitor run build
- npx playwright test tests/break-mobile-experience-toggle.spec.js
