### PR TITLE
refactor: extract agent loading helpers

### DIFF
--- a/src/orchestrator/ProjectRunner.js
+++ b/src/orchestrator/ProjectRunner.js
@@ -6,6 +6,7 @@ import Database from 'better-sqlite3';
 import { runAgentWithAPI } from '../agent-runner.js';
 import { resolveModel, callModel, buildUserMessage } from '../providers/index.js';
 import { resolveKeyForProject, markRateLimited, markKeySucceeded } from '../key-pool.js';
+import { getAgentDetailsForRunner, loadAgentsForRunner } from './agent-loading.js';
 
 export function createProjectRunnerClass(deps) {
   const {
@@ -222,158 +223,11 @@ class ProjectRunner {
   }
 
   loadAgents() {
-    const managers = [];
-    const workers = [];
-    
-    const managersDir = path.join(ROOT, 'agent', 'managers');
-    const workersDir = this.workerSkillsDir;
-    
-    const parseRole = (content) => {
-      // Prefer frontmatter role: field
-      const fmRole = (content.match(/^role:\s*(.+)$/m) || [])[1]?.trim();
-      if (fmRole) return fmRole;
-      // Fallback: match "# Name (Role)" in markdown
-      const match = content.match(/^#\s*\w+\s*\(([^)]+)\)/m);
-      return match ? match[1] : null;
-    };
-    
-    const shortenModel = (model) => {
-      if (!model) return null;
-      const versionMatch = model.match(/(opus|sonnet|haiku)-(\d+)(?:-(\d+))?/i);
-      if (versionMatch) {
-        const name = versionMatch[1].toLowerCase();
-        const major = versionMatch[2];
-        const minor = versionMatch[3];
-        return minor && minor.length <= 2 ? `${name} ${major}.${minor}` : `${name} ${major}`;
-      }
-      if (model.includes('opus')) return 'opus';
-      if (model.includes('sonnet')) return 'sonnet';
-      if (model.includes('haiku')) return 'haiku';
-      return model;
-    };
-    
-    const parseModel = (content) => {
-      const match = content.match(/^model:\s*(.+)$/m);
-      return match ? shortenModel(match[1].trim()) : null;
-    };
-    
-    const config = this.loadConfig();
-    const managerOverrides = config.managers || {};
-    
-    if (fs.existsSync(managersDir)) {
-      for (const file of fs.readdirSync(managersDir)) {
-        if (file.endsWith('.md')) {
-          const name = file.replace('.md', '');
-          const content = fs.readFileSync(path.join(managersDir, file), 'utf-8');
-          const overrides = managerOverrides[name] || {};
-          // Disabled check: config override takes priority, then frontmatter
-          const isDisabled = overrides.disabled !== undefined ? overrides.disabled : /^disabled:\s*true$/m.test(content);
-          if (isDisabled) continue;
-          // Model: config override takes priority, then frontmatter
-          const frontmatterModel = (content.match(/^model:\s*(.+)$/m) || [])[1]?.trim() || null;
-          const rawModel = overrides.model || frontmatterModel;
-          managers.push({ name, role: parseRole(content), model: shortenModel(rawModel), rawModel, isManager: true });
-        }
-      }
-    }
-    
-    if (fs.existsSync(workersDir)) {
-      for (const file of fs.readdirSync(workersDir)) {
-        if (file.endsWith('.md')) {
-          const name = file.replace('.md', '');
-          const content = fs.readFileSync(path.join(workersDir, file), 'utf-8');
-          if (/^disabled:\s*true$/m.test(content)) continue;
-          const reportsTo = (content.match(/^reports_to:\s*(.+)$/m) || [])[1]?.trim() || null;
-          workers.push({ name, role: parseRole(content), model: parseModel(content), rawModel: (content.match(/^model:\s*(.+)$/m) || [])[1]?.trim() || null, isManager: false, reportsTo });
-        }
-      }
-    }
-    
-    const costSummary = this.getCostSummary();
-    for (const agent of [...managers, ...workers]) {
-      const agentCost = costSummary.agents[agent.name];
-      agent.totalCost = agentCost ? agentCost.totalCost : 0;
-      agent.last24hCost = agentCost ? agentCost.last24hCost : 0;
-      agent.lastCallCost = agentCost ? agentCost.lastCallCost : 0;
-      agent.avgCallCost = agentCost ? agentCost.avgCallCost : 0;
-      agent.callCount = agentCost ? agentCost.callCount : 0;
-    }
-
-    return { managers, workers };
+    return loadAgentsForRunner(this, { root: ROOT });
   }
 
   getAgentDetails(agentName) {
-    const workersDir = this.workerSkillsDir;
-    const managersDir = path.join(ROOT, 'agent', 'managers');
-    const agentNotesDir = this.getAgentNotesDir(agentName);
-    
-    let skillPath = path.join(workersDir, `${agentName}.md`);
-    let isManager = false;
-    if (!fs.existsSync(skillPath)) {
-      skillPath = path.join(managersDir, `${agentName}.md`);
-      isManager = true;
-    }
-    
-    if (!fs.existsSync(skillPath)) {
-      return null;
-    }
-    
-    const skill = fs.readFileSync(skillPath, 'utf-8');
-    
-    let agentFiles = [];
-    if (fs.existsSync(agentNotesDir)) {
-      agentFiles = fs.readdirSync(agentNotesDir).flatMap(f => {
-        const filePath = path.join(agentNotesDir, f);
-        const stat = fs.statSync(filePath);
-        if (!stat.isFile()) return [];
-        return [{
-          name: f,
-          size: stat.size,
-          modified: stat.mtime,
-          content: stat.size < 50000 ? fs.readFileSync(filePath, 'utf-8') : null
-        }];
-      });
-    }
-    
-    // Get last response from response log
-    let lastResponse = null;
-    let lastRawOutput = null;
-    const responseLogPath = path.join(this.responsesDir, `${agentName}.log`);
-    const rawLogPath = path.join(this.responsesDir, `${agentName}.raw.log`);
-    
-    const getLastBlock = (filePath, maxChars = 15000) => {
-      if (!fs.existsSync(filePath)) return null;
-      try {
-        const content = fs.readFileSync(filePath, 'utf-8');
-        const blocks = content.split(/={60,}/);
-        if (blocks.length >= 2) {
-          const lastBlock = blocks.slice(-2).join('').trim();
-          return lastBlock.length > maxChars ? lastBlock.slice(-maxChars) : lastBlock;
-        }
-      } catch {}
-      return null;
-    };
-    
-    lastResponse = getLastBlock(responseLogPath);
-    lastRawOutput = getLastBlock(rawLogPath);
-    
-    // Extract model from frontmatter
-    const modelMatch = skill.match(/^model:\s*(.+)$/m);
-    const frontmatterModel = modelMatch ? modelMatch[1].trim() : null;
-    
-    // Check config override (config.managers.<name>.model or config.workers.<name>.model)
-    const config = this.loadConfig();
-    const overrides = (isManager ? config.managers : config.workers) || {};
-    const configModel = overrides[agentName]?.model || null;
-    const model = configModel || frontmatterModel || null;
-    
-    // Read shared rules: everyone.md + role-specific (worker.md or manager.md)
-    let everyone = null;
-    let roleRules = null;
-    try { everyone = fs.readFileSync(path.join(ROOT, 'agent', 'everyone.md'), 'utf-8'); } catch {}
-    try { roleRules = fs.readFileSync(path.join(ROOT, 'agent', isManager ? 'manager.md' : 'worker.md'), 'utf-8'); } catch {}
-
-    return { name: agentName, isManager, skill, agentFiles, lastResponse, lastRawOutput, model, everyone, roleRules };
+    return getAgentDetailsForRunner(this, agentName, { root: ROOT });
   }
 
   getLogs(lines = 50) {

--- a/src/orchestrator/agent-loading.js
+++ b/src/orchestrator/agent-loading.js
@@ -1,0 +1,149 @@
+import fs from 'fs';
+import path from 'path';
+
+function parseRole(content) {
+  const fmRole = (content.match(/^role:\s*(.+)$/m) || [])[1]?.trim();
+  if (fmRole) return fmRole;
+  const match = content.match(/^#\s*\w+\s*\(([^)]+)\)/m);
+  return match ? match[1] : null;
+}
+
+function shortenModel(model) {
+  if (!model) return null;
+  const versionMatch = model.match(/(opus|sonnet|haiku)-(\d+)(?:-(\d+))?/i);
+  if (versionMatch) {
+    const name = versionMatch[1].toLowerCase();
+    const major = versionMatch[2];
+    const minor = versionMatch[3];
+    return minor && minor.length <= 2 ? `${name} ${major}.${minor}` : `${name} ${major}`;
+  }
+  if (model.includes('opus')) return 'opus';
+  if (model.includes('sonnet')) return 'sonnet';
+  if (model.includes('haiku')) return 'haiku';
+  return model;
+}
+
+function parseModel(content) {
+  const match = content.match(/^model:\s*(.+)$/m);
+  return match ? shortenModel(match[1].trim()) : null;
+}
+
+function getLastBlock(filePath, maxChars = 15000) {
+  if (!fs.existsSync(filePath)) return null;
+  try {
+    const content = fs.readFileSync(filePath, 'utf-8');
+    const blocks = content.split(/={60,}/);
+    if (blocks.length >= 2) {
+      const lastBlock = blocks.slice(-2).join('').trim();
+      return lastBlock.length > maxChars ? lastBlock.slice(-maxChars) : lastBlock;
+    }
+  } catch {}
+  return null;
+}
+
+export function loadAgentsForRunner(runner, { root }) {
+  const managers = [];
+  const workers = [];
+  const managersDir = path.join(root, 'agent', 'managers');
+  const workersDir = runner.workerSkillsDir;
+  const config = runner.loadConfig();
+  const managerOverrides = config.managers || {};
+
+  if (fs.existsSync(managersDir)) {
+    for (const file of fs.readdirSync(managersDir)) {
+      if (!file.endsWith('.md')) continue;
+      const name = file.replace('.md', '');
+      const content = fs.readFileSync(path.join(managersDir, file), 'utf-8');
+      const overrides = managerOverrides[name] || {};
+      const isDisabled = overrides.disabled !== undefined ? overrides.disabled : /^disabled:\s*true$/m.test(content);
+      if (isDisabled) continue;
+      const frontmatterModel = (content.match(/^model:\s*(.+)$/m) || [])[1]?.trim() || null;
+      const rawModel = overrides.model || frontmatterModel;
+      managers.push({ name, role: parseRole(content), model: shortenModel(rawModel), rawModel, isManager: true });
+    }
+  }
+
+  if (fs.existsSync(workersDir)) {
+    for (const file of fs.readdirSync(workersDir)) {
+      if (!file.endsWith('.md')) continue;
+      const name = file.replace('.md', '');
+      const content = fs.readFileSync(path.join(workersDir, file), 'utf-8');
+      if (/^disabled:\s*true$/m.test(content)) continue;
+      const reportsTo = (content.match(/^reports_to:\s*(.+)$/m) || [])[1]?.trim() || null;
+      workers.push({
+        name,
+        role: parseRole(content),
+        model: parseModel(content),
+        rawModel: (content.match(/^model:\s*(.+)$/m) || [])[1]?.trim() || null,
+        isManager: false,
+        reportsTo,
+      });
+    }
+  }
+
+  const costSummary = runner.getCostSummary();
+  for (const agent of [...managers, ...workers]) {
+    const agentCost = costSummary.agents[agent.name];
+    agent.totalCost = agentCost ? agentCost.totalCost : 0;
+    agent.last24hCost = agentCost ? agentCost.last24hCost : 0;
+    agent.lastCallCost = agentCost ? agentCost.lastCallCost : 0;
+    agent.avgCallCost = agentCost ? agentCost.avgCallCost : 0;
+    agent.callCount = agentCost ? agentCost.callCount : 0;
+  }
+
+  return { managers, workers };
+}
+
+export function getAgentDetailsForRunner(runner, agentName, { root }) {
+  const workersDir = runner.workerSkillsDir;
+  const managersDir = path.join(root, 'agent', 'managers');
+  const agentNotesDir = runner.getAgentNotesDir(agentName);
+
+  let skillPath = path.join(workersDir, `${agentName}.md`);
+  let isManager = false;
+  if (!fs.existsSync(skillPath)) {
+    skillPath = path.join(managersDir, `${agentName}.md`);
+    isManager = true;
+  }
+  if (!fs.existsSync(skillPath)) return null;
+
+  const skill = fs.readFileSync(skillPath, 'utf-8');
+  let agentFiles = [];
+  if (fs.existsSync(agentNotesDir)) {
+    agentFiles = fs.readdirSync(agentNotesDir).flatMap(f => {
+      const filePath = path.join(agentNotesDir, f);
+      const stat = fs.statSync(filePath);
+      if (!stat.isFile()) return [];
+      return [{
+        name: f,
+        size: stat.size,
+        modified: stat.mtime,
+        content: stat.size < 50000 ? fs.readFileSync(filePath, 'utf-8') : null,
+      }];
+    });
+  }
+
+  const responseLogPath = path.join(runner.responsesDir, `${agentName}.log`);
+  const rawLogPath = path.join(runner.responsesDir, `${agentName}.raw.log`);
+  const frontmatterModel = (skill.match(/^model:\s*(.+)$/m) || [])[1]?.trim() || null;
+  const config = runner.loadConfig();
+  const overrides = (isManager ? config.managers : config.workers) || {};
+  const configModel = overrides[agentName]?.model || null;
+
+  let everyone = null;
+  let roleRules = null;
+  try { everyone = fs.readFileSync(path.join(root, 'agent', 'everyone.md'), 'utf-8'); } catch {}
+  try { roleRules = fs.readFileSync(path.join(root, 'agent', isManager ? 'manager.md' : 'worker.md'), 'utf-8'); } catch {}
+
+  return {
+    name: agentName,
+    isManager,
+    skill,
+    agentFiles,
+    lastResponse: getLastBlock(responseLogPath),
+    lastRawOutput: getLastBlock(rawLogPath),
+    model: configModel || frontmatterModel || null,
+    everyone,
+    roleRules,
+  };
+}


### PR DESCRIPTION
## Summary\n\nPhase 4 slice: start splitting ProjectRunner internals by extracting agent loading/details helpers.\n\n- Adds src/orchestrator/agent-loading.js for manager/worker discovery and agent detail assembly.\n- Keeps ProjectRunner public methods as delegating wrappers so route callers and source-inspection tests stay stable.\n- Leaves prompt construction and runtime execution in ProjectRunner for follow-up slices.\n\n## Checks\n\n- node --check src/orchestrator/ProjectRunner.js\n- node --check src/orchestrator/agent-loading.js\n- npm test\n- npm --prefix monitor run build\n