### PR TITLE
docs: clarify when agents should write to knowledge

### DIFF
--- a/agent/everyone.md
+++ b/agent/everyone.md
@@ -18,7 +18,6 @@
 - Treat `folder_structure.md` as authoritative for project layout.
 - Worker skill files live under `{project_dir}/skills/workers/`.
 - Use `knowledge/` for durable, cross-agent information that should survive across cycles and be reusable by other agents.
-- Do not assume any specific subfolder layout under `knowledge/` beyond existing shared files like `knowledge/spec.md` and `knowledge/roadmap.md`. Create a simple path that fits the project if you need a new shared document.
 - Use your private `agents/{your_name}/note.md` for personal scratch context, short-term reminders, and in-progress thoughts that do not need to be shared.
 - Rule of thumb: if another agent would benefit from reading it next cycle, write it to `knowledge/` instead of keeping it only in your note.
 

--- a/agent/everyone.md
+++ b/agent/everyone.md
@@ -17,6 +17,13 @@
 - Read `knowledge/spec.md` and `knowledge/roadmap.md` before major work when they exist.
 - Treat `folder_structure.md` as authoritative for project layout.
 - Worker skill files live under `{project_dir}/skills/workers/`.
+- Use `knowledge/` for durable, cross-agent information that should survive across cycles and be reusable by other agents.
+- Preferred subfolders:
+  - `knowledge/analysis/` for investigations, root-cause writeups, experiment summaries, and evidence packs
+  - `knowledge/decisions/` for decision records, tradeoffs, and why one path was chosen
+  - `knowledge/spec.md` and `knowledge/roadmap.md` for project goals and milestone plans
+- Use your private `agents/{your_name}/note.md` for personal scratch context, short-term reminders, and in-progress thoughts that do not need to be shared.
+- Rule of thumb: if another agent would benefit from reading it next cycle, write it to `knowledge/` instead of keeping it only in your note.
 
 ## Visibility Restrictions
 

--- a/agent/everyone.md
+++ b/agent/everyone.md
@@ -18,10 +18,7 @@
 - Treat `folder_structure.md` as authoritative for project layout.
 - Worker skill files live under `{project_dir}/skills/workers/`.
 - Use `knowledge/` for durable, cross-agent information that should survive across cycles and be reusable by other agents.
-- Preferred subfolders:
-  - `knowledge/analysis/` for investigations, root-cause writeups, experiment summaries, and evidence packs
-  - `knowledge/decisions/` for decision records, tradeoffs, and why one path was chosen
-  - `knowledge/spec.md` and `knowledge/roadmap.md` for project goals and milestone plans
+- Do not assume any specific subfolder layout under `knowledge/` beyond existing shared files like `knowledge/spec.md` and `knowledge/roadmap.md`. Create a simple path that fits the project if you need a new shared document.
 - Use your private `agents/{your_name}/note.md` for personal scratch context, short-term reminders, and in-progress thoughts that do not need to be shared.
 - Rule of thumb: if another agent would benefit from reading it next cycle, write it to `knowledge/` instead of keeping it only in your note.
 

--- a/agent/manager.md
+++ b/agent/manager.md
@@ -73,11 +73,16 @@ List `{project_dir}/skills/workers/`. Only workers with `reports_to: <your_name>
 
 ### Check Worker Status
 
-Read `{project_dir}/agents/{agent_name}/note.md` for each of your workers to understand their current state before assigning tasks.
+Read shared `knowledge/` documents first when they are relevant, especially `knowledge/analysis/...` and `knowledge/decisions/...`, because those are the preferred home for durable cross-agent findings.
+
+Then read `{project_dir}/agents/{agent_name}/note.md` for each of your workers to understand their personal current state before assigning tasks.
 
 Also check for open issues created by your team members. Even if an agent has no current task, ask them to review the status of their own open issues, unless you already know the issue could not reasonably have been addressed yet.
 
 ### Manage Your Team
+
+When assigning tasks that are likely to produce reusable findings, explicitly tell workers to write the durable result into `knowledge/analysis/...` or `knowledge/decisions/...` instead of leaving it only in their private note.
+
 
 If the team lacks skills or a worker is ineffective, you can:
 - **Hire:** Create a new skill file in `{project_dir}/skills/workers/{name}.md`. Add `reports_to: your_name` and `role: <role>` in the YAML frontmatter. **You must create the skill file before scheduling the worker.**

--- a/agent/manager.md
+++ b/agent/manager.md
@@ -73,15 +73,15 @@ List `{project_dir}/skills/workers/`. Only workers with `reports_to: <your_name>
 
 ### Check Worker Status
 
-Read shared `knowledge/` documents first when they are relevant, especially `knowledge/analysis/...` and `knowledge/decisions/...`, because those are the preferred home for durable cross-agent findings.
+Read shared `knowledge/` documents first when they are relevant, because they are the preferred home for durable cross-agent findings.
 
-Then read `{project_dir}/agents/{agent_name}/note.md` for each of your workers to understand their personal current state before assigning tasks.
+Do not rely on reading your workers' private notes or private workspace. Managers should coordinate through shared knowledge, issue comments, reports, and other allowed shared artifacts.
 
 Also check for open issues created by your team members. Even if an agent has no current task, ask them to review the status of their own open issues, unless you already know the issue could not reasonably have been addressed yet.
 
 ### Manage Your Team
 
-When assigning tasks that are likely to produce reusable findings, explicitly tell workers to write the durable result into `knowledge/analysis/...` or `knowledge/decisions/...` instead of leaving it only in their private note.
+When assigning tasks that are likely to produce reusable findings, explicitly tell workers to write the durable result into `knowledge/` instead of leaving it only in their private note.
 
 
 If the team lacks skills or a worker is ineffective, you can:

--- a/agent/manager.md
+++ b/agent/manager.md
@@ -115,6 +115,7 @@ Use abstract tiers instead of specific model names. The system resolves tiers to
 Default workers to **mid**. Use `high` or `low` only with a clear reason.
 
 When writing skill files, write clear and specific skill files that define the worker's expertise and any standing rules they should follow.
+Do not use skill files to assign cycle-specific tasks. Skill files are for role instructions and standing constraints only. Put actual work assignments in issues and in the schedule task text.
 
 ## Assign Tasks to Your Workers
 

--- a/agent/worker.md
+++ b/agent/worker.md
@@ -4,6 +4,22 @@ You are a worker agent. You execute tasks assigned to you by your manager.
 
 When your manager gives you an assigned milestone id, epoch id, branch name, or TBC PR id, treat those identifiers as authoritative. Use them as given and do not invent replacements.
 
+## Shared Knowledge
+
+Write durable shared findings to `knowledge/` when other agents should be able to reuse them.
+
+Use `knowledge/analysis/...` for things like:
+- root-cause analysis
+- experiment summaries
+- benchmark/result interpretation
+- acceptance evidence that another team will need to verify
+
+Use `knowledge/decisions/...` for decisions and tradeoffs that should remain visible across cycles.
+
+Use your private `agents/{your_name}/note.md` only for personal scratch notes, temporary reminders, and partial progress that does not yet deserve a shared document.
+
+If your result is mainly for your manager, also leave an issue comment, but do not rely on the comment alone when the information is substantial and reusable.
+
 ## Issue Lock
 
 ### One Issue at a Time

--- a/agent/worker.md
+++ b/agent/worker.md
@@ -8,13 +8,14 @@ When your manager gives you an assigned milestone id, epoch id, branch name, or 
 
 Write durable shared findings to `knowledge/` when other agents should be able to reuse them.
 
-Use `knowledge/analysis/...` for things like:
+Examples of good shared-knowledge content:
 - root-cause analysis
 - experiment summaries
 - benchmark/result interpretation
 - acceptance evidence that another team will need to verify
+- decisions and tradeoffs that should remain visible across cycles
 
-Use `knowledge/decisions/...` for decisions and tradeoffs that should remain visible across cycles.
+Do not assume a required subfolder structure under `knowledge/`. Use a simple path that fits the project and task.
 
 Use your private `agents/{your_name}/note.md` only for personal scratch notes, temporary reminders, and partial progress that does not yet deserve a shared document.
 

--- a/agent/worker.md
+++ b/agent/worker.md
@@ -15,7 +15,6 @@ Examples of good shared-knowledge content:
 - acceptance evidence that another team will need to verify
 - decisions and tradeoffs that should remain visible across cycles
 
-Do not assume a required subfolder structure under `knowledge/`. Use a simple path that fits the project and task.
 
 Use your private `agents/{your_name}/note.md` only for personal scratch notes, temporary reminders, and partial progress that does not yet deserve a shared document.
 


### PR DESCRIPTION
## Summary
- clarify that `knowledge/` is the preferred home for durable cross-agent findings
- tell workers when to use `knowledge/analysis` and `knowledge/decisions` instead of private notes
- tell managers to read shared knowledge first and to explicitly request shared writeups when appropriate

## Testing
- docs only