### PR TITLE
fix: preserve Themis EXAM_PASS without requiring a schedule

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -2487,7 +2487,7 @@ class ProjectRunner {
                 failData = { feedback: 'Themis rejected project completion, but the response could not be parsed.' };
               }
               decision = 'fail';
-            } else if (!schedule) {
+            } else if (!schedule && decision == null) {
               decision = 'fail';
             }
           }

--- a/tests/examination-phase.test.js
+++ b/tests/examination-phase.test.js
@@ -92,6 +92,15 @@ describe('Themis examination phase', () => {
       'Expected EXAM_PASS to exit examination phase cleanly');
   });
 
+  it('does not overwrite EXAM_PASS with failure just because no schedule exists', () => {
+    const src = readServer();
+    assert.doesNotMatch(
+      src,
+      /if \(result\.resultText\.includes\('\<\!-- EXAM_PASS --\>'\)\) \{\s*decision = 'pass';\s*\}[\s\S]*?else if \(!schedule\) \{\s*decision = 'fail';\s*\}/,
+      'EXAM_PASS must remain terminal success even when Themis returns no schedule'
+    );
+  });
+
   it('returns to athena and creates issues on EXAM_FAIL', () => {
     const src = readServer();
     const examBlock = src.match(/else if \(this\.phase === 'examination'\) \{([\s\S]*?)\n      \}/);


### PR DESCRIPTION
## Summary
- fix the examination-phase decision logic so EXAM_PASS remains a successful terminal result even when Themis returns no schedule
- keep the fallback failure path only for examination outputs that contain neither EXAM_PASS nor EXAM_FAIL nor a schedule
- add a regression test covering the SpaceLang loop where Themis approved completion but the backend incorrectly returned control to Athena

## Why
The old logic set decision = 'pass' for EXAM_PASS, but then overwrote it with decision = 'fail' when no schedule was present. That caused false completion rejections, sent projects back to Athena, and could create repeated completion/examination loops.

## Validation
- targeted examination regression test passes locally
- full unit suite passes locally (node --test tests/*.test.js)
- PR CI rerun is attached to this branch
