### PR TITLE
docs: align knowledge guidance with privacy policy

### DIFF
--- a/agent/everyone.md
+++ b/agent/everyone.md
@@ -18,10 +18,7 @@
 - Treat `folder_structure.md` as authoritative for project layout.
 - Worker skill files live under `{project_dir}/skills/workers/`.
 - Use `knowledge/` for durable, cross-agent information that should survive across cycles and be reusable by other agents.
-- Preferred subfolders:
-  - `knowledge/analysis/` for investigations, root-cause writeups, experiment summaries, and evidence packs
-  - `knowledge/decisions/` for decision records, tradeoffs, and why one path was chosen
-  - `knowledge/spec.md` and `knowledge/roadmap.md` for project goals and milestone plans
+- Do not assume any specific subfolder layout under `knowledge/` beyond existing shared files like `knowledge/spec.md` and `knowledge/roadmap.md`. Create a simple path that fits the project if you need a new shared document.
 - Use your private `agents/{your_name}/note.md` for personal scratch context, short-term reminders, and in-progress thoughts that do not need to be shared.
 - Rule of thumb: if another agent would benefit from reading it next cycle, write it to `knowledge/` instead of keeping it only in your note.
 

--- a/agent/manager.md
+++ b/agent/manager.md
@@ -73,15 +73,15 @@ List `{project_dir}/skills/workers/`. Only workers with `reports_to: <your_name>
 
 ### Check Worker Status
 
-Read shared `knowledge/` documents first when they are relevant, especially `knowledge/analysis/...` and `knowledge/decisions/...`, because those are the preferred home for durable cross-agent findings.
+Read shared `knowledge/` documents first when they are relevant, because they are the preferred home for durable cross-agent findings.
 
-Then read `{project_dir}/agents/{agent_name}/note.md` for each of your workers to understand their personal current state before assigning tasks.
+Do not rely on reading your workers' private notes or private workspace. Managers should coordinate through shared knowledge, issue comments, reports, and other allowed shared artifacts.
 
 Also check for open issues created by your team members. Even if an agent has no current task, ask them to review the status of their own open issues, unless you already know the issue could not reasonably have been addressed yet.
 
 ### Manage Your Team
 
-When assigning tasks that are likely to produce reusable findings, explicitly tell workers to write the durable result into `knowledge/analysis/...` or `knowledge/decisions/...` instead of leaving it only in their private note.
+When assigning tasks that are likely to produce reusable findings, explicitly tell workers to write the durable result into `knowledge/` instead of leaving it only in their private note.
 
 
 If the team lacks skills or a worker is ineffective, you can:

--- a/agent/worker.md
+++ b/agent/worker.md
@@ -8,13 +8,14 @@ When your manager gives you an assigned milestone id, epoch id, branch name, or 
 
 Write durable shared findings to `knowledge/` when other agents should be able to reuse them.
 
-Use `knowledge/analysis/...` for things like:
+Examples of good shared-knowledge content:
 - root-cause analysis
 - experiment summaries
 - benchmark/result interpretation
 - acceptance evidence that another team will need to verify
+- decisions and tradeoffs that should remain visible across cycles
 
-Use `knowledge/decisions/...` for decisions and tradeoffs that should remain visible across cycles.
+Do not assume a required subfolder structure under `knowledge/`. Use a simple path that fits the project and task.
 
 Use your private `agents/{your_name}/note.md` only for personal scratch notes, temporary reminders, and partial progress that does not yet deserve a shared document.
 


### PR DESCRIPTION
## Summary
- remove the suggested `knowledge/analysis` and `knowledge/decisions` subfolder convention
- clarify that managers must not read worker private notes or private workspace
- steer managers toward shared knowledge, issue comments, and reports instead

## Validation
- node --test tests/agent-filesystem-policy.test.js