### PR TITLE
feat: let Athena reset milestone planning anchor

### DIFF
--- a/agent/everyone.md
+++ b/agent/everyone.md
@@ -17,6 +17,9 @@
 - Read `knowledge/spec.md` and `knowledge/roadmap.md` before major work when they exist.
 - Treat `folder_structure.md` as authoritative for project layout.
 - Worker skill files live under `{project_dir}/skills/workers/`.
+- Use `knowledge/` for durable, cross-agent information that should survive across cycles and be reusable by other agents.
+- Use your private `agents/{your_name}/note.md` for personal scratch context, short-term reminders, and in-progress thoughts that do not need to be shared.
+- Rule of thumb: if another agent would benefit from reading it next cycle, write it to `knowledge/` instead of keeping it only in your note.
 
 ## Visibility Restrictions
 

--- a/agent/manager.md
+++ b/agent/manager.md
@@ -73,11 +73,16 @@ List `{project_dir}/skills/workers/`. Only workers with `reports_to: <your_name>
 
 ### Check Worker Status
 
-Read `{project_dir}/agents/{agent_name}/note.md` for each of your workers to understand their current state before assigning tasks.
+Read shared `knowledge/` documents first when they are relevant, because they are the preferred home for durable cross-agent findings.
+
+Do not rely on reading your workers' private notes or private workspace. Managers should coordinate through shared knowledge, issue comments, reports, and other allowed shared artifacts.
 
 Also check for open issues created by your team members. Even if an agent has no current task, ask them to review the status of their own open issues, unless you already know the issue could not reasonably have been addressed yet.
 
 ### Manage Your Team
+
+When assigning tasks that are likely to produce reusable findings, explicitly tell workers to write the durable result into `knowledge/` instead of leaving it only in their private note.
+
 
 If the team lacks skills or a worker is ineffective, you can:
 - **Hire:** Create a new skill file in `{project_dir}/skills/workers/{name}.md`. Add `reports_to: your_name` and `role: <role>` in the YAML frontmatter. **You must create the skill file before scheduling the worker.**
@@ -110,6 +115,7 @@ Use abstract tiers instead of specific model names. The system resolves tiers to
 Default workers to **mid**. Use `high` or `low` only with a clear reason.
 
 When writing skill files, write clear and specific skill files that define the worker's expertise and any standing rules they should follow.
+Do not use skill files to assign cycle-specific tasks. Skill files are for role instructions and standing constraints only. Put actual work assignments in issues and in the schedule task text.
 
 ## Assign Tasks to Your Workers
 

--- a/agent/managers/ares.md
+++ b/agent/managers/ares.md
@@ -34,6 +34,8 @@ Read:
 
 **If returning from verification failure:** Apollo's feedback is injected at top. You have **half the original cycle budget** to fix the issues and re-claim.
 
+**If in grace review mode:** your worker budget is exhausted. Do not emit a schedule or assign workers. Review existing evidence only, then either emit `<!-- CLAIM_COMPLETE -->` or leave it out.
+
 Decide: is there still work to do, or is the milestone fully achieved?
 
 ### Step 2: Schedule

--- a/agent/managers/athena.md
+++ b/agent/managers/athena.md
@@ -11,6 +11,7 @@ Epoch workflow additions:
 - Use the orchestrator-assigned milestone id. Do not invent milestone ids, epoch ids, branch names, or PR ids.
 - Use the soft 600-lines-of-actual-code heuristic only as a sizing guardrail, not a target.
 - If Apollo rejects a milestone PR, split or narrow the milestone for the next cycle instead of sending it back as an open-ended fix round.
+- If the current subtree is misguided, you may reset planning to an ancestor milestone (or `root`) by setting `reset_to` in the milestone JSON.
 
 ## Your Team
 
@@ -117,7 +118,7 @@ When you are ready, output the next milestone for Ares's team.
 Decide the immediate next milestone for Ares' team. When ready, output:
 
 <!-- MILESTONE -->
-{"title":"Short milestone title (≤80 chars)","description":"Clear, specific description of what must be achieved","cycles":8}
+{"title":"Short milestone title (≤80 chars)","description":"Clear, specific description of what must be achieved","cycles":8,"reset_to":"M2"}
 <!-- /MILESTONE -->
 
 Rules:
@@ -125,6 +126,7 @@ Rules:
 - The milestone should be small enough for one Apollo review pass and one epoch PR
 - `description` should be specific and verifiable — Apollo's team will check every claim
 - `cycles` is the number of cycles Ares's team gets — if unsure, go smaller.
+- `reset_to` is optional. Use it only when you want to abandon the current deeper subtree and replan from an ancestor milestone (for example `"M2"`, `"M2.1"`) or from `"root"`. The next milestone will become a new child under that anchor (or a new top-level milestone for `root`).
 
 
 Alternatively, if the project is complete or hopelessly stuck, output:

--- a/agent/worker.md
+++ b/agent/worker.md
@@ -4,6 +4,22 @@ You are a worker agent. You execute tasks assigned to you by your manager.
 
 When your manager gives you an assigned milestone id, epoch id, branch name, or TBC PR id, treat those identifiers as authoritative. Use them as given and do not invent replacements.
 
+## Shared Knowledge
+
+Write durable shared findings to `knowledge/` when other agents should be able to reuse them.
+
+Examples of good shared-knowledge content:
+- root-cause analysis
+- experiment summaries
+- benchmark/result interpretation
+- acceptance evidence that another team will need to verify
+- decisions and tradeoffs that should remain visible across cycles
+
+
+Use your private `agents/{your_name}/note.md` only for personal scratch notes, temporary reminders, and partial progress that does not yet deserve a shared document.
+
+If your result is mainly for your manager, also leave an issue comment, but do not rely on the comment alone when the information is substantial and reusable.
+
 ## Issue Lock
 
 ### One Issue at a Time

--- a/monitor/src/components/layout/ProjectView.jsx
+++ b/monitor/src/components/layout/ProjectView.jsx
@@ -15,6 +15,7 @@ import WorkerCard from '@/components/project/WorkerCard'
 import IssuesSidebar from '@/components/project/IssuesSidebar'
 import HumanInterventionCard from '@/components/project/HumanInterventionCard'
 import AgentReportsCard from '@/components/project/AgentReportsCard'
+import MilestoneTreeCard from '@/components/project/MilestoneTreeCard'
 import ChatCard from '@/components/project/ChatCard'
 import SettingsPanel from '@/components/panels/SettingsPanel'
 import NotificationPanel from '@/components/panels/NotificationPanel'
@@ -24,6 +25,7 @@ import ChatPanel from '@/components/panels/ChatPanel'
 import AgentDetailPanel from '@/components/panels/AgentDetailPanel'
 import IssueDetailPanel from '@/components/panels/IssueDetailPanel'
 import PRDetailPanel from '@/components/panels/PRDetailPanel'
+import MilestoneDetailPanel from '@/components/panels/MilestoneDetailPanel'
 import ProjectSettingsPanel from '@/components/panels/ProjectSettingsPanel'
 import LoginModal from '@/components/modals/LoginModal'
 import ApiKeyHelpModal from '@/components/modals/ApiKeyHelpModal'
@@ -120,6 +122,7 @@ export default function ProjectView({
   const [commentsPage, setCommentsPage] = useState(1)
   const [commentsHasMore, setCommentsHasMore] = useState(true)
   const [commentsLoading, setCommentsLoading] = useState(false)
+  const [milestones, setMilestones] = useState([])
   const [selectedAgent, setSelectedAgent] = useState(() => localStorage.getItem('selectedAgent') || null)
   const initialPathPanel = parseProjectPanelPath(currentPath, selectedProject)
   const [reportsPanelOpen, setReportsPanelOpen] = useState(initialPathPanel.panel === 'reports')
@@ -142,6 +145,11 @@ export default function ProjectView({
     error: null,
     requestedNumber: null,
   })
+  const [milestoneModal, setMilestoneModal] = useState({
+    open: initialPathPanel.panel === 'milestone',
+    milestone: null,
+    requestedId: initialPathPanel.panel === 'milestone' ? initialPathPanel.id : null,
+  })
   const [createIssueModal, setCreateIssueModal] = useState({ open: false, title: '', body: '', receiver: '', creating: false, error: null, focusedField: 'title' })
   const modKey = typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.userAgent) ? '⌘' : 'Ctrl'
   const [bootstrapModal, setBootstrapModal] = useState({ open: false, loading: false, preview: null, error: null, executing: false, removeRoadmap: true, specMode: 'keep', specContent: '', whatToBuild: '', successCriteria: '' })
@@ -162,6 +170,7 @@ export default function ProjectView({
   const isChatPanelOpen = chatPanelOpen || pathPanel.panel === 'chat'
   const isIssuePanelOpen = issueModal.open || pathPanel.panel === 'issue'
   const isPrPanelOpen = prModal.open || pathPanel.panel === 'pr'
+  const isMilestonePanelOpen = milestoneModal.open || pathPanel.panel === 'milestone'
   const isAgentPanelOpen = agentModal.open || pathPanel.panel === 'agent'
   const isBootstrapPanelOpen = bootstrapModal.open || pathPanel.panel === 'bootstrap'
 
@@ -244,6 +253,17 @@ export default function ProjectView({
     })
   }, [navigateProjectPath, shouldClearCurrentPanelPath])
 
+  const setMilestoneModalWithUrl = useCallback((updater) => {
+    setMilestoneModal(prev => {
+      const next = typeof updater === 'function' ? updater(prev) : updater
+      if (prev.open && !next.open) {
+        if (shouldClearCurrentPanelPath('milestone')) navigateProjectPath()
+        return { ...next, requestedId: null }
+      }
+      return next
+    })
+  }, [navigateProjectPath, shouldClearCurrentPanelPath])
+
   const setAgentModalTab = useCallback((nextTab) => {
     setAgentModal(prev => {
       if (!prev.open || !prev.agent || prev.tab === nextTab) return prev
@@ -270,6 +290,7 @@ export default function ProjectView({
     setChatPanelOpen(false)
     setIssueModal(prev => ({ ...prev, open: false, loading: false, requestedId: null }))
     setPrModal(prev => ({ ...prev, open: false, loading: false, error: null, requestedNumber: null }))
+    setMilestoneModal(prev => ({ ...prev, open: false, milestone: null, requestedId: null }))
     setAgentModal(prev => ({ ...prev, open: false }))
   }, [abortIssueRequest, abortPrRequest])
 
@@ -315,6 +336,13 @@ export default function ProjectView({
     clearPanelPathIfActive('chat')
   }, [clearPanelPathIfActive])
 
+  const openMilestoneModal = useCallback((milestoneId) => {
+    const requestedId = String(milestoneId)
+    const milestone = milestones.find((item) => String(item.milestone_id) === requestedId) || null
+    setMilestoneModal({ open: true, milestone, requestedId })
+    navigateProjectPath(['milestone', requestedId])
+  }, [milestones, navigateProjectPath])
+
   // Project settings (token state now managed inside ProjectSettingsPanel)
 
   // Agent settings modal
@@ -347,13 +375,14 @@ export default function ProjectView({
     if (initial) setProjectLoading(true)
     
     try {
-      const [logsRes, agentsRes, configRes, prsRes, issuesRes, repoRes] = await Promise.all([
+      const [logsRes, agentsRes, configRes, prsRes, issuesRes, repoRes, milestonesRes] = await Promise.all([
         fetch(`${baseApi}/logs?lines=100`),
         fetch(`${baseApi}/agents`),
         fetch(`${baseApi}/config`),
         fetch(`${baseApi}/prs?status=${prFilter}`),
         fetch(`${baseApi}/issues`).catch(() => ({ ok: false })),
-        fetch(`${baseApi}/repo`)
+        fetch(`${baseApi}/repo`),
+        fetch(`${baseApi}/milestones`).catch(() => ({ ok: false }))
       ])
       
       if (selectedProjectRef.current?.id !== currentProject.id) return
@@ -375,6 +404,11 @@ export default function ProjectView({
       setPrs((await prsRes.json()).prs || [])
       if (issuesRes.ok) {
         setIssues((await issuesRes.json()).issues || [])
+      }
+      if (milestonesRes.ok) {
+        setMilestones((await milestonesRes.json()).milestones || [])
+      } else {
+        setMilestones([])
       }
       setRepoUrl((await repoRes.json()).url)
     } catch (err) {
@@ -928,6 +962,12 @@ export default function ProjectView({
       return
     }
 
+    const activeMilestoneId = milestoneModal.requestedId
+    if (panel === 'milestone' && panelId && (!milestoneModal.open || String(activeMilestoneId) !== String(panelId))) {
+      openMilestoneModal(panelId)
+      return
+    }
+
     if (panel === 'agent' && panelId) {
       const needsAgentData = agentModal.agent === panelId && !agentModal.loading && !agentModal.data
       if (!agentModal.open || agentModal.agent !== panelId || needsAgentData) {
@@ -954,12 +994,25 @@ export default function ProjectView({
     issueModal.requestedId,
     prModal.open,
     prModal.requestedNumber,
+    milestoneModal.open,
+    milestoneModal.requestedId,
     agentModal.open,
     agentModal.agent,
     agentModal.tab,
     openBootstrapModal,
+    openMilestoneModal,
     shouldClearCurrentPanelPath,
   ])
+
+  useEffect(() => {
+    if (!milestoneModal.requestedId) return
+    const milestone = milestones.find((item) => String(item.milestone_id) === String(milestoneModal.requestedId))
+    if (!milestone) return
+    setMilestoneModal(prev => {
+      if (String(prev.requestedId) !== String(milestone.milestone_id) || prev.milestone === milestone) return prev
+      return { ...prev, milestone }
+    })
+  }, [milestones, milestoneModal.requestedId])
 
   useEffect(() => () => {
     abortIssueRequest()
@@ -1191,6 +1244,13 @@ export default function ProjectView({
                 setReportsPanelOpen={openReportsPanel}
               />
 
+              <MilestoneTreeCard
+                milestones={milestones}
+                currentMilestoneId={selectedProject?.currentMilestoneId || null}
+                onMilestoneClick={openMilestoneModal}
+                onPrClick={openPRModal}
+              />
+
               <DashboardWidget icon={GitPullRequest} title={`Agent PRs (${prs.length})`}>
                   <div className="space-y-2">
                     <SegmentedControl
@@ -1335,6 +1395,11 @@ export default function ProjectView({
         modKey={modKey}
       />
       <PRDetailPanel prModal={{ ...prModal, open: isPrPanelOpen }} setPrModal={setPrModalWithUrl} />
+      <MilestoneDetailPanel
+        milestoneModal={{ ...milestoneModal, open: isMilestonePanelOpen }}
+        setMilestoneModal={setMilestoneModalWithUrl}
+        onOpenPR={openPRModal}
+      />
       <ChatPanel
         open={isChatPanelOpen}
         onClose={closeChatPanel}

--- a/monitor/src/components/panels/MilestoneDetailPanel.jsx
+++ b/monitor/src/components/panels/MilestoneDetailPanel.jsx
@@ -1,0 +1,103 @@
+import React from 'react'
+import { Panel, PanelHeader, PanelContent } from '@/components/ui/panel'
+import { Flag, GitBranch, GitPullRequest } from 'lucide-react'
+import StatusPill from '@/components/ui/status-pill'
+
+function formatDate(value) {
+  if (!value) return 'Unknown'
+  return new Date(value).toLocaleString([], {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  })
+}
+
+export default function MilestoneDetailPanel({ milestoneModal, setMilestoneModal, onOpenPR }) {
+  const milestone = milestoneModal.milestone
+
+  return (
+    <Panel id="milestone-detail" open={milestoneModal.open} onClose={() => setMilestoneModal({ open: false, milestone: null, requestedId: null })}>
+      <PanelHeader onClose={() => setMilestoneModal({ open: false, milestone: null, requestedId: null })}>
+        {milestone ? `${milestone.milestone_id} ${milestone.title || ''}`.trim() : 'Milestone'}
+      </PanelHeader>
+      <PanelContent>
+        {!milestone && <div className="text-sm text-neutral-500">Loading milestone details...</div>}
+
+        {milestone && (
+          <div className="space-y-5">
+            <div className="flex items-center gap-2 flex-wrap">
+              <Flag className="w-4 h-4 text-neutral-500" />
+              <span className="text-xs text-neutral-500">{milestone.milestone_id}</span>
+              {milestone.status && <StatusPill variant={milestone.status === 'completed' ? 'success' : milestone.status === 'failed' ? 'danger' : milestone.status === 'active' ? 'warning' : 'meta'}>{milestone.status}</StatusPill>}
+              {milestone.phase && <StatusPill variant="meta">{milestone.phase}</StatusPill>}
+            </div>
+
+            <div>
+              <div className="text-xs uppercase tracking-wide text-neutral-500 mb-2">Title</div>
+              <div className="text-sm font-medium text-neutral-900 dark:text-neutral-100">
+                {milestone.title || milestone.description || milestone.milestone_id}
+              </div>
+            </div>
+
+            <div>
+              <div className="text-xs uppercase tracking-wide text-neutral-500 mb-2">Description</div>
+              <div className="whitespace-pre-wrap text-sm leading-6 text-neutral-800 dark:text-neutral-200">
+                {milestone.description?.trim() || 'No description'}
+              </div>
+            </div>
+
+            <div className="grid grid-cols-[112px_1fr] gap-x-3 gap-y-3 text-sm leading-5">
+              <div className="text-neutral-500">Created</div>
+              <div className="font-medium">{formatDate(milestone.created_at)}</div>
+
+              {milestone.completed_at && (
+                <>
+                  <div className="text-neutral-500">Completed</div>
+                  <div className="font-medium">{formatDate(milestone.completed_at)}</div>
+                </>
+              )}
+
+              {milestone.parent_milestone_id && (
+                <>
+                  <div className="text-neutral-500">Parent</div>
+                  <div className="font-medium">{milestone.parent_milestone_id}</div>
+                </>
+              )}
+
+              {milestone.branch_name && (
+                <>
+                  <div className="text-neutral-500">Branch</div>
+                  <div className="font-medium break-all inline-flex items-center gap-2"><GitBranch className="w-4 h-4 text-neutral-500" />{milestone.branch_name}</div>
+                </>
+              )}
+            </div>
+
+            {milestone.linked_pr_id && (
+              <div>
+                <div className="text-xs uppercase tracking-wide text-neutral-500 mb-2">Linked PR</div>
+                <button
+                  type="button"
+                  onClick={() => onOpenPR?.(milestone.linked_pr_id)}
+                  className="inline-flex items-center gap-2 rounded border border-neutral-200 px-3 py-2 text-sm hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-900"
+                >
+                  <GitPullRequest className="w-4 h-4" />
+                  PR #{milestone.linked_pr_id}
+                </button>
+              </div>
+            )}
+
+            {milestone.failure_reason && (
+              <div>
+                <div className="text-xs uppercase tracking-wide text-neutral-500 mb-2">Failure reason</div>
+                <div className="whitespace-pre-wrap text-sm leading-6 text-red-700 dark:text-red-300">
+                  {milestone.failure_reason}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </PanelContent>
+    </Panel>
+  )
+}

--- a/monitor/src/components/project/AgentReportsCard.jsx
+++ b/monitor/src/components/project/AgentReportsCard.jsx
@@ -205,6 +205,11 @@ export function ReportCardHeader({ report }) {
               <VisibilityIcon className="w-2.5 h-2.5 mr-0.5" />
               {visibilityMeta.label}
             </StatusPill>
+            {report.milestone_id && (
+              <StatusPill variant="meta" className="shrink-0 normal-case text-indigo-700 dark:text-indigo-300">
+                {report.milestone_id}
+              </StatusPill>
+            )}
           </div>
         </div>
       </div>

--- a/monitor/src/components/project/MilestoneTreeCard.jsx
+++ b/monitor/src/components/project/MilestoneTreeCard.jsx
@@ -1,0 +1,141 @@
+import React, { useMemo, useState } from 'react'
+import { GitBranch, ChevronRight, ChevronDown } from 'lucide-react'
+import DashboardWidget from '@/components/ui/DashboardWidget'
+import StatusPill from '@/components/ui/status-pill'
+
+function milestoneSortValue(id = '') {
+  return String(id)
+    .replace(/^M/i, '')
+    .split('.')
+    .map((part) => Number(part) || 0)
+}
+
+function compareMilestonesAsc(a, b) {
+  const aa = milestoneSortValue(a?.milestone_id)
+  const bb = milestoneSortValue(b?.milestone_id)
+  const len = Math.max(aa.length, bb.length)
+  for (let i = 0; i < len; i += 1) {
+    const diff = (aa[i] || 0) - (bb[i] || 0)
+    if (diff !== 0) return diff
+  }
+  return String(a?.milestone_id || '').localeCompare(String(b?.milestone_id || ''))
+}
+
+function compareMilestonesDesc(a, b) {
+  return compareMilestonesAsc(b, a)
+}
+
+function buildTree(milestones = []) {
+  const byId = new Map()
+  const roots = []
+  milestones.forEach((m) => byId.set(m.milestone_id, { ...m, children: [] }))
+  byId.forEach((node) => {
+    const parentId = node.parent_milestone_id
+    const parent = parentId ? byId.get(parentId) : null
+    if (parent) parent.children.push(node)
+    else roots.push(node)
+  })
+  const sortNode = (node) => {
+    node.children.sort(compareMilestonesDesc)
+    node.children.forEach(sortNode)
+  }
+  roots.sort(compareMilestonesDesc)
+  roots.forEach(sortNode)
+  return roots
+}
+
+function statusVariant(node) {
+  if (node.status === 'completed') return 'success'
+  if (node.status === 'failed') return 'danger'
+  if (node.status === 'active') return 'warning'
+  return 'meta'
+}
+
+function TreeNode({ node, currentMilestoneId, onMilestoneClick, onPrClick, depth = 0 }) {
+  const [open, setOpen] = useState(false)
+  const hasChildren = node.children?.length > 0
+  const isCurrent = currentMilestoneId && node.milestone_id === currentMilestoneId
+
+  return (
+    <div className="space-y-2">
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={() => onMilestoneClick?.(node.milestone_id)}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault()
+            onMilestoneClick?.(node.milestone_id)
+          }
+        }}
+        className={`block w-full rounded-lg border px-1.5 py-2 text-left cursor-pointer ${isCurrent ? 'border-blue-300/70 dark:border-blue-700/70' : 'border-neutral-200 dark:border-neutral-800'}`}
+      >
+        <div className="flex items-start gap-2">
+          <div className="min-w-0 flex-1">
+            <div className="flex items-start justify-between gap-2">
+              <div className="flex items-center gap-2 flex-wrap min-w-0">
+                <span className="font-mono text-xs text-neutral-600 dark:text-neutral-300">{node.milestone_id}</span>
+                {node.status && node.status !== 'active' && !isCurrent && <StatusPill variant={statusVariant(node)}>{node.status}</StatusPill>}
+                {node.phase && <StatusPill variant="meta">{node.phase}</StatusPill>}
+                {node.linked_pr_id && (
+                  <button
+                    type="button"
+                    onClick={(event) => {
+                      event.stopPropagation()
+                      onPrClick?.(node.linked_pr_id)
+                    }}
+                    className="inline-flex"
+                  >
+                    <StatusPill variant="meta">PR #{node.linked_pr_id}</StatusPill>
+                  </button>
+                )}
+              </div>
+              {hasChildren && (
+                <button
+                  type="button"
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    setOpen((v) => !v)
+                  }}
+                  className="inline-flex shrink-0 items-center justify-center rounded border border-neutral-200 p-1 text-neutral-600 hover:bg-neutral-50 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-900"
+                  aria-label={open ? 'Collapse milestone' : 'Expand milestone'}
+                  title={open ? 'Collapse' : 'Expand'}
+                >
+                  {open ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+                </button>
+              )}
+            </div>
+            <div className="mt-1 text-sm font-medium text-neutral-900 dark:text-neutral-100 break-words">
+              {node.title || node.description || node.milestone_id}
+            </div>
+          </div>
+        </div>
+      </div>
+      {hasChildren && open && (
+        <div className="ml-4 space-y-2 border-l border-neutral-200 pl-2.5 dark:border-neutral-800">
+          {node.children.map((child) => (
+            <TreeNode key={child.milestone_id} node={child} currentMilestoneId={currentMilestoneId} onMilestoneClick={onMilestoneClick} onPrClick={onPrClick} depth={depth + 1} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default function MilestoneTreeCard({ milestones = [], currentMilestoneId = null, onMilestoneClick, onPrClick }) {
+  const tree = useMemo(() => buildTree(milestones), [milestones])
+
+  return (
+    <DashboardWidget icon={GitBranch} title={`Milestones (${milestones.length})`}>
+      {tree.length === 0 ? (
+        <div className="text-sm text-neutral-500">No milestone records yet.</div>
+      ) : (
+        <div className="space-y-3">
+          {tree.map((node) => (
+            <TreeNode key={node.milestone_id} node={node} currentMilestoneId={currentMilestoneId} onMilestoneClick={onMilestoneClick} onPrClick={onPrClick} />
+          ))}
+        </div>
+      )}
+    </DashboardWidget>
+  )
+}

--- a/monitor/src/components/project/OrchestratorState.jsx
+++ b/monitor/src/components/project/OrchestratorState.jsx
@@ -57,6 +57,36 @@ export function OrchestratorStateCard({ selectedProject, globalUptime, controlAc
                selectedProject.phase || 'Unknown'}
             </StatusPill>
           </div>
+          {selectedProject.currentMilestoneId && (
+            <div className="flex justify-between items-center gap-3">
+              <span className="text-neutral-600 dark:text-neutral-300">Milestone ID</span>
+              <span className="text-sm font-mono text-right break-all">{selectedProject.currentMilestoneId}</span>
+            </div>
+          )}
+          {!selectedProject.currentMilestoneId && selectedProject.pendingMilestoneId && (
+            <div className="flex justify-between items-center gap-3">
+              <span className="text-neutral-600 dark:text-neutral-300">Pending Milestone</span>
+              <span className="text-sm font-mono text-right break-all">{selectedProject.pendingMilestoneId}</span>
+            </div>
+          )}
+          {selectedProject.currentEpochId && (
+            <div className="flex justify-between items-center gap-3">
+              <span className="text-neutral-600 dark:text-neutral-300">Epoch ID</span>
+              <span className="text-sm font-mono text-right break-all">{selectedProject.currentEpochId}</span>
+            </div>
+          )}
+          {selectedProject.currentEpochPrId && (
+            <div className="flex justify-between items-center gap-3">
+              <span className="text-neutral-600 dark:text-neutral-300">Epoch PR</span>
+              <span className="text-sm font-mono text-right">#{selectedProject.currentEpochPrId}</span>
+            </div>
+          )}
+          {selectedProject.currentMilestoneBranch && (
+            <div className="flex justify-between items-center gap-3">
+              <span className="text-neutral-600 dark:text-neutral-300">Milestone Branch</span>
+              <span className="text-sm font-mono text-right break-all">{selectedProject.currentMilestoneBranch}</span>
+            </div>
+          )}
           {selectedProject.phase === 'implementation' && selectedProject.milestoneCyclesBudget > 0 && (
             <div className="flex justify-between items-center">
               <span className="text-neutral-600 dark:text-neutral-300">Milestone Progress</span>

--- a/src/server.js
+++ b/src/server.js
@@ -1103,12 +1103,71 @@ class ProjectRunner {
     }
   }
 
+  closeOpenEpochPRForBranch(branchName, { actor = 'apollo', reason = '' } = {}) {
+    if (!branchName) return null;
+    try {
+      const db = this.getDb();
+      const pr = db.prepare(`
+        SELECT * FROM tbc_prs
+        WHERE status = 'open'
+          AND (
+            (branch_name IS NOT NULL AND branch_name = ?)
+            OR head_branch = ?
+          )
+        ORDER BY updated_at DESC, id DESC
+        LIMIT 1
+      `).get(branchName, branchName);
+      if (!pr) {
+        db.close();
+        return null;
+      }
+      const normalizedStatus = 'closed';
+      db.prepare(`
+        UPDATE tbc_prs
+        SET status = ?, decision = ?, decision_reason = ?, updated_by = ?, updated_at = ?
+        WHERE id = ?
+      `).run(
+        normalizedStatus,
+        'close',
+        reason || '',
+        actor,
+        new Date().toISOString(),
+        pr.id,
+      );
+      db.close();
+      return { ...pr, status: normalizedStatus, decision: 'close', decision_reason: reason || '' };
+    } catch {
+      return null;
+    }
+  }
+
+  normalizeResetTargetMilestone(resetTo) {
+    const value = typeof resetTo === 'string' ? resetTo.trim() : '';
+    if (!value) return null;
+    if (/^root$/i.test(value)) return { milestoneId: null, label: 'root' };
+    const current = String(this.currentMilestoneId || '').trim();
+    if (!current) return null;
+    const candidate = value.replace(/^m/i, 'M');
+    const ancestors = [];
+    const parts = current.split('.');
+    for (let i = parts.length; i >= 1; i--) ancestors.push(parts.slice(0, i).join('.'));
+    if (!ancestors.includes(candidate)) return null;
+    return { milestoneId: candidate, label: candidate };
+  }
+
   makeMilestoneBranchPrefix(milestoneId) {
     return String(milestoneId || 'M0').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
   }
 
-  slugifyMilestoneTitle(title) {
-    return String(title || 'milestone').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 48) || 'milestone';
+  slugifyMilestoneTitle(title, { stripLeadingMilestoneId = null } = {}) {
+    let normalizedTitle = String(title || 'milestone');
+    if (stripLeadingMilestoneId) {
+      const escapedMilestoneId = String(stripLeadingMilestoneId)
+        .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+        .replace(/\\\./g, '[\\s._-]*');
+      normalizedTitle = normalizedTitle.replace(new RegExp(`^\\s*${escapedMilestoneId}(?:[\\s:._-]+|\\b)`, 'i'), '');
+    }
+    return normalizedTitle.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 48) || 'milestone';
   }
 
   async allocateNextMilestoneId(parentMilestoneId = null) {
@@ -1687,14 +1746,24 @@ class ProjectRunner {
     if (this.currentAgentProcess) {
       this.currentAgentProcess.kill('SIGTERM');
     }
+    if (this.currentMilestoneBranch) {
+      this.closeOpenEpochPRForBranch(this.currentMilestoneBranch, {
+        actor: 'ares',
+        reason: `Epoch killed manually while replanning milestone ${this.currentMilestoneId || 'unknown'}.`,
+      });
+    }
     this.currentSchedule = null;
     this.completedAgents = [];
     this.setState({
       phase: 'athena',
+      pendingMilestoneId: null,
       milestoneTitle: null,
       milestoneDescription: null,
       milestoneCyclesBudget: 0,
       milestoneCyclesUsed: 0,
+      currentEpochId: null,
+      currentEpochPrId: null,
+      currentMilestoneBranch: null,
       verificationFeedback: null,
       isFixRound: false,
     });
@@ -1919,7 +1988,11 @@ class ProjectRunner {
           } else {
             situation = `> **Situation: Implementation Deadline Missed**\n> Ares's team used ${this.milestoneCyclesUsed}/${this.milestoneCyclesBudget} cycles without completing the milestone.\n> Previous milestone: ${this.currentMilestoneId || 'unknown'}\n> Current branch: ${this.currentMilestoneBranch || 'not set'}\n\n`;
           }
-          situation += `> **Assigned milestone ID:** ${this.pendingMilestoneId}\n> **Reserved branch prefix:** ${reservedBranchPrefix}\n\n`;
+          situation += `> **Assigned milestone ID:** ${this.pendingMilestoneId}\n> **Reserved branch prefix:** ${reservedBranchPrefix}\n`;
+          if (this.currentMilestoneId) {
+            situation += `> **Optional reset:** If the current subtree is wrong, you may return a milestone with \"reset_to\": \"${this.currentMilestoneId}\" or any ancestor milestone id (or \"root\") to abandon deeper branches and replan from that level.\n`;
+          }
+          situation += `\n`;
 
           const result = await this.runAgent(athena, config, null, situation);
           cycleTotal++;
@@ -1938,7 +2011,23 @@ class ProjectRunner {
               try {
                 const milestone = JSON.parse(milestoneMatch[1]);
                 const milestoneTitle = milestone.title || milestone.description.slice(0, 80);
-                const milestoneId = this.pendingMilestoneId || this.currentMilestoneId || await this.allocateNextMilestoneId(this.currentMilestoneId || null);
+                const resetTarget = this.normalizeResetTargetMilestone(milestone.reset_to);
+                const resetTo = resetTarget ? resetTarget.milestoneId : (this.currentMilestoneId || null);
+                const shouldReusePendingMilestoneId = !!this.pendingMilestoneId && resetTo === (this.currentMilestoneId || null);
+                const milestoneId = shouldReusePendingMilestoneId
+                  ? this.pendingMilestoneId
+                  : await this.allocateNextMilestoneId(resetTo);
+                if (milestone.reset_to && !resetTarget) {
+                  log(`Ignoring invalid reset_to target from Athena: ${milestone.reset_to}`, this.id);
+                } else if (milestone.reset_to && resetTarget) {
+                  log(`Athena reset planning anchor to ${resetTarget.label}`, this.id);
+                  if (this.currentMilestoneBranch) {
+                    this.closeOpenEpochPRForBranch(this.currentMilestoneBranch, {
+                      actor: 'athena',
+                      reason: `Athena reset subtree to ${resetTarget.label} while replanning.`,
+                    });
+                  }
+                }
                 this.setState({
                   milestoneTitle,
                   milestoneDescription: milestone.description,
@@ -2065,7 +2154,7 @@ class ProjectRunner {
           }
           if (!this.currentMilestoneBranch) {
             const branchPrefix = this.makeMilestoneBranchPrefix(this.currentMilestoneId);
-            this.currentMilestoneBranch = `${String(this.currentEpochId || 'E0').toLowerCase()}-${branchPrefix}-${this.slugifyMilestoneTitle(this.milestoneTitle)}`;
+            this.currentMilestoneBranch = `${String(this.currentEpochId || 'E0').toLowerCase()}-${branchPrefix}-${this.slugifyMilestoneTitle(this.milestoneTitle, { stripLeadingMilestoneId: this.currentMilestoneId })}`;
             epochStateChanged = true;
           }
           if (epochStateChanged) this.saveState();

--- a/src/server.js
+++ b/src/server.js
@@ -2114,6 +2114,8 @@ class ProjectRunner {
             const { total, failures } = await this.executeSchedule(schedule, config, 'athena');
             cycleTotal += total;
             cycleFailures += failures;
+            this.currentSchedule = null;
+            this.completedAgents = [];
           }
 
           this.saveState();

--- a/src/server.js
+++ b/src/server.js
@@ -379,6 +379,7 @@ class ProjectRunner {
     this.currentEpochPrId = null;
     this.currentMilestoneBranch = null;
     this.lastMergedMilestoneBranch = null;
+    this.aresGraceCycleUsed = false;
     this.verificationFeedback = null;
     this.examinationFeedback = null;
     this.pendingCompletionMessage = null;
@@ -1155,6 +1156,24 @@ class ProjectRunner {
     return { milestoneId: candidate, label: candidate };
   }
 
+  getParentMilestoneId(milestoneId = null) {
+    const value = String(milestoneId || '').trim();
+    if (!value || !value.includes('.')) return null;
+    return value.split('.').slice(0, -1).join('.') || null;
+  }
+
+  async getMilestoneRecord(milestoneId) {
+    if (!milestoneId) return null;
+    try {
+      const db = this.getDb();
+      const row = db.prepare(`SELECT * FROM milestones WHERE milestone_id = ?`).get(milestoneId);
+      db.close();
+      return row || null;
+    } catch {
+      return null;
+    }
+  }
+
   makeMilestoneBranchPrefix(milestoneId) {
     return String(milestoneId || 'M0').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
   }
@@ -1430,6 +1449,7 @@ class ProjectRunner {
       currentEpochId: null,
       currentEpochPrId: null,
       currentMilestoneBranch: null,
+      aresGraceCycleUsed: false,
       verificationFeedback: null,
       examinationFeedback: null,
       pendingCompletionMessage: null,
@@ -1491,6 +1511,7 @@ class ProjectRunner {
       agent TEXT NOT NULL,
       body TEXT NOT NULL,
       summary TEXT,
+      milestone_id TEXT,
       created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
     )`);
     try { db.exec('ALTER TABLE reports ADD COLUMN summary TEXT'); } catch {}
@@ -1505,14 +1526,15 @@ class ProjectRunner {
     try { db.exec('ALTER TABLE reports ADD COLUMN key_id TEXT'); } catch {}
     try { db.exec('ALTER TABLE reports ADD COLUMN visibility_mode TEXT'); } catch {}
     try { db.exec('ALTER TABLE reports ADD COLUMN visibility_issues TEXT'); } catch {}
-    db.prepare(`INSERT INTO reports (cycle, agent, body, created_at, cost, duration_ms, input_tokens, output_tokens, cache_read_tokens, success, model, timed_out, key_id, visibility_mode, visibility_issues)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(
+    try { db.exec('ALTER TABLE reports ADD COLUMN milestone_id TEXT'); } catch {}
+    db.prepare(`INSERT INTO reports (cycle, agent, body, created_at, cost, duration_ms, input_tokens, output_tokens, cache_read_tokens, success, model, timed_out, key_id, visibility_mode, visibility_issues, milestone_id)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(
       this.cycleCount, agentName, reportBody, new Date().toISOString(),
       null, durationMs,
       null, null, null,
       success ? 1 : 0, null, 0,
       null,
-      'full', JSON.stringify([])
+      'full', JSON.stringify([]), this.currentMilestoneId || null
     );
     const lastId = db.prepare('SELECT last_insert_rowid() as id').get().id;
     db.close();
@@ -1611,6 +1633,7 @@ class ProjectRunner {
         this.currentEpochPrId = state.currentEpochPrId || null;
         this.currentMilestoneBranch = state.currentMilestoneBranch || null;
         this.lastMergedMilestoneBranch = state.lastMergedMilestoneBranch || null;
+        this.aresGraceCycleUsed = state.aresGraceCycleUsed || false;
         this.verificationFeedback = state.verificationFeedback || null;
         this.examinationFeedback = state.examinationFeedback || null;
         this.pendingCompletionMessage = state.pendingCompletionMessage || null;
@@ -1655,6 +1678,7 @@ class ProjectRunner {
         currentEpochPrId: this.currentEpochPrId || null,
         currentMilestoneBranch: this.currentMilestoneBranch || null,
         lastMergedMilestoneBranch: this.lastMergedMilestoneBranch || null,
+        aresGraceCycleUsed: this.aresGraceCycleUsed || false,
         verificationFeedback: this.verificationFeedback,
         examinationFeedback: this.examinationFeedback,
         pendingCompletionMessage: this.pendingCompletionMessage,
@@ -2038,6 +2062,7 @@ class ProjectRunner {
                   currentEpochId: null,
                   currentEpochPrId: null,
                   currentMilestoneBranch: null,
+                  aresGraceCycleUsed: false,
                   verificationFeedback: null,
                   examinationFeedback: null,
                   pendingCompletionMessage: null,
@@ -2124,13 +2149,14 @@ class ProjectRunner {
 
       // ===== PHASE: IMPLEMENTATION (Ares + his workers) =====
       else if (this.phase === 'implementation') {
+        const aresGraceMode = this.milestoneCyclesUsed >= this.milestoneCyclesBudget;
         // Check if deadline missed (before running)
-        if (this.milestoneCyclesUsed >= this.milestoneCyclesBudget) {
+        if (aresGraceMode && this.aresGraceCycleUsed) {
           const failureReason = `Implementation deadline missed after ${this.milestoneCyclesUsed}/${this.milestoneCyclesBudget} cycles for ${this.currentMilestoneId || 'unknown milestone'}.`;
           await this.decideEpochPR('closed', { actor: 'apollo', reason: failureReason });
           await this.markCurrentMilestoneFailed(failureReason);
           log(`⏰ Implementation deadline missed (${this.milestoneCyclesUsed}/${this.milestoneCyclesBudget} cycles)`, this.id);
-          this.setState({ currentEpochId: null, currentEpochPrId: null, phase: 'athena' });
+          this.setState({ currentEpochId: null, currentEpochPrId: null, currentMilestoneBranch: null, aresGraceCycleUsed: false, phase: 'athena' });
           continue;
         }
 
@@ -2162,38 +2188,74 @@ class ProjectRunner {
           if (epochStateChanged) this.saveState();
           const openEpochPr = await this.ensureEpochPRForCurrentMilestone();
           // Build context for Ares (remaining includes this cycle)
-          const cyclesRemaining = this.milestoneCyclesBudget - this.milestoneCyclesUsed;
-          let aresContext = `> **Milestone ID:** ${this.currentMilestoneId || 'unknown'}\n> **Milestone:** ${this.milestoneDescription}\n> **Epoch ID:** ${this.currentEpochId || 'unknown'}\n> **Cycles remaining:** ${cyclesRemaining} of ${this.milestoneCyclesBudget}\n> **Milestone branch:** ${this.currentMilestoneBranch || 'not set'}\n> **Epoch PR:** ${openEpochPr?.id ? `#${openEpochPr.id}` : 'not set'}\n> **Epoch PR rule:** The orchestrator assigned exactly one TBC PR to this milestone branch. Use it instead of creating competing PRs.\n\n`;
+          const cyclesRemaining = Math.max(0, this.milestoneCyclesBudget - this.milestoneCyclesUsed);
+          let aresContext = `> **Milestone ID:** ${this.currentMilestoneId || 'unknown'}
+> **Milestone:** ${this.milestoneDescription}
+> **Epoch ID:** ${this.currentEpochId || 'unknown'}
+> **Cycles remaining:** ${cyclesRemaining} of ${this.milestoneCyclesBudget}
+> **Milestone branch:** ${this.currentMilestoneBranch || 'not set'}
+> **Epoch PR:** ${openEpochPr?.id ? `#${openEpochPr.id}` : 'not set'}
+> **Epoch PR rule:** The orchestrator assigned exactly one TBC PR to this milestone branch. Use it instead of creating competing PRs.
+
+`;
+          if (aresGraceMode) {
+            aresContext += `> **Grace review mode:** Worker budget is exhausted. This is your final manager-only pass.
+> **Do not emit a schedule. Do not assign any workers.**
+> Review the existing evidence only. If the milestone is already complete, emit <!-- CLAIM_COMPLETE -->. Otherwise emit no completion block and the milestone will fail.
+
+`;
+          }
           if (this.isFixRound && this.verificationFeedback) {
-            aresContext += `> **Legacy verification feedback:**\n> ${this.verificationFeedback}\n\n`;
+            aresContext += `> **Legacy verification feedback:**
+> ${this.verificationFeedback}
+
+`;
           }
 
           const result = await this.runAgent(ares, config, null, aresContext);
           cycleTotal++;
           if (!result || !result.success) cycleFailures++;
+          if (aresGraceMode) this.aresGraceCycleUsed = true;
 
           // Parse schedule and check for CLAIM_COMPLETE
           let schedule = null;
+          let claimedComplete = false;
           if (result && result.resultText) {
-            schedule = this.parseSchedule(result.resultText);
-            if (schedule) {
-              log(`Schedule: ${JSON.stringify(schedule)}`, this.id);
-              this.currentSchedule = schedule;
+            if (!aresGraceMode) {
+              schedule = this.parseSchedule(result.resultText);
+              if (schedule) {
+                log(`Schedule: ${JSON.stringify(schedule)}`, this.id);
+                this.currentSchedule = schedule;
+              }
+            } else if (this.parseSchedule(result.resultText)) {
+              log('⚠️ Ignoring Ares schedule because grace review mode forbids worker scheduling', this.id);
             }
 
             // Check if Ares claims milestone complete
             if (result.resultText.includes('<!-- CLAIM_COMPLETE -->')) {
+              claimedComplete = true;
               const openEpochPr = await this.ensureEpochPRForCurrentMilestone();
               if (!openEpochPr) {
                 this.verificationFeedback = `Ares claimed milestone completion without an orchestrator-managed epoch PR on branch ${this.currentMilestoneBranch || 'unknown'}.`;
                 log('⚠️ CLAIM_COMPLETE ignored because no orchestrator-managed epoch PR exists for the current milestone branch', this.id);
                 this.saveState();
+                claimedComplete = false;
               } else {
                 log(`🎯 Ares claims milestone complete for epoch PR #${openEpochPr.id} — switching to verification`, this.id);
                 this.setState({ phase: 'verification', currentEpochPrId: openEpochPr.id });
                 broadcastEvent({ type: 'phase', project: this.id, phase: 'verification', title: this.milestoneTitle });
               }
             }
+          }
+
+          if (aresGraceMode && !claimedComplete) {
+            const failureReason = `Implementation deadline missed after ${this.milestoneCyclesUsed}/${this.milestoneCyclesBudget} cycles for ${this.currentMilestoneId || 'unknown milestone'} (Ares grace review did not claim completion).`;
+            await this.decideEpochPR('closed', { actor: 'apollo', reason: failureReason });
+            await this.markCurrentMilestoneFailed(failureReason);
+            log(`⏰ ${failureReason}`, this.id);
+            this.setState({ currentEpochId: null, currentEpochPrId: null, currentMilestoneBranch: null, aresGraceCycleUsed: false, phase: 'athena', verificationFeedback: failureReason });
+            this.saveState();
+            continue;
           }
 
           // Execute schedule steps (delays + workers)
@@ -2232,7 +2294,10 @@ class ProjectRunner {
         } else {
         const apollo = managers.find(m => m.name === 'apollo');
         if (apollo) {
-          const apolloContext = `> **Milestone to verify:** ${this.milestoneDescription}\n> **Milestone branch:** ${this.currentMilestoneBranch || 'not set'}\n> **Active epoch PR:** ${this.currentEpochPrId || 'unknown'}\n> Apollo owns the PR decision: merge on pass, close on fail.\n\n`;
+          const isRollupVerification = !this.currentEpochPrId;
+          const apolloContext = isRollupVerification
+            ? `> **Milestone to verify:** ${this.milestoneDescription}\n> **Rollup verification target:** ${this.currentMilestoneId || 'unknown'}\n> **Verification mode:** Parent milestone rollup after a child milestone passed\n> **Active epoch PR:** none (rollup verification)\n> Apollo should decide whether this parent milestone is now fully complete or Athena should plan the next child under it.\n\n`
+            : `> **Milestone to verify:** ${this.milestoneDescription}\n> **Milestone branch:** ${this.currentMilestoneBranch || 'not set'}\n> **Active epoch PR:** ${this.currentEpochPrId || 'unknown'}\n> Apollo owns the PR decision: merge on pass, close on fail.\n\n`;
 
           const result = await this.runAgent(apollo, config, null, apolloContext);
           cycleTotal++;
@@ -2278,46 +2343,103 @@ class ProjectRunner {
 
           // Process decision
           if (decision === 'pass') {
-            const mergedPr = await this.decideEpochPR('merged', {
+            const mergedPr = isRollupVerification ? null : await this.decideEpochPR('merged', {
               actor: 'apollo',
               reason: `Apollo passed milestone ${this.currentMilestoneId || ''} ${this.milestoneTitle || this.milestoneDescription || ''}`.trim(),
             });
+            const completedMilestoneId = this.currentMilestoneId;
+            const completedMilestoneTitle = this.milestoneTitle;
+            const parentMilestoneId = this.getParentMilestoneId(completedMilestoneId);
             await this.markCurrentMilestoneCompleted();
-            log(`✅ Milestone verified — waking Athena for next milestone`, this.id);
-            broadcastEvent({ type: 'verified', project: this.id, title: this.milestoneTitle });
-            this.milestoneTitle = null;
-            this.setState({
-              milestoneTitle: null,
-              milestoneDescription: null,
-              milestoneCyclesBudget: 0,
-              milestoneCyclesUsed: 0,
-              currentMilestoneId: null,
-              pendingMilestoneId: null,
-              currentEpochId: null,
-              currentEpochPrId: null,
-              currentMilestoneBranch: null,
-              lastMergedMilestoneBranch: mergedPr?.branch_name || mergedPr?.head_branch || this.currentMilestoneBranch || this.lastMergedMilestoneBranch,
-              verificationFeedback: null,
-              isFixRound: false,
-              phase: 'athena',
-            });
+            if (parentMilestoneId) {
+              const parentMilestone = await this.getMilestoneRecord(parentMilestoneId);
+              log(`✅ Milestone verified — escalating completion check to parent milestone ${parentMilestoneId}`, this.id);
+              broadcastEvent({ type: 'verified', project: this.id, title: completedMilestoneTitle });
+              if (parentMilestone) {
+                await this.upsertMilestoneRecord({
+                  milestoneId: parentMilestoneId,
+                  title: parentMilestone.title,
+                  description: parentMilestone.description,
+                  cyclesBudget: parentMilestone.cycles_budget,
+                  branchName: parentMilestone.branch_name,
+                  parentMilestoneId: parentMilestone.parent_milestone_id,
+                  phase: 'verification',
+                  status: 'active',
+                  linkedPrId: parentMilestone.linked_pr_id,
+                  failureReason: null,
+                });
+              }
+              this.setState({
+                milestoneTitle: parentMilestone?.title || parentMilestoneId,
+                milestoneDescription: parentMilestone?.description || `Parent rollup verification for ${parentMilestoneId}`,
+                milestoneCyclesBudget: parentMilestone?.cycles_budget || 0,
+                milestoneCyclesUsed: parentMilestone?.cycles_used || 0,
+                currentMilestoneId: parentMilestoneId,
+                pendingMilestoneId: null,
+                currentEpochId: null,
+                currentEpochPrId: null,
+                currentMilestoneBranch: parentMilestone?.branch_name || null,
+                aresGraceCycleUsed: false,
+                lastMergedMilestoneBranch: mergedPr?.branch_name || mergedPr?.head_branch || this.currentMilestoneBranch || this.lastMergedMilestoneBranch,
+                verificationFeedback: null,
+                isFixRound: false,
+                phase: 'verification',
+              });
+              broadcastEvent({ type: 'phase', project: this.id, phase: 'verification', title: parentMilestone?.title || parentMilestoneId });
+            } else {
+              log(`✅ Milestone verified — waking Athena for next milestone`, this.id);
+              broadcastEvent({ type: 'verified', project: this.id, title: this.milestoneTitle });
+              this.milestoneTitle = null;
+              this.setState({
+                milestoneTitle: null,
+                milestoneDescription: null,
+                milestoneCyclesBudget: 0,
+                milestoneCyclesUsed: 0,
+                currentMilestoneId: null,
+                pendingMilestoneId: null,
+                currentEpochId: null,
+                currentEpochPrId: null,
+                currentMilestoneBranch: null,
+                aresGraceCycleUsed: false,
+                lastMergedMilestoneBranch: mergedPr?.branch_name || mergedPr?.head_branch || this.currentMilestoneBranch || this.lastMergedMilestoneBranch,
+                verificationFeedback: null,
+                isFixRound: false,
+                phase: 'athena',
+              });
+            }
           } else if (decision === 'fail') {
             const failureReason = this.verificationFeedback || 'Apollo rejected the epoch PR and requested milestone splitting or narrowing.';
-            await this.decideEpochPR('closed', {
-              actor: 'apollo',
-              reason: failureReason,
-            });
-            await this.markCurrentMilestoneFailed(failureReason);
-            log('❌ Verification failed — returning to Athena for split/replan', this.id);
-            broadcastEvent({ type: 'verify-fail', project: this.id, title: this.milestoneTitle });
-            this.setState({
-              pendingMilestoneId: null,
-              currentEpochId: null,
-              currentEpochPrId: null,
-              verificationFeedback: failureReason,
-              isFixRound: false,
-              phase: 'athena',
-            });
+            if (isRollupVerification) {
+              log('❌ Parent rollup verification incomplete — returning to Athena to plan the next child milestone', this.id);
+              broadcastEvent({ type: 'verify-fail', project: this.id, title: this.milestoneTitle });
+              this.setState({
+                pendingMilestoneId: null,
+                currentEpochId: null,
+                currentEpochPrId: null,
+                currentMilestoneBranch: null,
+                aresGraceCycleUsed: false,
+                verificationFeedback: failureReason,
+                isFixRound: false,
+                phase: 'athena',
+              });
+            } else {
+              await this.decideEpochPR('closed', {
+                actor: 'apollo',
+                reason: failureReason,
+              });
+              await this.markCurrentMilestoneFailed(failureReason);
+              log('❌ Verification failed — returning to Athena for split/replan', this.id);
+              broadcastEvent({ type: 'verify-fail', project: this.id, title: this.milestoneTitle });
+              this.setState({
+                pendingMilestoneId: null,
+                currentEpochId: null,
+                currentEpochPrId: null,
+                aresGraceCycleUsed: false,
+                verificationFeedback: failureReason,
+                isFixRound: false,
+                phase: 'athena',
+              });
+            }
           } else {
             // No decision yet, stay in verification phase — still save
             this.saveState();
@@ -2365,7 +2487,7 @@ class ProjectRunner {
                 failData = { feedback: 'Themis rejected project completion, but the response could not be parsed.' };
               }
               decision = 'fail';
-            } else if (!schedule) {
+            } else if (!schedule && decision == null) {
               decision = 'fail';
             }
           }
@@ -2642,6 +2764,7 @@ class ProjectRunner {
           agent TEXT NOT NULL,
           body TEXT NOT NULL,
           summary TEXT,
+          milestone_id TEXT,
           created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
         )`);
         try { db.exec('ALTER TABLE reports ADD COLUMN summary TEXT'); } catch {}
@@ -2656,14 +2779,16 @@ class ProjectRunner {
         try { db.exec('ALTER TABLE reports ADD COLUMN key_id TEXT'); } catch {}
         try { db.exec('ALTER TABLE reports ADD COLUMN visibility_mode TEXT'); } catch {}
         try { db.exec('ALTER TABLE reports ADD COLUMN visibility_issues TEXT'); } catch {}
-        db.prepare(`INSERT INTO reports (cycle, agent, body, created_at, cost, duration_ms, input_tokens, output_tokens, cache_read_tokens, success, model, timed_out, key_id, visibility_mode, visibility_issues)
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(
+        try { db.exec('ALTER TABLE reports ADD COLUMN milestone_id TEXT'); } catch {}
+    try { db.exec('ALTER TABLE reports ADD COLUMN milestone_id TEXT'); } catch {}
+        db.prepare(`INSERT INTO reports (cycle, agent, body, created_at, cost, duration_ms, input_tokens, output_tokens, cache_read_tokens, success, model, timed_out, key_id, visibility_mode, visibility_issues, milestone_id)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(
           this.cycleCount, agent.name, reportBody, new Date().toISOString(),
           cost ?? null, durationMs ?? null,
           usage?.inputTokens ?? null, usage?.outputTokens ?? null, usage?.cacheReadTokens ?? null,
           success ? 1 : 0, this.currentAgentModel ?? null, killedByTimeout ? 1 : 0,
           this.currentAgentKeyId ?? null,
-          this.currentAgentVisibility?.mode || 'full', JSON.stringify(this.currentAgentVisibility?.issues || [])
+          this.currentAgentVisibility?.mode || 'full', JSON.stringify(this.currentAgentVisibility?.issues || []), this.currentMilestoneId || null
         );
         const lastId = db.prepare('SELECT last_insert_rowid() as id').get().id;
         db.close();
@@ -4049,6 +4174,25 @@ const server = http.createServer(async (req, res) => {
       return;
     }
 
+    // GET /api/projects/:id/milestones — list milestone records for tree rendering
+    if (req.method === 'GET' && subPath === 'milestones') {
+      try {
+        const db = runner.getDb();
+        const milestones = db.prepare(`
+          SELECT id, milestone_id, title, description, cycles_budget, cycles_used, branch_name, parent_milestone_id, linked_pr_id, failure_reason, phase, status, created_at, completed_at
+          FROM milestones
+          ORDER BY created_at ASC, id ASC
+        `).all();
+        db.close();
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ milestones }));
+      } catch (e) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: e.message }));
+      }
+      return;
+    }
+
     // GET /api/projects/:id/prs/:prId — single PR
     const prDetailMatch = req.method === 'GET' && subPath.match(/^prs\/(\d+)$/);
     if (prDetailMatch) {
@@ -4084,6 +4228,8 @@ const server = http.createServer(async (req, res) => {
         try { db.exec('ALTER TABLE reports ADD COLUMN summary TEXT'); } catch {}
         try { db.exec('ALTER TABLE reports ADD COLUMN visibility_mode TEXT'); } catch {}
         try { db.exec('ALTER TABLE reports ADD COLUMN visibility_issues TEXT'); } catch {}
+        try { db.exec('ALTER TABLE reports ADD COLUMN milestone_id TEXT'); } catch {}
+    try { db.exec('ALTER TABLE reports ADD COLUMN milestone_id TEXT'); } catch {}
         const agent = url.searchParams.get('agent');
         const page = parseInt(url.searchParams.get('page')) || 1;
         const perPage = parseInt(url.searchParams.get('per_page')) || 20;

--- a/tests/athena-schedule-cleanup.test.js
+++ b/tests/athena-schedule-cleanup.test.js
@@ -1,0 +1,16 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const server = fs.readFileSync(path.resolve('src/server.js'), 'utf8')
+
+describe('athena schedule cleanup', () => {
+  it('clears currentSchedule and completedAgents after an Athena worker schedule finishes', () => {
+    const athenaBlock = server.match(/if \(this\.phase === 'athena'\) \{[\s\S]*?\n      \}\n\n      \/\/ ===== PHASE: IMPLEMENTATION/)
+    assert.ok(athenaBlock, 'Athena phase block not found')
+    const block = athenaBlock[0]
+    assert.match(block, /await this\.executeSchedule\(schedule, config, 'athena'\);[\s\S]*this\.currentSchedule = null;/)
+    assert.match(block, /await this\.executeSchedule\(schedule, config, 'athena'\);[\s\S]*this\.completedAgents = \[\];/)
+  })
+})

--- a/tests/epoch-pr-workflow.test.js
+++ b/tests/epoch-pr-workflow.test.js
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 const server = fs.readFileSync(path.resolve('src/server.js'), 'utf8');
+const athena = fs.readFileSync(path.resolve('agent/managers/athena.md'), 'utf8');
 
 describe('epoch-as-PR orchestrator flow', () => {
   it('requires an orchestrator-managed epoch PR before Ares can claim completion', () => {
@@ -22,5 +23,34 @@ describe('epoch-as-PR orchestrator flow', () => {
     assert.match(server, /Verification failed — returning to Athena for split\/replan/i);
     assert.match(server, /phase: 'athena'/);
     assert.doesNotMatch(server, /Verification failed — returning to Ares/);
+  });
+
+  it('avoids duplicating the milestone id in generated branch names', () => {
+    assert.match(server, /stripLeadingMilestoneId:\s*this\.currentMilestoneId/);
+    assert.match(server, /slugifyMilestoneTitle\(title, \{ stripLeadingMilestoneId = null \} = \{\}\)/);
+  });
+
+  it('treats kill epoch like a failed epoch by clearing active epoch state, keeping the milestone anchor, and closing any open epoch PR', () => {
+    const killEpochBlock = server.match(/killEpoch\(\) \{[\s\S]*?\n  \}\n\n  \/\/ Wait while paused/);
+    assert.ok(killEpochBlock);
+    const block = killEpochBlock[0];
+    assert.match(block, /closeOpenEpochPRForBranch\(this\.currentMilestoneBranch/);
+    assert.match(block, /pendingMilestoneId: null/);
+    assert.match(block, /currentEpochId: null/);
+    assert.match(block, /currentEpochPrId: null/);
+    assert.match(block, /currentMilestoneBranch: null/);
+    assert.doesNotMatch(block, /currentMilestoneId: null/);
+  });
+
+  it('lets Athena reset planning to an ancestor milestone or root before allocating the next milestone id', () => {
+    assert.match(server, /normalizeResetTargetMilestone\(milestone\.reset_to\)/);
+    assert.match(server, /await this\.allocateNextMilestoneId\(resetTo\)/);
+    assert.match(server, /Athena reset planning anchor to/);
+  });
+
+  it('documents the optional reset_to field for Athena milestone output', () => {
+    assert.match(athena, /"reset_to":"M2"/);
+    assert.match(athena, /`reset_to` is optional/);
+    assert.match(athena, /ancestor milestone/);
   });
 });

--- a/tests/epoch-pr-workflow.test.js
+++ b/tests/epoch-pr-workflow.test.js
@@ -5,6 +5,7 @@ import path from 'node:path';
 
 const server = fs.readFileSync(path.resolve('src/server.js'), 'utf8');
 const athena = fs.readFileSync(path.resolve('agent/managers/athena.md'), 'utf8');
+const ares = fs.readFileSync(path.resolve('agent/managers/ares.md'), 'utf8');
 
 describe('epoch-as-PR orchestrator flow', () => {
   it('requires an orchestrator-managed epoch PR before Ares can claim completion', () => {
@@ -52,5 +53,36 @@ describe('epoch-as-PR orchestrator flow', () => {
     assert.match(athena, /"reset_to":"M2"/);
     assert.match(athena, /`reset_to` is optional/);
     assert.match(athena, /ancestor milestone/);
+  });
+
+  it('escalates a successful child milestone to parent rollup verification instead of jumping to root', () => {
+    assert.match(server, /const isRollupVerification = !this\.currentEpochPrId/);
+    assert.match(server, /const parentMilestoneId = this\.getParentMilestoneId\(completedMilestoneId\)/);
+    assert.match(server, /Milestone verified — escalating completion check to parent milestone/);
+    assert.match(server, /phase: 'verification'/);
+    assert.match(server, /currentMilestoneId: parentMilestoneId/);
+  });
+
+  it('returns rollup verification failures to Athena without treating them as epoch PR failures', () => {
+    const rollupFailBlock = server.match(/if \(isRollupVerification\) \{[\s\S]*?\n            \} else \{/)
+    assert.ok(rollupFailBlock)
+    const block = rollupFailBlock[0]
+    assert.match(block, /Parent rollup verification incomplete — returning to Athena to plan the next child milestone/)
+    assert.doesNotMatch(block, /markCurrentMilestoneFailed/)
+  });
+
+  it('gives Ares one grace review turn after worker budget exhaustion', () => {
+    assert.match(server, /const aresGraceMode = this\.milestoneCyclesUsed >= this\.milestoneCyclesBudget/)
+    assert.match(server, /if \(aresGraceMode && this\.aresGraceCycleUsed\)/)
+    assert.match(server, /Grace review mode:\*\* Worker budget is exhausted/)
+    assert.match(server, /if \(aresGraceMode\) this\.aresGraceCycleUsed = true/)
+    assert.match(server, /Ares grace review did not claim completion/)
+    assert.match(server, /Ignoring Ares schedule because grace review mode forbids worker scheduling/)
+  });
+
+  it('documents that grace review mode forbids scheduling and allows only a completion claim', () => {
+    assert.match(ares, /If in grace review mode/)
+    assert.match(ares, /Do not emit a schedule or assign workers/)
+    assert.match(ares, /either emit `<!-- CLAIM_COMPLETE -->` or leave it out/)
   });
 });

--- a/tests/examination-phase.test.js
+++ b/tests/examination-phase.test.js
@@ -92,6 +92,15 @@ describe('Themis examination phase', () => {
       'Expected EXAM_PASS to exit examination phase cleanly');
   });
 
+  it('does not overwrite EXAM_PASS with failure just because no schedule exists', () => {
+    const src = readServer();
+    assert.doesNotMatch(
+      src,
+      /if \(result\.resultText\.includes\('\<\!-- EXAM_PASS --\>'\)\) \{\s*decision = 'pass';\s*\}[\s\S]*?else if \(!schedule\) \{\s*decision = 'fail';\s*\}/,
+      'EXAM_PASS must remain terminal success even when Themis returns no schedule'
+    );
+  });
+
   it('returns to athena and creates issues on EXAM_FAIL', () => {
     const src = readServer();
     const examBlock = src.match(/else if \(this\.phase === 'examination'\) \{([\s\S]*?)\n      \}/);

--- a/tests/milestone-tree-widget.test.js
+++ b/tests/milestone-tree-widget.test.js
@@ -1,0 +1,37 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const server = fs.readFileSync(path.resolve('src/server.js'), 'utf8')
+const projectView = fs.readFileSync(path.resolve('monitor/src/components/layout/ProjectView.jsx'), 'utf8')
+const treeCard = fs.readFileSync(path.resolve('monitor/src/components/project/MilestoneTreeCard.jsx'), 'utf8')
+
+describe('milestone tree widget', () => {
+  it('exposes milestone records through the project API', () => {
+    assert.match(server, /GET \/api\/projects\/:id\/milestones/)
+    assert.match(server, /FROM milestones/)
+    assert.match(server, /parent_milestone_id/)
+  })
+
+  it('loads milestones in ProjectView and renders the tree widget', () => {
+    assert.match(projectView, /fetch\(`\$\{baseApi\}\/milestones`\)/)
+    assert.match(projectView, /setMilestones\(/)
+    assert.match(projectView, /<MilestoneTreeCard/)
+  })
+
+  it('renders a read-only nested milestone tree with status metadata', () => {
+    assert.match(treeCard, /function buildTree/)
+    assert.match(treeCard, /children: \[\]/)
+    assert.match(treeCard, /Milestones \(\$\{milestones.length\}\)/)
+    assert.match(treeCard, /currentMilestoneId/)
+    assert.match(treeCard, /node\.linked_pr_id/)
+  })
+
+  it('shows recent milestones first, starts folded, and uses page scrolling like issues', () => {
+    assert.match(treeCard, /compareMilestonesDesc/)
+    assert.match(treeCard, /const \[open, setOpen\] = useState\(false\)/)
+    assert.doesNotMatch(treeCard, /max-h-\[32rem\] overflow-y-auto/)
+    assert.doesNotMatch(treeCard, /IntersectionObserver/)
+  })
+})

--- a/tests/report-metadata.test.js
+++ b/tests/report-metadata.test.js
@@ -227,3 +227,12 @@ describe('Report metadata in SQLite', () => {
     });
   });
 });
+
+
+describe('report milestone metadata UI', () => {
+  it('renders a milestone pill in the report header when milestone_id is present', () => {
+    const card = fs.readFileSync(path.resolve('monitor/src/components/project/AgentReportsCard.jsx'), 'utf8');
+    assert.match(card, /report\.milestone_id/);
+    assert.match(card, /StatusPill variant="meta" className="shrink-0 normal-case text-indigo-700 dark:text-indigo-300"/);
+  });
+});


### PR DESCRIPTION
## Summary
- let Athena emit optional `reset_to` in milestone JSON to abandon a subtree and re-anchor planning at an ancestor or root
- close any open epoch PR when kill-epoch is used, to match failed-epoch semantics
- surface the current milestone/epoch identifiers in the orchestrator state panel

## Testing
- node --test tests/epoch-pr-workflow.test.js
- npm run build --prefix monitor