### PR TITLE
refactor: extract project database helpers

### DIFF
--- a/src/orchestrator/ProjectRunner.js
+++ b/src/orchestrator/ProjectRunner.js
@@ -2,11 +2,16 @@ import fs from 'fs';
 import path from 'path';
 import { execSync } from 'child_process';
 import yaml from 'js-yaml';
-import Database from 'better-sqlite3';
 import { runAgentWithAPI } from '../agent-runner.js';
 import { resolveModel, callModel, buildUserMessage } from '../providers/index.js';
 import { resolveKeyForProject, markRateLimited, markKeySucceeded } from '../key-pool.js';
 import { getAgentDetailsForRunner, loadAgentsForRunner } from './agent-loading.js';
+import { decideProjectEpochPr, getOpenEpochPrForBranch, getProjectComments, getProjectCostSummary, getProjectPr, getProjectPrs, openProjectDb, writeRunnerReport } from './project-db.js';
+import { allocateNextEpochId, allocateNextMilestoneId, ensureEpochPRForCurrentMilestone, getMilestoneRecord, getParentMilestoneId, makeMilestoneBranchPrefix, markCurrentMilestoneCompleted, markCurrentMilestoneFailed, normalizeResetTargetMilestone, slugifyMilestoneTitle, upsertMilestoneRecord } from './milestones.js';
+import { buildAgentPrompt, getAgentFilesystemPolicy } from './agent-prompt.js';
+import { killRunnerCycle, killRunnerEpoch, killRunnerRun, loadRunnerState, pauseRunner, resumeRunner, saveRunnerState, skipRunner, startRunner, stopRunner } from './state-control.js';
+import { autoPauseWait, executeSchedule, parseSchedule, parseVisibility, sleepDelay } from './scheduler.js';
+import { runRunnerLoop } from './phase-machine.js';
 
 export function createProjectRunnerClass(deps) {
   const {
@@ -238,56 +243,7 @@ class ProjectRunner {
   }
 
   getCostSummary() {
-    const empty = { totalCost: 0, last24hCost: 0, lastCycleCost: 0, avgCycleCost: 0, lastCycleDuration: 0, avgCycleDuration: 0, agents: {} };
-    try {
-      const db = this.getDb();
-      // Ensure cost columns exist
-      try { db.exec('ALTER TABLE reports ADD COLUMN cost REAL'); } catch {}
-      try { db.exec('ALTER TABLE reports ADD COLUMN duration_ms INTEGER'); } catch {}
-
-      const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
-
-      // Total cost
-      const totalCost = db.prepare('SELECT COALESCE(SUM(cost), 0) as v FROM reports').get().v;
-      const last24hCost = db.prepare('SELECT COALESCE(SUM(cost), 0) as v FROM reports WHERE created_at > ?').get(cutoff).v;
-
-      // Per-cycle data
-      const cycles = db.prepare('SELECT cycle, SUM(cost) as cost, SUM(duration_ms) as duration FROM reports WHERE cost IS NOT NULL GROUP BY cycle ORDER BY cycle ASC').all();
-      let lastCycleCost = 0, avgCycleCost = 0, lastCycleDuration = 0, avgCycleDuration = 0;
-      if (cycles.length > 0) {
-        const last = cycles[cycles.length - 1];
-        lastCycleCost = last.cost || 0;
-        lastCycleDuration = last.duration || 0;
-        const totalCycleCost = cycles.reduce((s, c) => s + (c.cost || 0), 0);
-        const totalCycleDuration = cycles.reduce((s, c) => s + (c.duration || 0), 0);
-        avgCycleCost = totalCycleCost / cycles.length;
-        avgCycleDuration = totalCycleDuration / cycles.length;
-      }
-
-      // Per-agent data
-      const agentRows = db.prepare(`SELECT agent,
-        COALESCE(SUM(cost), 0) as totalCost,
-        COALESCE(SUM(CASE WHEN created_at > ? THEN cost ELSE 0 END), 0) as last24hCost,
-        COUNT(*) as callCount
-        FROM reports WHERE cost IS NOT NULL GROUP BY agent`).all(cutoff);
-      const agents = {};
-      for (const row of agentRows) {
-        const lastCall = db.prepare('SELECT cost FROM reports WHERE agent = ? AND cost IS NOT NULL ORDER BY id DESC LIMIT 1').get(row.agent);
-        agents[row.agent] = {
-          totalCost: row.totalCost,
-          last24hCost: row.last24hCost,
-          callCount: row.callCount,
-          lastCallCost: lastCall?.cost || 0,
-          avgCallCost: row.callCount > 0 ? row.totalCost / row.callCount : 0,
-        };
-      }
-
-      db.close();
-
-      return { totalCost, last24hCost, lastCycleCost, avgCycleCost, lastCycleDuration, avgCycleDuration, agents };
-    } catch {
-      return empty;
-    }
+    return getProjectCostSummary(this);
   }
 
   computeSleepInterval() {
@@ -412,43 +368,6 @@ class ProjectRunner {
     };
   }
 
-  _syncAgentRegistry(db) {
-    const upsert = db.prepare(`
-      INSERT INTO agents (name, role, reports_to, model, disabled)
-      VALUES (?, ?, ?, ?, ?)
-      ON CONFLICT(name) DO UPDATE SET
-        role = excluded.role,
-        reports_to = excluded.reports_to,
-        model = excluded.model,
-        disabled = excluded.disabled
-    `);
-    const managersDir = path.join(ROOT, 'agent', 'managers');
-    const workersDir = this.workerSkillsDir;
-    const parseRole = (content) => (content.match(/^role:\s*(.+)$/m) || [])[1]?.trim() || null;
-    const parseModel = (content) => (content.match(/^model:\s*(.+)$/m) || [])[1]?.trim() || null;
-
-    if (fs.existsSync(managersDir)) {
-      for (const file of fs.readdirSync(managersDir)) {
-        if (!file.endsWith('.md')) continue;
-        const content = fs.readFileSync(path.join(managersDir, file), 'utf-8');
-        const name = file.replace('.md', '');
-        const disabled = /^disabled:\s*true$/m.test(content) ? 1 : 0;
-        upsert.run(name, parseRole(content), null, parseModel(content), disabled);
-      }
-    }
-
-    if (fs.existsSync(workersDir)) {
-      for (const file of fs.readdirSync(workersDir)) {
-        if (!file.endsWith('.md')) continue;
-        const content = fs.readFileSync(path.join(workersDir, file), 'utf-8');
-        const name = file.replace('.md', '');
-        const disabled = /^disabled:\s*true$/m.test(content) ? 1 : 0;
-        const reportsTo = (content.match(/^reports_to:\s*(.+)$/m) || [])[1]?.trim() || null;
-        upsert.run(name, parseRole(content), reportsTo, parseModel(content), disabled);
-      }
-    }
-  }
-
   _resolveAllowedIssueClosers(db, issueCreator) {
     if (issueCreator === 'human' || issueCreator === 'chat') {
       return { allowed: new Set(['human', 'chat']), special: 'chat-human' };
@@ -457,404 +376,77 @@ class ProjectRunner {
   }
 
   getDb() {
-    const dbPath = this.projectDbPath;
-    const db = new Database(dbPath);
-    db.pragma('journal_mode = WAL');
-    db.pragma('foreign_keys = ON');
-    db.exec(`
-      CREATE TABLE IF NOT EXISTS agents (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT UNIQUE NOT NULL, role TEXT, reports_to TEXT, model TEXT, disabled INTEGER DEFAULT 0, created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')));
-      CREATE TABLE IF NOT EXISTS issues (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL, body TEXT DEFAULT '', status TEXT DEFAULT 'open', creator TEXT NOT NULL, assignee TEXT, labels TEXT DEFAULT '', created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')), updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')), updated_by TEXT, closed_at TEXT, closed_by TEXT);
-      CREATE TABLE IF NOT EXISTS comments (id INTEGER PRIMARY KEY AUTOINCREMENT, issue_id INTEGER NOT NULL REFERENCES issues(id), author TEXT NOT NULL, body TEXT NOT NULL, created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')));
-      CREATE TABLE IF NOT EXISTS milestones (id INTEGER PRIMARY KEY AUTOINCREMENT, milestone_id TEXT UNIQUE, title TEXT, description TEXT NOT NULL, cycles_budget INTEGER DEFAULT 20, cycles_used INTEGER DEFAULT 0, branch_name TEXT, parent_milestone_id TEXT, linked_pr_id INTEGER, failure_reason TEXT, phase TEXT DEFAULT 'implementation', status TEXT DEFAULT 'active', created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')), completed_at TEXT);
-      CREATE TABLE IF NOT EXISTS tbc_prs (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL, summary TEXT DEFAULT '', milestone_id TEXT, parent_pr_id INTEGER, epoch_index TEXT, branch_name TEXT, base_branch TEXT NOT NULL, head_branch TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'open' CHECK(status IN ('open', 'merged', 'closed')), decision TEXT, decision_reason TEXT DEFAULT '', issue_ids TEXT DEFAULT '[]', test_status TEXT DEFAULT 'unknown', github_pr_number INTEGER, github_pr_url TEXT, actor TEXT, updated_by TEXT, created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')), updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')));
-    `);
-    try { db.exec('ALTER TABLE issues ADD COLUMN updated_by TEXT'); } catch {}
-    try { db.exec('ALTER TABLE issues ADD COLUMN closed_by TEXT'); } catch {}
-    try { db.exec('ALTER TABLE milestones ADD COLUMN milestone_id TEXT'); } catch {}
-    try { db.exec('ALTER TABLE milestones ADD COLUMN title TEXT'); } catch {}
-    try { db.exec('ALTER TABLE milestones ADD COLUMN branch_name TEXT'); } catch {}
-    try { db.exec('ALTER TABLE milestones ADD COLUMN parent_milestone_id TEXT'); } catch {}
-    try { db.exec('ALTER TABLE milestones ADD COLUMN linked_pr_id INTEGER'); } catch {}
-    try { db.exec('ALTER TABLE milestones ADD COLUMN failure_reason TEXT'); } catch {}
-    try { db.exec('ALTER TABLE tbc_prs ADD COLUMN milestone_id TEXT'); } catch {}
-    try { db.exec('ALTER TABLE tbc_prs ADD COLUMN parent_pr_id INTEGER'); } catch {}
-    try { db.exec('ALTER TABLE tbc_prs ADD COLUMN epoch_index TEXT'); } catch {}
-    try { db.exec('ALTER TABLE tbc_prs ADD COLUMN branch_name TEXT'); } catch {}
-    try { db.exec('ALTER TABLE tbc_prs ADD COLUMN decision TEXT'); } catch {}
-    try { db.exec('ALTER TABLE tbc_prs ADD COLUMN decision_reason TEXT DEFAULT ""'); } catch {}
-    try { db.exec('ALTER TABLE tbc_prs ADD COLUMN actor TEXT'); } catch {}
-    try { db.exec('ALTER TABLE tbc_prs ADD COLUMN updated_by TEXT'); } catch {}
-    db.exec(`
-      UPDATE tbc_prs
-      SET status = CASE
-        WHEN status = 'merged' THEN 'merged'
-        WHEN status IN ('closed', 'completed', 'superseded') THEN 'closed'
-        ELSE 'open'
-      END
-      WHERE status NOT IN ('open', 'merged', 'closed');
-      CREATE TRIGGER IF NOT EXISTS tbc_prs_status_insert_check
-      BEFORE INSERT ON tbc_prs
-      FOR EACH ROW
-      WHEN NEW.status NOT IN ('open', 'merged', 'closed')
-      BEGIN
-        SELECT RAISE(ABORT, 'invalid tbc_prs.status');
-      END;
-      CREATE TRIGGER IF NOT EXISTS tbc_prs_status_update_check
-      BEFORE UPDATE OF status ON tbc_prs
-      FOR EACH ROW
-      WHEN NEW.status NOT IN ('open', 'merged', 'closed')
-      BEGIN
-        SELECT RAISE(ABORT, 'invalid tbc_prs.status');
-      END;
-    `);
-    this._syncAgentRegistry(db);
-    return db;
+    return openProjectDb(this, { root: ROOT });
   }
 
   async getComments(author, page = 1, perPage = 20) {
-    try {
-      const db = this.getDb();
-      let query, countQuery, params;
-      if (author) {
-        query = `SELECT c.id, c.issue_id, c.author, c.body, c.created_at FROM comments c WHERE c.author = ? ORDER BY c.created_at DESC LIMIT ? OFFSET ?`;
-        countQuery = `SELECT COUNT(*) as total FROM comments WHERE author = ?`;
-        params = [author, perPage, (page - 1) * perPage];
-      } else {
-        query = `SELECT c.id, c.issue_id, c.author, c.body, c.created_at FROM comments c ORDER BY c.created_at DESC LIMIT ? OFFSET ?`;
-        countQuery = `SELECT COUNT(*) as total FROM comments`;
-        params = [perPage, (page - 1) * perPage];
-      }
-      const comments = db.prepare(query).all(...params).map(c => ({ ...c, agent: c.author }));
-      const { total } = author ? db.prepare(countQuery).get(author) : db.prepare(countQuery).get();
-      db.close();
-      return {
-        comments,
-        total,
-        page,
-        perPage,
-        hasMore: page * perPage < total
-      };
-    } catch (e) {
-      return { comments: [], total: 0, error: e.message };
-    }
+    return getProjectComments(this, author, page, perPage);
   }
 
   async getPRs(status = 'open') {
-    try {
-      const db = this.getDb();
-      let query = `
-        SELECT id, title, summary, milestone_id, parent_pr_id, epoch_index, branch_name, base_branch, head_branch, status, decision, decision_reason, issue_ids, test_status, github_pr_number, github_pr_url, actor, updated_by, created_at, updated_at
-        FROM tbc_prs
-      `;
-      const params = [];
-      if (status === 'open' || status === 'merged' || status === 'closed') {
-        query += ` WHERE status = ?`;
-        params.push(status);
-      }
-      query += `
-        ORDER BY updated_at DESC, id DESC
-        LIMIT 50
-      `;
-      const prs = db.prepare(query).all(...params);
-      db.close();
-      return prs.map(pr => ({
-        ...pr,
-        number: pr.id,
-        headRefName: pr.head_branch,
-        baseRefName: pr.base_branch,
-        shortTitle: pr.title,
-        issueIds: (() => { try { return JSON.parse(pr.issue_ids || '[]'); } catch { return []; } })(),
-      }));
-    } catch {
-      return [];
-    }
+    return getProjectPrs(this, status);
   }
 
   async getPR(prId) {
-    try {
-      const db = this.getDb();
-      const pr = db.prepare(`
-        SELECT id, title, summary, milestone_id, parent_pr_id, epoch_index, branch_name, base_branch, head_branch, status, decision, decision_reason, issue_ids, test_status, github_pr_number, github_pr_url, actor, updated_by, created_at, updated_at
-        FROM tbc_prs
-        WHERE id = ?
-      `).get(prId);
-      db.close();
-      if (!pr) return null;
-      return {
-        ...pr,
-        number: pr.id,
-        headRefName: pr.head_branch,
-        baseRefName: pr.base_branch,
-        shortTitle: pr.title,
-        issueIds: (() => { try { return JSON.parse(pr.issue_ids || '[]'); } catch { return []; } })(),
-      };
-    } catch {
-      return null;
-    }
+    return getProjectPr(this, prId);
   }
 
   async getOpenEpochPRForCurrentMilestone() {
-    try {
-      const db = this.getDb();
-      const pr = db.prepare(`
-        SELECT * FROM tbc_prs
-        WHERE status = 'open'
-          AND (
-            (branch_name IS NOT NULL AND branch_name = ?)
-            OR head_branch = ?
-          )
-        ORDER BY updated_at DESC, id DESC
-        LIMIT 1
-      `).get(this.currentMilestoneBranch || '', this.currentMilestoneBranch || '');
-      db.close();
-      return pr || null;
-    } catch {
-      return null;
-    }
+    return getOpenEpochPrForBranch(this, this.currentMilestoneBranch || '');
   }
 
   async decideEpochPR(status, { actor = 'apollo', reason = '' } = {}) {
     const pr = await this.getOpenEpochPRForCurrentMilestone();
-    if (!pr) return null;
-    try {
-      const db = this.getDb();
-      const normalizedStatus = status === 'merged' ? 'merged' : 'closed';
-      db.prepare(`
-        UPDATE tbc_prs
-        SET status = ?, decision = ?, decision_reason = ?, updated_by = ?, updated_at = ?
-        WHERE id = ?
-      `).run(
-        normalizedStatus,
-        normalizedStatus === 'merged' ? 'merge' : 'close',
-        reason || '',
-        actor,
-        new Date().toISOString(),
-        pr.id,
-      );
-      db.close();
-      return { ...pr, status: normalizedStatus, decision: normalizedStatus === 'merged' ? 'merge' : 'close', decision_reason: reason || '' };
-    } catch {
-      return null;
-    }
+    return decideProjectEpochPr(this, pr, status, { actor, reason });
   }
 
   closeOpenEpochPRForBranch(branchName, { actor = 'apollo', reason = '' } = {}) {
-    if (!branchName) return null;
-    try {
-      const db = this.getDb();
-      const pr = db.prepare(`
-        SELECT * FROM tbc_prs
-        WHERE status = 'open'
-          AND (
-            (branch_name IS NOT NULL AND branch_name = ?)
-            OR head_branch = ?
-          )
-        ORDER BY updated_at DESC, id DESC
-        LIMIT 1
-      `).get(branchName, branchName);
-      if (!pr) {
-        db.close();
-        return null;
-      }
-      const normalizedStatus = 'closed';
-      db.prepare(`
-        UPDATE tbc_prs
-        SET status = ?, decision = ?, decision_reason = ?, updated_by = ?, updated_at = ?
-        WHERE id = ?
-      `).run(
-        normalizedStatus,
-        'close',
-        reason || '',
-        actor,
-        new Date().toISOString(),
-        pr.id,
-      );
-      db.close();
-      return { ...pr, status: normalizedStatus, decision: 'close', decision_reason: reason || '' };
-    } catch {
-      return null;
-    }
+    const pr = getOpenEpochPrForBranch(this, branchName);
+    return decideProjectEpochPr(this, pr, 'closed', { actor, reason });
   }
 
   normalizeResetTargetMilestone(resetTo) {
-    const value = typeof resetTo === 'string' ? resetTo.trim() : '';
-    if (!value) return null;
-    if (/^root$/i.test(value)) return { milestoneId: null, label: 'root' };
-    const current = String(this.currentMilestoneId || '').trim();
-    if (!current) return null;
-    const candidate = value.replace(/^m/i, 'M');
-    const ancestors = [];
-    const parts = current.split('.');
-    for (let i = parts.length; i >= 1; i--) ancestors.push(parts.slice(0, i).join('.'));
-    if (!ancestors.includes(candidate)) return null;
-    return { milestoneId: candidate, label: candidate };
+    return normalizeResetTargetMilestone.call(this, resetTo);
   }
 
   getParentMilestoneId(milestoneId = null) {
-    const value = String(milestoneId || '').trim();
-    if (!value || !value.includes('.')) return null;
-    return value.split('.').slice(0, -1).join('.') || null;
+    return getParentMilestoneId.call(this, milestoneId);
   }
 
   async getMilestoneRecord(milestoneId) {
-    if (!milestoneId) return null;
-    try {
-      const db = this.getDb();
-      const row = db.prepare(`SELECT * FROM milestones WHERE milestone_id = ?`).get(milestoneId);
-      db.close();
-      return row || null;
-    } catch {
-      return null;
-    }
+    return getMilestoneRecord.call(this, milestoneId);
   }
 
   makeMilestoneBranchPrefix(milestoneId) {
-    return String(milestoneId || 'M0').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+    return makeMilestoneBranchPrefix.call(this, milestoneId);
   }
 
-  slugifyMilestoneTitle(title, { stripLeadingMilestoneId = null } = {}) {
-    let normalizedTitle = String(title || 'milestone');
-    if (stripLeadingMilestoneId) {
-      const escapedMilestoneId = String(stripLeadingMilestoneId)
-        .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-        .replace(/\\\./g, '[\\s._-]*');
-      normalizedTitle = normalizedTitle.replace(new RegExp(`^\\s*${escapedMilestoneId}(?:[\\s:._-]+|\\b)`, 'i'), '');
-    }
-    return normalizedTitle.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 48) || 'milestone';
+  slugifyMilestoneTitle(title, options = {}) {
+    return slugifyMilestoneTitle.call(this, title, options);
   }
 
   async allocateNextMilestoneId(parentMilestoneId = null) {
-    try {
-      const db = this.getDb();
-      let nextId = 'M1';
-      if (parentMilestoneId) {
-        const rows = db.prepare(`SELECT milestone_id FROM milestones WHERE parent_milestone_id = ? OR milestone_id LIKE ?`).all(parentMilestoneId, `${parentMilestoneId}.%`);
-        let maxChild = 0;
-        for (const row of rows) {
-          const key = String(row.milestone_id || '');
-          const suffix = key.slice(parentMilestoneId.length + 1);
-          if (/^\d+$/.test(suffix)) maxChild = Math.max(maxChild, Number(suffix));
-        }
-        nextId = `${parentMilestoneId}.${maxChild + 1}`;
-      } else {
-        const rows = db.prepare(`SELECT milestone_id FROM milestones WHERE milestone_id GLOB 'M*'`).all();
-        let maxTop = 0;
-        for (const row of rows) {
-          const m = String(row.milestone_id || '').match(/^M(\d+)$/);
-          if (m) maxTop = Math.max(maxTop, Number(m[1]));
-        }
-        nextId = `M${maxTop + 1}`;
-      }
-      db.close();
-      return nextId;
-    } catch {
-      if (parentMilestoneId) return `${parentMilestoneId}.1`;
-      return `M${(this.epochCount || 0) + 1}`;
-    }
+    return allocateNextMilestoneId.call(this, parentMilestoneId);
   }
 
   async allocateNextEpochId() {
-    try {
-      const db = this.getDb();
-      const rows = db.prepare(`SELECT epoch_index FROM tbc_prs WHERE epoch_index IS NOT NULL`).all();
-      let maxEpoch = 0;
-      for (const row of rows) {
-        const m = String(row.epoch_index || '').match(/^E(\d+)$/);
-        if (m) maxEpoch = Math.max(maxEpoch, Number(m[1]));
-      }
-      db.close();
-      return `E${maxEpoch + 1}`;
-    } catch {
-      return `E${(this.epochCount || 0) + 1}`;
-    }
+    return allocateNextEpochId.call(this);
   }
 
-  async upsertMilestoneRecord({ milestoneId, title, description, cyclesBudget, branchName, parentMilestoneId = null, status = 'active', phase = 'implementation', failureReason = null, linkedPrId = null }) {
-    if (!milestoneId) return;
-    try {
-      const db = this.getDb();
-      const existing = db.prepare(`SELECT id FROM milestones WHERE milestone_id = ?`).get(milestoneId);
-      const now = new Date().toISOString();
-      if (existing) {
-        db.prepare(`UPDATE milestones SET title = ?, description = ?, cycles_budget = ?, branch_name = ?, parent_milestone_id = ?, linked_pr_id = ?, failure_reason = ?, phase = ?, status = ?, completed_at = CASE WHEN ? = 'completed' THEN COALESCE(completed_at, ?) ELSE completed_at END WHERE milestone_id = ?`)
-          .run(title || null, description || '', cyclesBudget || 0, branchName || null, parentMilestoneId || null, linkedPrId || null, failureReason || null, phase, status, status, now, milestoneId);
-      } else {
-        db.prepare(`INSERT INTO milestones (milestone_id, title, description, cycles_budget, cycles_used, branch_name, parent_milestone_id, linked_pr_id, failure_reason, phase, status) VALUES (?, ?, ?, ?, 0, ?, ?, ?, ?, ?, ?)`)
-          .run(milestoneId, title || null, description || '', cyclesBudget || 0, branchName || null, parentMilestoneId || null, linkedPrId || null, failureReason || null, phase, status);
-      }
-      db.close();
-    } catch {}
+  async upsertMilestoneRecord(record) {
+    return upsertMilestoneRecord.call(this, record);
   }
 
   async ensureEpochPRForCurrentMilestone() {
-    if (!this.currentMilestoneId || !this.milestoneTitle || !this.currentMilestoneBranch) return null;
-    const existing = await this.getOpenEpochPRForCurrentMilestone();
-    if (existing) {
-      if (!this.currentEpochPrId) this.setState({ currentEpochPrId: existing.id }, { save: true });
-      return existing;
-    }
-    try {
-      const db = this.getDb();
-      const now = new Date().toISOString();
-      const result = db.prepare(`INSERT INTO tbc_prs (title, summary, milestone_id, parent_pr_id, epoch_index, branch_name, base_branch, head_branch, status, decision, decision_reason, issue_ids, test_status, actor, updated_by, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'open', NULL, '', '[]', 'unknown', 'ares', 'ares', ?, ?)`).run(
-        this.milestoneTitle,
-        this.milestoneDescription || '',
-        this.currentMilestoneId,
-        null,
-        this.currentEpochId,
-        this.currentMilestoneBranch,
-        'main',
-        this.currentMilestoneBranch,
-        now,
-        now,
-      );
-      const prId = result.lastInsertRowid;
-      db.close();
-      await this.upsertMilestoneRecord({
-        milestoneId: this.currentMilestoneId,
-        title: this.milestoneTitle,
-        description: this.milestoneDescription,
-        cyclesBudget: this.milestoneCyclesBudget,
-        branchName: this.currentMilestoneBranch,
-        parentMilestoneId: this.currentMilestoneId.includes('.') ? this.currentMilestoneId.split('.').slice(0, -1).join('.') : null,
-        linkedPrId: prId,
-      });
-      this.setState({ currentEpochPrId: prId }, { save: true });
-      return await this.getPR(prId);
-    } catch {
-      return null;
-    }
+    return ensureEpochPRForCurrentMilestone.call(this);
   }
 
   async markCurrentMilestoneFailed(reason) {
-    if (!this.currentMilestoneId) return;
-    await this.upsertMilestoneRecord({
-      milestoneId: this.currentMilestoneId,
-      title: this.milestoneTitle,
-      description: this.milestoneDescription,
-      cyclesBudget: this.milestoneCyclesBudget,
-      branchName: this.currentMilestoneBranch,
-      parentMilestoneId: this.currentMilestoneId.includes('.') ? this.currentMilestoneId.split('.').slice(0, -1).join('.') : null,
-      status: 'failed',
-      phase: 'athena',
-      failureReason: reason || null,
-      linkedPrId: this.currentEpochPrId,
-    });
+    return markCurrentMilestoneFailed.call(this, reason);
   }
 
   async markCurrentMilestoneCompleted() {
-    if (!this.currentMilestoneId) return;
-    await this.upsertMilestoneRecord({
-      milestoneId: this.currentMilestoneId,
-      title: this.milestoneTitle,
-      description: this.milestoneDescription,
-      cyclesBudget: this.milestoneCyclesBudget,
-      branchName: this.currentMilestoneBranch,
-      parentMilestoneId: this.currentMilestoneId.includes('.') ? this.currentMilestoneId.split('.').slice(0, -1).join('.') : null,
-      status: 'completed',
-      phase: 'athena',
-      linkedPrId: this.currentEpochPrId,
-    });
+    return markCurrentMilestoneCompleted.call(this);
   }
 
   async getIssues() {
@@ -1034,47 +626,10 @@ class ProjectRunner {
   }
 
   _writeReport(agentName, body, { success = true, durationMs = 0 } = {}) {
-    const durationStr = `${Math.floor(durationMs / 60000)}m ${Math.floor((durationMs % 60000) / 1000)}s`;
-    const startedAt = new Date();
-    const endedAt = new Date();
-    const reportBody = `> ⏱ Started: ${startedAt.toLocaleString('sv-SE')} | Ended: ${endedAt.toLocaleString('sv-SE')} | Duration: ${durationStr}\n\n${body.trim()}`;
-    const db = this.getDb();
-    db.exec(`CREATE TABLE IF NOT EXISTS reports (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      cycle INTEGER NOT NULL,
-      agent TEXT NOT NULL,
-      body TEXT NOT NULL,
-      summary TEXT,
-      milestone_id TEXT,
-      created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
-    )`);
-    try { db.exec('ALTER TABLE reports ADD COLUMN summary TEXT'); } catch {}
-    try { db.exec('ALTER TABLE reports ADD COLUMN cost REAL'); } catch {}
-    try { db.exec('ALTER TABLE reports ADD COLUMN duration_ms INTEGER'); } catch {}
-    try { db.exec('ALTER TABLE reports ADD COLUMN input_tokens INTEGER'); } catch {}
-    try { db.exec('ALTER TABLE reports ADD COLUMN output_tokens INTEGER'); } catch {}
-    try { db.exec('ALTER TABLE reports ADD COLUMN cache_read_tokens INTEGER'); } catch {}
-    try { db.exec('ALTER TABLE reports ADD COLUMN success INTEGER'); } catch {}
-    try { db.exec('ALTER TABLE reports ADD COLUMN model TEXT'); } catch {}
-    try { db.exec('ALTER TABLE reports ADD COLUMN timed_out INTEGER'); } catch {}
-    try { db.exec('ALTER TABLE reports ADD COLUMN key_id TEXT'); } catch {}
-    try { db.exec('ALTER TABLE reports ADD COLUMN visibility_mode TEXT'); } catch {}
-    try { db.exec('ALTER TABLE reports ADD COLUMN visibility_issues TEXT'); } catch {}
-    try { db.exec('ALTER TABLE reports ADD COLUMN milestone_id TEXT'); } catch {}
-    db.prepare(`INSERT INTO reports (cycle, agent, body, created_at, cost, duration_ms, input_tokens, output_tokens, cache_read_tokens, success, model, timed_out, key_id, visibility_mode, visibility_issues, milestone_id)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(
-      this.cycleCount, agentName, reportBody, new Date().toISOString(),
-      null, durationMs,
-      null, null, null,
-      success ? 1 : 0, null, 0,
-      null,
-      'full', JSON.stringify([]), this.currentMilestoneId || null
-    );
-    const lastId = db.prepare('SELECT last_insert_rowid() as id').get().id;
-    db.close();
+    const { reportId } = writeRunnerReport(this, agentName, body, { success, durationMs });
     log(`Saved report for ${agentName}`, this.id);
-    broadcastReportUpdate(this.id, lastId, agentName, this.cycleCount);
-    return { reportId: lastId };
+    broadcastReportUpdate(this.id, reportId, agentName, this.cycleCount);
+    return { reportId };
   }
 
   async runDoctor() {
@@ -1118,1110 +673,80 @@ class ProjectRunner {
   }
 
   async start() {
-    if (this.running) return;
-    // Validate project path exists
-    if (!fs.existsSync(this.path)) {
-      log(`ERROR: Project path does not exist: ${this.path}`, this.id);
-      return;
-    }
-
-    // Ensure project directories exist
-    fs.mkdirSync(this.projectDir, { recursive: true });
-    fs.mkdirSync(this.chatsDir, { recursive: true });
-    fs.mkdirSync(this.agentsDir, { recursive: true });
-    fs.mkdirSync(this.responsesDir, { recursive: true });
-    fs.mkdirSync(this.skillsDir, { recursive: true });
-    fs.mkdirSync(this.knowledgeDir, { recursive: true });
-    fs.mkdirSync(path.join(this.projectDir, 'knowledge', 'analysis'), { recursive: true });
-    fs.mkdirSync(path.join(this.projectDir, 'knowledge', 'decisions'), { recursive: true });
-    fs.mkdirSync(this.workerSkillsDir, { recursive: true });
-    
-    // Load persisted state
-    this.loadState();
-    
-    this.running = true;
-    log(`Starting project runner (data: ${this.projectDir}, cycle: ${this.cycleCount})`, this.id);
-    this.runLoop();
+    return await startRunner(this, { log });
   }
 
   loadState() {
-    const statePath = this.statePath;
-    try {
-      if (fs.existsSync(statePath)) {
-        const state = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
-        this.cycleCount = state.cycleCount || 0;
-        this.epochCount = state.epochCount || 0;
-        this.completedAgents = state.completedAgents || [];
-        this.currentCycleId = state.currentCycleId || null;
-        this.currentSchedule = state.currentSchedule || null;
-        if (state.isPaused !== undefined) this.isPaused = state.isPaused;
-        // Phase state
-        this.phase = state.phase || 'athena';
-        this.milestoneTitle = state.milestoneTitle || null;
-        this.milestoneDescription = state.milestoneDescription || null;
-        this.milestoneCyclesBudget = state.milestoneCyclesBudget || 0;
-        this.milestoneCyclesUsed = state.milestoneCyclesUsed || 0;
-        this.currentMilestoneId = state.currentMilestoneId || null;
-        this.pendingMilestoneId = state.pendingMilestoneId || null;
-        this.currentEpochId = state.currentEpochId || null;
-        this.currentEpochPrId = state.currentEpochPrId || null;
-        this.currentMilestoneBranch = state.currentMilestoneBranch || null;
-        this.lastMergedMilestoneBranch = state.lastMergedMilestoneBranch || null;
-        this.aresGraceCycleUsed = state.aresGraceCycleUsed || false;
-        this.verificationFeedback = state.verificationFeedback || null;
-        this.examinationFeedback = state.examinationFeedback || null;
-        this.pendingCompletionMessage = state.pendingCompletionMessage || null;
-        this.isFixRound = state.isFixRound || false;
-        this.isComplete = state.isComplete || false;
-        this.completionSuccess = state.completionSuccess || false;
-        this.completionMessage = state.completionMessage || null;
-        log(`Loaded state: cycle ${this.cycleCount}, phase: ${this.phase}, completed: [${this.completedAgents.join(', ')}]${this.isPaused ? ', paused' : ''}`, this.id);
-      } else {
-        // New project — start paused
-        this.setState({ isPaused: true, pauseReason: 'New project (paused by default)' }, { save: false });
-        this.completedAgents = [];
-        this.currentCycleId = null;
-        this.currentSchedule = null;
-      }
-    } catch (e) {
-      log(`Failed to load state: ${e.message}`, this.id);
-      this.completedAgents = [];
-      this.currentCycleId = null;
-      this.currentSchedule = null;
-    }
+    return loadRunnerState(this, { log });
   }
 
   saveState() {
-    const statePath = this.statePath;
-    try {
-      const state = {
-        cycleCount: this.cycleCount,
-        epochCount: this.epochCount || 0,
-        completedAgents: this.completedAgents || [],
-        currentCycleId: this.currentCycleId,
-        currentSchedule: this.currentSchedule || null,
-        isPaused: this.isPaused || false,
-        phase: this.phase,
-        milestoneTitle: this.milestoneTitle,
-        milestoneDescription: this.milestoneDescription,
-        milestoneCyclesBudget: this.milestoneCyclesBudget,
-        milestoneCyclesUsed: this.milestoneCyclesUsed,
-        currentMilestoneId: this.currentMilestoneId || null,
-        pendingMilestoneId: this.pendingMilestoneId || null,
-        currentEpochId: this.currentEpochId || null,
-        currentEpochPrId: this.currentEpochPrId || null,
-        currentMilestoneBranch: this.currentMilestoneBranch || null,
-        lastMergedMilestoneBranch: this.lastMergedMilestoneBranch || null,
-        aresGraceCycleUsed: this.aresGraceCycleUsed || false,
-        verificationFeedback: this.verificationFeedback,
-        examinationFeedback: this.examinationFeedback,
-        pendingCompletionMessage: this.pendingCompletionMessage,
-        isFixRound: this.isFixRound,
-        isComplete: this.isComplete || false,
-        completionSuccess: this.completionSuccess || false,
-        completionMessage: this.completionMessage || null,
-        lastUpdated: new Date().toISOString()
-      };
-      fs.writeFileSync(statePath, JSON.stringify(state, null, 2));
-    } catch (e) {
-      log(`Failed to save state: ${e.message}`, this.id);
-    }
+    return saveRunnerState(this, { log });
   }
 
   stop() {
-    this.running = false;
-    if (this.currentAgentProcess) {
-      this.currentAgentProcess.kill('SIGTERM');
-    }
-    log(`Stopped project runner`, this.id);
+    return stopRunner(this, { log });
   }
 
   pause() {
-    this.setState({ isPaused: true, pauseReason: null });
-    log(`Paused`, this.id);
+    return pauseRunner(this, { log });
   }
 
   resume() {
-    if (this.isComplete) {
-      log(`Reopening completed project`, this.id);
-      this.setState({
-        isComplete: false,
-        completionSuccess: false,
-        completionMessage: null,
-        isPaused: false,
-        pauseReason: null,
-        phase: 'athena',
-        milestoneTitle: null,
-        milestoneDescription: null,
-        milestoneCyclesBudget: 0,
-        milestoneCyclesUsed: 0,
-        verificationFeedback: null,
-        examinationFeedback: null,
-        pendingCompletionMessage: null,
-        currentSchedule: null,
-        completedAgents: [],
-      });
-    } else {
-      this.setState({ isPaused: false, pauseReason: null });
-    }
-    this.wakeNow = true;
-    log(`Resumed`, this.id);
+    return resumeRunner(this, { log });
   }
 
   skip() {
-    if (this.currentAgentProcess) {
-      log(`Skipping current agent`, this.id);
-      this.currentAgentProcess.kill('SIGTERM');
-    } else if (this.sleepUntil) {
-      log(`Skipping sleep`, this.id);
-      this.wakeNow = true;
-    }
+    return skipRunner(this, { log });
   }
 
   // Kill Run: terminate the current agent, move to next in schedule
   killRun() {
-    if (this.currentAgentProcess) {
-      log(`🔴 Kill Run: terminating current agent`, this.id);
-      this.currentAgentProcess.kill('SIGTERM');
-    }
+    return killRunnerRun(this, { log });
   }
 
   // Kill Cycle: terminate current agent + skip remaining workers in schedule
   killCycle() {
-    log(`🔴 Kill Cycle: terminating agent and clearing schedule`, this.id);
-    if (this.currentAgentProcess) {
-      this.currentAgentProcess.kill('SIGTERM');
-    }
-    this.currentSchedule = null;
-    this.completedAgents = [];
-    this.saveState();
+    return killRunnerCycle(this, { log });
   }
 
   // Kill Epoch: terminate everything + force back to Athena
   killEpoch() {
-    log(`🔴 Kill Epoch: terminating agent, clearing schedule, returning to Athena`, this.id);
-    this.abortCurrentCycle = true;
-    if (this.currentAgentProcess) {
-      this.currentAgentProcess.kill('SIGTERM');
-    }
-    if (this.currentMilestoneBranch) {
-      this.closeOpenEpochPRForBranch(this.currentMilestoneBranch, {
-        actor: 'ares',
-        reason: `Epoch killed manually while replanning milestone ${this.currentMilestoneId || 'unknown'}.`,
-      });
-    }
-    this.currentSchedule = null;
-    this.completedAgents = [];
-    this.setState({
-      phase: 'athena',
-      pendingMilestoneId: null,
-      milestoneTitle: null,
-      milestoneDescription: null,
-      milestoneCyclesBudget: 0,
-      milestoneCyclesUsed: 0,
-      currentEpochId: null,
-      currentEpochPrId: null,
-      currentMilestoneBranch: null,
-      verificationFeedback: null,
-      isFixRound: false,
-    });
+    return killRunnerEpoch(this, { log });
   }
 
   // Wait while paused, auto-resuming after intervalMs. Optional condition check to resume early.
   async _autoPauseWait(intervalMs, resumeCondition = null) {
-    const retryAt = Date.now() + intervalMs;
-    while (this.isPaused && this.running && !this.wakeNow) {
-      await sleep(5000);
-      // Check if it's time to auto-retry
-      if (Date.now() >= retryAt) {
-        if (resumeCondition && !resumeCondition()) {
-          // Condition not met, keep waiting (check again in 2h)
-          log(`Auto-retry check: condition not met, waiting another 2h`, this.id);
-          return this._autoPauseWait(intervalMs, resumeCondition);
-        }
-        log(`Auto-resuming after ${Math.round(intervalMs / 60000)}m pause`, this.id);
-        this.isPaused = false;
-        this.pauseReason = null;
-        return;
-      }
-    }
-    // Manually resumed or stopped
-    if (!this.isPaused) {
-      this.pauseReason = null;
-    }
+    return autoPauseWait(this, { log, sleep }, intervalMs, resumeCondition);
   }
 
   async sleepDelay(minutes, label) {
-    const ms = Math.min(Math.max(parseFloat(minutes) || 0, 0), 120) * 60000;
-    if (ms <= 0) return;
-    log(`⏳ Waiting ${Math.round(ms / 60000)}m after ${label}...`, this.id);
-    this.sleepUntil = Date.now() + ms;
-    let slept = 0;
-    while (slept < ms && !this.wakeNow && this.running && !this.abortCurrentCycle) {
-      await sleep(5000);
-      slept += 5000;
-      while (this.isPaused && !this.wakeNow && this.running && !this.abortCurrentCycle) { await sleep(1000); }
-    }
-    this.sleepUntil = null;
+    return sleepDelay(this, { log, sleep }, minutes, label);
   }
 
   _parseVisibility(value, task) {
-    const visMode = typeof value === 'object' ? value.visibility : undefined;
-    if (!visMode || visMode === 'full') return null;
-    if (visMode === 'blind') return { mode: 'blind', issues: [] };
-    if (visMode === 'focused') {
-      const issueIds = (task || '').match(/#(\d+)/g)?.map(m => m.slice(1)) || [];
-      return { mode: 'focused', issues: issueIds };
-    }
-    return null;
+    return parseVisibility(this, {}, value, task);
   }
 
   parseSchedule(resultText) {
-    // Parse <!-- SCHEDULE --> ... <!-- /SCHEDULE --> from manager response.
-    // Canonical format only: a JSON array of steps.
-    const match = resultText.match(/<!--\s*SCHEDULE\s*-->\s*([\[{][\s\S]*?[\]}])\s*<!--\s*\/SCHEDULE\s*-->/);
-    if (!match) return null;
-    const normalizeStep = (step) => {
-      if (!step || typeof step !== 'object' || Array.isArray(step)) return null;
-      if (step.delay !== undefined) {
-        return Object.keys(step).length === 1 && typeof step.delay === 'number'
-          ? { delay: step.delay }
-          : null;
-      }
-      if (typeof step.agent !== 'string' || !step.agent.trim()) return null;
-      const { agent, ...rest } = step;
-      if (!Object.prototype.hasOwnProperty.call(rest, 'task')) return null;
-      return { [agent]: rest };
-    };
-    try {
-      const raw = JSON.parse(match[1]);
-      if (!Array.isArray(raw)) return null;
-      const steps = raw.map(normalizeStep);
-      if (steps.some(step => step === null)) return null;
-      return { _steps: steps };
-    } catch (e) {
-      log(`Failed to parse schedule: ${e.message}`, this.id);
-      return null;
-    }
+    return parseSchedule(this, { log }, resultText);
   }
 
   async executeSchedule(schedule, config, managerName = null) {
-    if (!schedule || !schedule._steps) return { total: 0, failures: 0 };
-    
-    let total = 0;
-    let failures = 0;
-    const ownerName = typeof managerName === 'string' ? managerName.toLowerCase() : null;
-    const freshWorkers = this.loadAgents().workers.filter(worker => {
-      if (!ownerName) return true;
-      return (worker.reportsTo || '').toLowerCase() === ownerName;
-    });
-    
-    for (const step of schedule._steps) {
-      if (!this.running || this.abortCurrentCycle) break;
-      
-      // Delay step
-      if (step.delay !== undefined) {
-        await this.sleepDelay(step.delay, 'schedule');
-        if (this.abortCurrentCycle) break;
-        continue;
-      }
-      
-      // Agent step: { "agentName": taskValue }
-      const name = Object.keys(step).find(k => k !== 'delay');
-      if (!name) continue;
-
-      // Skip agents already completed (supports resume after reboot)
-      if (this.completedAgents.includes(name.toLowerCase())) {
-        log(`Skipping ${name} (already completed this cycle)`, this.id);
-        continue;
-      }
-      
-      const value = step[name];
-      const worker = freshWorkers.find(w => w.name.toLowerCase() === name.toLowerCase());
-      if (!worker) {
-        log(`Worker "${name}" not found, skipping`, this.id);
-        continue;
-      }
-      
-      while (this.isPaused && this.running && !this.abortCurrentCycle) { await sleep(1000); }
-      if (this.abortCurrentCycle) break;
-      
-      const task = typeof value === 'string' ? value : value.task || null;
-      const vis = this._parseVisibility(value, task);
-      
-      // Retry on timeout/failure (up to 2 retries)
-      const maxRetries = 2;
-      let attempt = 0;
-      let succeeded = false;
-      while (attempt <= maxRetries && !succeeded && this.running && !this.abortCurrentCycle) {
-        if (attempt > 0) {
-          log(`Retrying ${worker.name} (attempt ${attempt + 1}/${maxRetries + 1})`, this.id);
-        }
-        const wResult = await this.runAgent(worker, config, null, task, vis);
-        if (this.abortCurrentCycle) break;
-        total++;
-        if (wResult && wResult.success) {
-          succeeded = true;
-          this.completedAgents.push(name.toLowerCase());
-          this.saveState();
-        } else {
-          failures++;
-          const wasTimeout = wResult && wResult.killedByTimeout;
-          if (wasTimeout) break; // Don't retry on timeout (agent can't finish in time)
-          attempt++;
-        }
-      }
-    }
-    
-    return { total, failures };
+    return executeSchedule(this, { log, sleep }, schedule, config, managerName);
   }
 
   async runLoop() {
-    while (this.running) {
-      while (this.isPaused && this.running) {
-        await sleep(1000);
-      }
-      if (!this.running) break;
-
-      const config = this.loadConfig();
-
-      // Check budget before starting cycle
-      const budgetStatus = this.getBudgetStatus();
-      if (budgetStatus && budgetStatus.exhausted) {
-        log(`Budget exhausted ($${budgetStatus.spent24h.toFixed(2)}/$${budgetStatus.budgetPer24h}), waiting for budget to roll off`, this.id);
-        this.setState({ isPaused: true, pauseReason: `Budget exhausted: $${budgetStatus.spent24h.toFixed(2)} / $${budgetStatus.budgetPer24h} (24h)` });
-        // Re-check every 2 hours until budget rolls off or manually resumed
-        await this._autoPauseWait(2 * 60 * 60 * 1000, () => !this.getBudgetStatus().exhausted);
-        if (!this.running) break;
-        continue;
-      }
-
-      // Check if any API key is available before starting a cycle
-      const preConfig = this.loadConfig();
-      const poolCheck = getKeyPoolSafe();
-      if (poolCheck.keys.filter(k => k.enabled).length === 0 && !preConfig.setupToken) {
-        log(`No API keys configured. Pausing project. Add a key in Settings > Credentials.`, this.id);
-        this.setState({ isPaused: true, pauseReason: 'No API keys configured. Add one in Settings > Credentials.' });
-        await this._autoPauseWait(30_000, () => getKeyPoolSafe().keys.some(k => k.enabled));
-        if (!this.running) break;
-        continue;
-      }
-
-      const { managers, workers } = this.loadAgents();
-
-      // Start new cycle — preserve schedule state if resuming from reboot
-      this.abortCurrentCycle = false;
-      const resuming = !!this.currentSchedule;
-      if (!resuming) {
-        this.cycleCount++;
-        this.completedAgents = [];
-        this.saveState();
-      }
-      log(`===== CYCLE ${this.cycleCount} (phase: ${this.phase})${resuming ? ' [RESUMING]' : ''} =====`, this.id);
-
-      let cycleFailures = 0;
-      let cycleTotal = 0;
-
-      // ===== PHASE: ATHENA (strategy) =====
-      if (this.phase === 'athena') {
-        const athena = managers.find(m => m.name === 'athena');
-        if (athena) {
-          // Build situation context for Athena
-          if (!this.pendingMilestoneId) {
-            const parentMilestoneId = this.currentMilestoneId || null;
-            this.pendingMilestoneId = await this.allocateNextMilestoneId(parentMilestoneId);
-            this.saveState();
-          }
-          const reservedBranchPrefix = this.makeMilestoneBranchPrefix(this.pendingMilestoneId);
-
-          let situation = '';
-          if (this.examinationFeedback) {
-            situation = `> **Situation: Project Completion Rejected by Themis**\n> ${this.examinationFeedback}\n\n`;
-          } else if (!this.milestoneDescription) {
-            situation = '> **Situation: Project Just Started**\n\n';
-          } else if (this.verificationFeedback === '__passed__') {
-            situation = '> **Situation: Milestone Verified Complete**\n> Previous milestone was verified by Apollo\'s team.\n\n';
-          } else if (this.verificationFeedback) {
-            situation = `> **Situation: Epoch PR Rejected by Apollo**\n> ${this.verificationFeedback}\n> Previous milestone: ${this.currentMilestoneId || 'unknown'}\n> Previous branch: ${this.currentMilestoneBranch || 'unknown'}\n> Athena should split or narrow the failed milestone into a new PR-sized milestone, not send it back as a generic fix round.\n\n`;
-          } else {
-            situation = `> **Situation: Implementation Deadline Missed**\n> Ares's team used ${this.milestoneCyclesUsed}/${this.milestoneCyclesBudget} cycles without completing the milestone.\n> Previous milestone: ${this.currentMilestoneId || 'unknown'}\n> Current branch: ${this.currentMilestoneBranch || 'not set'}\n\n`;
-          }
-          situation += `> **Assigned milestone ID:** ${this.pendingMilestoneId}\n> **Reserved branch prefix:** ${reservedBranchPrefix}\n`;
-          if (this.currentMilestoneId) {
-            situation += `> **Optional reset:** If the current subtree is wrong, you may return a milestone with \"reset_to\": \"${this.currentMilestoneId}\" or any ancestor milestone id (or \"root\") to abandon deeper branches and replan from that level.\n`;
-          }
-          situation += `\n`;
-
-          const result = await this.runAgent(athena, config, null, situation);
-          cycleTotal++;
-          if (!result || !result.success) cycleFailures++;
-
-          // Parse schedule and milestone from Athena's response
-          let schedule = null;
-          if (result && result.resultText) {
-            schedule = this.parseSchedule(result.resultText);
-            if (schedule) {
-              log(`Schedule: ${JSON.stringify(schedule)}`, this.id);
-            }
-
-            const milestoneMatch = result.resultText.match(/<!-- MILESTONE -->\s*([\s\S]*?)\s*<!-- \/MILESTONE -->/);
-            if (milestoneMatch) {
-              try {
-                const milestone = JSON.parse(milestoneMatch[1]);
-                const milestoneTitle = milestone.title || milestone.description.slice(0, 80);
-                const resetTarget = this.normalizeResetTargetMilestone(milestone.reset_to);
-                const resetTo = resetTarget ? resetTarget.milestoneId : (this.currentMilestoneId || null);
-                const shouldReusePendingMilestoneId = !!this.pendingMilestoneId && resetTo === (this.currentMilestoneId || null);
-                const milestoneId = shouldReusePendingMilestoneId
-                  ? this.pendingMilestoneId
-                  : await this.allocateNextMilestoneId(resetTo);
-                if (milestone.reset_to && !resetTarget) {
-                  log(`Ignoring invalid reset_to target from Athena: ${milestone.reset_to}`, this.id);
-                } else if (milestone.reset_to && resetTarget) {
-                  log(`Athena reset planning anchor to ${resetTarget.label}`, this.id);
-                  if (this.currentMilestoneBranch) {
-                    this.closeOpenEpochPRForBranch(this.currentMilestoneBranch, {
-                      actor: 'athena',
-                      reason: `Athena reset subtree to ${resetTarget.label} while replanning.`,
-                    });
-                  }
-                }
-                this.setState({
-                  milestoneTitle,
-                  milestoneDescription: milestone.description,
-                  milestoneCyclesBudget: milestone.cycles || 20,
-                  milestoneCyclesUsed: 0,
-                  currentMilestoneId: milestoneId,
-                  pendingMilestoneId: null,
-                  currentEpochId: null,
-                  currentEpochPrId: null,
-                  currentMilestoneBranch: null,
-                  aresGraceCycleUsed: false,
-                  verificationFeedback: null,
-                  examinationFeedback: null,
-                  pendingCompletionMessage: null,
-                  isFixRound: false,
-                  phase: 'implementation',
-                });
-                await this.upsertMilestoneRecord({
-                  milestoneId,
-                  title: milestoneTitle,
-                  description: milestone.description,
-                  cyclesBudget: milestone.cycles || 20,
-                  branchName: null,
-                  parentMilestoneId: milestoneId.includes('.') ? milestoneId.split('.').slice(0, -1).join('.') : null,
-                  phase: 'implementation',
-                  status: 'active',
-                });
-                this.epochCount++;
-                this.saveState();
-                log(`Epoch ${this.epochCount}: New milestone (${this.milestoneCyclesBudget} cycles): ${this.milestoneDescription.slice(0, 100)}...`, this.id);
-                broadcastEvent({ type: 'milestone', project: this.id, title: this.milestoneTitle, cycles: this.milestoneCyclesBudget });
-              } catch (e) {
-                log(`Failed to parse milestone: ${e.message}`, this.id);
-              }
-            }
-            // Check for PROJECT_COMPLETE tag
-            const completeMatch = result.resultText.match(/<!-- PROJECT_COMPLETE -->\s*([\s\S]*?)\s*<!-- \/PROJECT_COMPLETE -->/);
-            if (completeMatch) {
-              try {
-                const completion = JSON.parse(completeMatch[1]);
-                const success = !!completion.success;
-                const message = completion.message || 'Project completed';
-                if (success) {
-                  this.setState({
-                    phase: 'examination',
-                    pendingCompletionMessage: message,
-                    examinationFeedback: null,
-                    completionSuccess: false,
-                    completionMessage: null,
-                    isComplete: false,
-                    isPaused: false,
-                    pauseReason: null,
-                  });
-                  log(`🧪 PROJECT COMPLETE claimed — routing to Themis examination: ${message}`, this.id);
-                  broadcastEvent({ type: 'phase', project: this.id, phase: 'examination', title: this.milestoneTitle || 'Project examination' });
-                } else {
-                  this.setState({
-                    isComplete: true,
-                    completionSuccess: success,
-                    completionMessage: message,
-                    isPaused: true,
-                    pauseReason: `Project ${success ? 'completed successfully' : 'ended'}: ${message}`,
-                  });
-                  log(`🏁 PROJECT COMPLETE (success: ${success}): ${message}`, this.id);
-                  broadcastEvent({ type: 'project-complete', project: this.id, success, message });
-                }
-                continue;
-              } catch (e) {
-                log(`Failed to parse PROJECT_COMPLETE: ${e.message}`, this.id);
-              }
-            }
-
-            // Check for STOP file
-            if (fs.existsSync(this.stopPath)) {
-              log(`STOP file detected — pausing project`, this.id);
-              this.setState({ isPaused: true, pauseReason: 'Project stopped by Athena' });
-              continue;
-            }
-          }
-
-          // Execute schedule steps (delays + workers)
-          if (schedule) {
-            this.currentSchedule = schedule;
-            this.saveState(); // Persist schedule before execution so it survives reboot
-            const { total, failures } = await this.executeSchedule(schedule, config, 'athena');
-            cycleTotal += total;
-            cycleFailures += failures;
-            this.currentSchedule = null;
-            this.completedAgents = [];
-          }
-
-          this.saveState();
-        }
-      }
-
-      // ===== PHASE: IMPLEMENTATION (Ares + his workers) =====
-      else if (this.phase === 'implementation') {
-        const aresGraceMode = this.milestoneCyclesUsed >= this.milestoneCyclesBudget;
-        // Check if deadline missed (before running)
-        if (aresGraceMode && this.aresGraceCycleUsed) {
-          const failureReason = `Implementation deadline missed after ${this.milestoneCyclesUsed}/${this.milestoneCyclesBudget} cycles for ${this.currentMilestoneId || 'unknown milestone'}.`;
-          await this.decideEpochPR('closed', { actor: 'apollo', reason: failureReason });
-          await this.markCurrentMilestoneFailed(failureReason);
-          log(`⏰ Implementation deadline missed (${this.milestoneCyclesUsed}/${this.milestoneCyclesBudget} cycles)`, this.id);
-          this.setState({ currentEpochId: null, currentEpochPrId: null, currentMilestoneBranch: null, aresGraceCycleUsed: false, phase: 'athena' });
-          continue;
-        }
-
-        // Resume interrupted schedule from previous cycle (e.g. after reboot)
-        // Note: don't require completedAgents — schedule may start with a delay step
-        if (this.currentSchedule) {
-          log(`Resuming interrupted schedule (${this.completedAgents.length} agents already completed${this.completedAgents.length ? ': [' + this.completedAgents.join(', ') + ']' : ''})`, this.id);
-          const { total, failures } = await this.executeSchedule(this.currentSchedule, config, 'ares');
-          cycleTotal += total;
-          cycleFailures += failures;
-          this.currentSchedule = null;
-          this.completedAgents = [];
-          this.saveState();
-        } else {
-
-        const ares = managers.find(m => m.name === 'ares');
-        if (ares) {
-          let epochStateChanged = false;
-          if (!this.currentEpochId) {
-            this.currentEpochId = await this.allocateNextEpochId();
-            this.epochCount += 1;
-            epochStateChanged = true;
-          }
-          if (!this.currentMilestoneBranch) {
-            const branchPrefix = this.makeMilestoneBranchPrefix(this.currentMilestoneId);
-            this.currentMilestoneBranch = `${String(this.currentEpochId || 'E0').toLowerCase()}-${branchPrefix}-${this.slugifyMilestoneTitle(this.milestoneTitle, { stripLeadingMilestoneId: this.currentMilestoneId })}`;
-            epochStateChanged = true;
-          }
-          if (epochStateChanged) this.saveState();
-          const openEpochPr = await this.ensureEpochPRForCurrentMilestone();
-          // Build context for Ares (remaining includes this cycle)
-          const cyclesRemaining = Math.max(0, this.milestoneCyclesBudget - this.milestoneCyclesUsed);
-          let aresContext = `> **Milestone ID:** ${this.currentMilestoneId || 'unknown'}
-> **Milestone:** ${this.milestoneDescription}
-> **Epoch ID:** ${this.currentEpochId || 'unknown'}
-> **Cycles remaining:** ${cyclesRemaining} of ${this.milestoneCyclesBudget}
-> **Milestone branch:** ${this.currentMilestoneBranch || 'not set'}
-> **Epoch PR:** ${openEpochPr?.id ? `#${openEpochPr.id}` : 'not set'}
-> **Epoch PR rule:** The orchestrator assigned exactly one TBC PR to this milestone branch. Use it instead of creating competing PRs.
-
-`;
-          if (aresGraceMode) {
-            aresContext += `> **Grace review mode:** Worker budget is exhausted. This is your final manager-only pass.
-> **Do not emit a schedule. Do not assign any workers.**
-> Review the existing evidence only. If the milestone is already complete, emit <!-- CLAIM_COMPLETE -->. Otherwise emit no completion block and the milestone will fail.
-
-`;
-          }
-          if (this.isFixRound && this.verificationFeedback) {
-            aresContext += `> **Legacy verification feedback:**
-> ${this.verificationFeedback}
-
-`;
-          }
-
-          const result = await this.runAgent(ares, config, null, aresContext);
-          cycleTotal++;
-          if (!result || !result.success) cycleFailures++;
-          if (aresGraceMode) this.aresGraceCycleUsed = true;
-
-          // Parse schedule and check for CLAIM_COMPLETE
-          let schedule = null;
-          let claimedComplete = false;
-          if (result && result.resultText) {
-            if (!aresGraceMode) {
-              schedule = this.parseSchedule(result.resultText);
-              if (schedule) {
-                log(`Schedule: ${JSON.stringify(schedule)}`, this.id);
-                this.currentSchedule = schedule;
-              }
-            } else if (this.parseSchedule(result.resultText)) {
-              log('⚠️ Ignoring Ares schedule because grace review mode forbids worker scheduling', this.id);
-            }
-
-            // Check if Ares claims milestone complete
-            if (result.resultText.includes('<!-- CLAIM_COMPLETE -->')) {
-              claimedComplete = true;
-              const openEpochPr = await this.ensureEpochPRForCurrentMilestone();
-              if (!openEpochPr) {
-                this.verificationFeedback = `Ares claimed milestone completion without an orchestrator-managed epoch PR on branch ${this.currentMilestoneBranch || 'unknown'}.`;
-                log('⚠️ CLAIM_COMPLETE ignored because no orchestrator-managed epoch PR exists for the current milestone branch', this.id);
-                this.saveState();
-                claimedComplete = false;
-              } else {
-                log(`🎯 Ares claims milestone complete for epoch PR #${openEpochPr.id} — switching to verification`, this.id);
-                this.setState({ phase: 'verification', currentEpochPrId: openEpochPr.id });
-                broadcastEvent({ type: 'phase', project: this.id, phase: 'verification', title: this.milestoneTitle });
-              }
-            }
-          }
-
-          if (aresGraceMode && !claimedComplete) {
-            const failureReason = `Implementation deadline missed after ${this.milestoneCyclesUsed}/${this.milestoneCyclesBudget} cycles for ${this.currentMilestoneId || 'unknown milestone'} (Ares grace review did not claim completion).`;
-            await this.decideEpochPR('closed', { actor: 'apollo', reason: failureReason });
-            await this.markCurrentMilestoneFailed(failureReason);
-            log(`⏰ ${failureReason}`, this.id);
-            this.setState({ currentEpochId: null, currentEpochPrId: null, currentMilestoneBranch: null, aresGraceCycleUsed: false, phase: 'athena', verificationFeedback: failureReason });
-            this.saveState();
-            continue;
-          }
-
-          // Execute schedule steps (delays + workers)
-          if (schedule) {
-            this.completedAgents = [];
-            this.saveState(); // Persist schedule before execution so it survives reboot
-            const { total, failures } = await this.executeSchedule(schedule, config, 'ares');
-            cycleTotal += total;
-            cycleFailures += failures;
-            this.currentSchedule = null;
-            this.completedAgents = [];
-            this.saveState();
-          }
-        }
-        } // end else (no interrupted schedule)
-        // Only count cycle if at least one agent succeeded
-        if (cycleTotal > 0 && cycleFailures < cycleTotal) {
-          this.milestoneCyclesUsed++;
-        } else if (cycleTotal > 0) {
-          log(`All ${cycleTotal} agents failed — cycle not counted toward milestone budget`, this.id);
-        }
-        this.saveState();
-      }
-
-      // ===== PHASE: VERIFICATION (Apollo + his workers) =====
-      else if (this.phase === 'verification') {
-        // Resume interrupted verification schedule (e.g. after reboot)
-        if (this.currentSchedule && this.completedAgents.length > 0) {
-          log(`Resuming interrupted verification schedule (${this.completedAgents.length} agents already completed: [${this.completedAgents.join(', ')}])`, this.id);
-          const { total, failures } = await this.executeSchedule(this.currentSchedule, config, 'apollo');
-          cycleTotal += total;
-          cycleFailures += failures;
-          this.currentSchedule = null;
-          this.completedAgents = [];
-          this.saveState();
-        } else {
-        const apollo = managers.find(m => m.name === 'apollo');
-        if (apollo) {
-          const isRollupVerification = !this.currentEpochPrId;
-          const apolloContext = isRollupVerification
-            ? `> **Milestone to verify:** ${this.milestoneDescription}\n> **Rollup verification target:** ${this.currentMilestoneId || 'unknown'}\n> **Verification mode:** Parent milestone rollup after a child milestone passed\n> **Active epoch PR:** none (rollup verification)\n> Apollo should decide whether this parent milestone is now fully complete or Athena should plan the next child under it.\n\n`
-            : `> **Milestone to verify:** ${this.milestoneDescription}\n> **Milestone branch:** ${this.currentMilestoneBranch || 'not set'}\n> **Active epoch PR:** ${this.currentEpochPrId || 'unknown'}\n> Apollo owns the PR decision: merge on pass, close on fail.\n\n`;
-
-          const result = await this.runAgent(apollo, config, null, apolloContext);
-          cycleTotal++;
-          if (!result || !result.success) cycleFailures++;
-
-          let schedule = null;
-          let decision = null;
-          if (result && result.resultText) {
-            schedule = this.parseSchedule(result.resultText);
-            if (schedule) {
-              log(`Schedule: ${JSON.stringify(schedule)}`, this.id);
-            }
-
-            // Check for verification decision
-            if (result.resultText.includes('<!-- VERIFY_PASS -->')) {
-              decision = 'pass';
-            }
-            const failMatch = result.resultText.match(/<!-- VERIFY_FAIL -->\s*([\s\S]*?)\s*<!-- \/VERIFY_FAIL -->/);
-            if (failMatch) {
-              try {
-                const failData = JSON.parse(failMatch[1]);
-                decision = 'fail';
-                this.verificationFeedback = failData.feedback || 'Verification failed (no specific feedback)';
-              } catch {
-                decision = 'fail';
-                this.verificationFeedback = 'Verification failed (could not parse feedback)';
-              }
-            }
-          }
-
-          // Execute schedule steps (delays + workers)
-          if (schedule) {
-            this.currentSchedule = schedule;
-            this.completedAgents = [];
-            this.saveState(); // Persist schedule before execution so it survives reboot
-            const { total, failures } = await this.executeSchedule(schedule, config, 'apollo');
-            cycleTotal += total;
-            cycleFailures += failures;
-            this.currentSchedule = null;
-            this.completedAgents = [];
-            this.saveState();
-          }
-
-          // Process decision
-          if (decision === 'pass') {
-            const mergedPr = isRollupVerification ? null : await this.decideEpochPR('merged', {
-              actor: 'apollo',
-              reason: `Apollo passed milestone ${this.currentMilestoneId || ''} ${this.milestoneTitle || this.milestoneDescription || ''}`.trim(),
-            });
-            const completedMilestoneId = this.currentMilestoneId;
-            const completedMilestoneTitle = this.milestoneTitle;
-            const parentMilestoneId = this.getParentMilestoneId(completedMilestoneId);
-            await this.markCurrentMilestoneCompleted();
-            if (parentMilestoneId) {
-              const parentMilestone = await this.getMilestoneRecord(parentMilestoneId);
-              log(`✅ Milestone verified — escalating completion check to parent milestone ${parentMilestoneId}`, this.id);
-              broadcastEvent({ type: 'verified', project: this.id, title: completedMilestoneTitle });
-              if (parentMilestone) {
-                await this.upsertMilestoneRecord({
-                  milestoneId: parentMilestoneId,
-                  title: parentMilestone.title,
-                  description: parentMilestone.description,
-                  cyclesBudget: parentMilestone.cycles_budget,
-                  branchName: parentMilestone.branch_name,
-                  parentMilestoneId: parentMilestone.parent_milestone_id,
-                  phase: 'verification',
-                  status: 'active',
-                  linkedPrId: parentMilestone.linked_pr_id,
-                  failureReason: null,
-                });
-              }
-              this.setState({
-                milestoneTitle: parentMilestone?.title || parentMilestoneId,
-                milestoneDescription: parentMilestone?.description || `Parent rollup verification for ${parentMilestoneId}`,
-                milestoneCyclesBudget: parentMilestone?.cycles_budget || 0,
-                milestoneCyclesUsed: parentMilestone?.cycles_used || 0,
-                currentMilestoneId: parentMilestoneId,
-                pendingMilestoneId: null,
-                currentEpochId: null,
-                currentEpochPrId: null,
-                currentMilestoneBranch: parentMilestone?.branch_name || null,
-                aresGraceCycleUsed: false,
-                lastMergedMilestoneBranch: mergedPr?.branch_name || mergedPr?.head_branch || this.currentMilestoneBranch || this.lastMergedMilestoneBranch,
-                verificationFeedback: null,
-                isFixRound: false,
-                phase: 'verification',
-              });
-              broadcastEvent({ type: 'phase', project: this.id, phase: 'verification', title: parentMilestone?.title || parentMilestoneId });
-            } else {
-              log(`✅ Milestone verified — waking Athena for next milestone`, this.id);
-              broadcastEvent({ type: 'verified', project: this.id, title: this.milestoneTitle });
-              this.milestoneTitle = null;
-              this.setState({
-                milestoneTitle: null,
-                milestoneDescription: null,
-                milestoneCyclesBudget: 0,
-                milestoneCyclesUsed: 0,
-                currentMilestoneId: null,
-                pendingMilestoneId: null,
-                currentEpochId: null,
-                currentEpochPrId: null,
-                currentMilestoneBranch: null,
-                aresGraceCycleUsed: false,
-                lastMergedMilestoneBranch: mergedPr?.branch_name || mergedPr?.head_branch || this.currentMilestoneBranch || this.lastMergedMilestoneBranch,
-                verificationFeedback: null,
-                isFixRound: false,
-                phase: 'athena',
-              });
-            }
-          } else if (decision === 'fail') {
-            const failureReason = this.verificationFeedback || 'Apollo rejected the epoch PR and requested milestone splitting or narrowing.';
-            if (isRollupVerification) {
-              log('❌ Parent rollup verification incomplete — returning to Athena to plan the next child milestone', this.id);
-              broadcastEvent({ type: 'verify-fail', project: this.id, title: this.milestoneTitle });
-              this.setState({
-                pendingMilestoneId: null,
-                currentEpochId: null,
-                currentEpochPrId: null,
-                currentMilestoneBranch: null,
-                aresGraceCycleUsed: false,
-                verificationFeedback: failureReason,
-                isFixRound: false,
-                phase: 'athena',
-              });
-            } else {
-              await this.decideEpochPR('closed', {
-                actor: 'apollo',
-                reason: failureReason,
-              });
-              await this.markCurrentMilestoneFailed(failureReason);
-              log('❌ Verification failed — returning to Athena for split/replan', this.id);
-              broadcastEvent({ type: 'verify-fail', project: this.id, title: this.milestoneTitle });
-              this.setState({
-                pendingMilestoneId: null,
-                currentEpochId: null,
-                currentEpochPrId: null,
-                aresGraceCycleUsed: false,
-                verificationFeedback: failureReason,
-                isFixRound: false,
-                phase: 'athena',
-              });
-            }
-          } else {
-            // No decision yet, stay in verification phase — still save
-            this.saveState();
-          }
-        }
-        } // end else (no interrupted verification schedule)
-      }
-
-      // ===== PHASE: EXAMINATION (Themis final audit) =====
-      else if (this.phase === 'examination') {
-        // Resume interrupted examination schedule (e.g. after reboot)
-        if (this.currentSchedule) {
-          log(`Resuming interrupted examination schedule (${this.completedAgents.length} agents already completed${this.completedAgents.length ? ': [' + this.completedAgents.join(', ') + ']' : ''})`, this.id);
-          const { total, failures } = await this.executeSchedule(this.currentSchedule, config, 'themis');
-          cycleTotal += total;
-          cycleFailures += failures;
-          this.currentSchedule = null;
-          this.completedAgents = [];
-          this.saveState();
-        } else {
-        const themis = managers.find(m => m.name === 'themis');
-        if (themis) {
-          const themisContext = `> **Final completion claim:** ${this.pendingCompletionMessage || 'Project claimed complete'}\n> **Evaluate the entire project, not just the human\'s explicit goal.** Audit correctness, completeness, maintainability, artifacts, tests, docs, and obvious risks.\n\n`;
-          const result = await this.runAgent(themis, config, null, themisContext, { mode: 'full', issues: [] });
-          cycleTotal++;
-          if (!result || !result.success) cycleFailures++;
-
-          let schedule = null;
-          let decision = null;
-          let failData = null;
-          if (result && result.resultText) {
-            schedule = this.parseSchedule(result.resultText);
-            if (schedule) {
-              log(`Schedule: ${JSON.stringify(schedule)}`, this.id);
-            }
-
-            if (result.resultText.includes('<!-- EXAM_PASS -->')) {
-              decision = 'pass';
-            }
-            const failMatch = result.resultText.match(/<!-- EXAM_FAIL -->\s*([\s\S]*?)\s*<!-- \/EXAM_FAIL -->/);
-            if (failMatch) {
-              try {
-                failData = JSON.parse(failMatch[1]);
-              } catch {
-                failData = { feedback: 'Themis rejected project completion, but the response could not be parsed.' };
-              }
-              decision = 'fail';
-            } else if (!schedule && decision == null) {
-              decision = 'fail';
-            }
-          }
-
-          if (schedule) {
-            this.currentSchedule = schedule;
-            this.completedAgents = [];
-            this.saveState();
-            const { total, failures } = await this.executeSchedule(schedule, config, 'themis');
-            cycleTotal += total;
-            cycleFailures += failures;
-            this.currentSchedule = null;
-            this.completedAgents = [];
-            this.saveState();
-          }
-
-          if (decision === 'pass') {
-            const message = this.pendingCompletionMessage || 'Project completed';
-            this.setState({
-              phase: 'athena',
-              isComplete: true,
-              completionSuccess: true,
-              completionMessage: message,
-              pendingCompletionMessage: null,
-              examinationFeedback: null,
-              currentSchedule: null,
-              completedAgents: [],
-              isPaused: true,
-              pauseReason: `Project completed successfully: ${message}`,
-            });
-            log(`🏁 PROJECT COMPLETE (validated by Themis): ${message}`, this.id);
-            broadcastEvent({ type: 'project-complete', project: this.id, success: true, message });
-          } else if (decision === 'fail') {
-            let issues = Array.isArray(failData?.issues) ? failData.issues : [];
-            const rawFeedback = (result?.resultText || '').trim();
-            if (issues.length === 0) {
-              issues = [{
-                title: 'Themis rejected project completion',
-                body: rawFeedback || failData?.feedback || failData?.summary || 'Themis did not issue EXAM_PASS, so the completion claim was rejected.',
-              }];
-            }
-            const createdIssueIds = [];
-            for (const issue of issues) {
-              if (!issue?.title) continue;
-              try {
-                const created = await this.createIssue(issue.title, issue.body || '', 'themis');
-                createdIssueIds.push(created.issueId);
-              } catch (e) {
-                log(`Themis issue creation failed: ${e.message}`, this.id);
-              }
-            }
-            const feedback = failData?.feedback || failData?.summary || rawFeedback || 'Themis rejected the project completion claim.';
-            this.setState({
-              phase: 'athena',
-              examinationFeedback: createdIssueIds.length
-                ? `${feedback} New issues: ${createdIssueIds.map(id => `#${id}`).join(', ')}`
-                : feedback,
-              pendingCompletionMessage: null,
-              currentSchedule: null,
-              completedAgents: [],
-              isComplete: false,
-              completionSuccess: false,
-              completionMessage: null,
-              isPaused: false,
-              pauseReason: null,
-            });
-            log(`❌ Themis rejected project completion — returning to Athena`, this.id);
-            broadcastEvent({ type: 'phase', project: this.id, phase: 'athena', title: this.milestoneTitle || 'Replanning after Themis rejection' });
-          } else {
-            // No decision yet, stay in examination phase — still save
-            this.saveState();
-          }
-        }
-        } // end else (no interrupted examination schedule)
-      }
-
-      // If no agent succeeded, don't count this cycle
-      if (cycleTotal > 0 && cycleFailures === cycleTotal) {
-        this.cycleCount--;
-        this.saveState();
-      }
-
-      // Track consecutive agent failures — auto-pause after 10
-      this.consecutiveFailures = (cycleTotal > 0 && cycleFailures === cycleTotal)
-        ? this.consecutiveFailures + cycleFailures
-        : 0;
-      if (this.consecutiveFailures >= 10 && this.running) {
-        log(`⚠️ ${this.consecutiveFailures} consecutive agent failures — auto-pausing (retry in 2h)`, this.id);
-        broadcastEvent({ type: 'error', project: this.id, message: `${this.consecutiveFailures} consecutive failures — auto-paused` });
-        this.setState({ isPaused: true, pauseReason: `${this.consecutiveFailures} consecutive agent failures` });
-        this.consecutiveFailures = 0;
-        await this._autoPauseWait(2 * 60 * 60 * 1000);
-        if (!this.running) break;
-        continue;
-      }
-
-      // Compute sleep: budget-derived or fixed interval
-      const sleepMs = this.computeSleepInterval();
-      this.lastComputedSleepMs = sleepMs; // Cache for status requests
-      if (this.running) {
-        log(`Sleeping ${Math.round(sleepMs / 1000)}s...`, this.id);
-        this.wakeNow = false;
-        this.sleepUntil = Date.now() + sleepMs;
-
-        let sleptMs = 0;
-        while (sleptMs < sleepMs && !this.wakeNow && this.running) {
-          await sleep(5000);
-          sleptMs += 5000;
-          while (this.isPaused && !this.wakeNow && this.running) {
-            await sleep(1000);
-          }
-        }
-        this.sleepUntil = null;
-      }
-    }
+    return runRunnerLoop(this, { getKeyPoolSafe, log, sleep });
   }
 
   // Build the full prompt for an agent (shared across CLI and API paths)
   _getAgentFilesystemPolicy(agent, visibility = null) {
-    if (agent.name === 'doctor') {
-      return null;
-    }
-    const visMode = visibility?.mode || 'full';
-    const repoDir = this.path;
-    const knowledgeDir = this.knowledgeDir;
-    const ownWorkspaceDir = path.join(this.agentsDir, agent.name);
-    const read = [repoDir];
-    const write = [repoDir];
-    if (visMode !== 'blind') {
-      read.push(knowledgeDir);
-      read.push(ownWorkspaceDir);
-      write.push(ownWorkspaceDir);
-    }
-    if (agent.isManager && visMode !== 'blind') {
-      read.push(this.workerSkillsDir);
-      write.push(this.workerSkillsDir);
-    }
-    const denied = [
-      this.agentsDir,
-      this.responsesDir,
-      this.uploadsDir,
-      this.skillsDir,
-      this.statePath,
-      this.orchestratorLogPath,
-      this.projectDbPath,
-    ];
-    return { read, write, denied, dbPath: this.projectDbPath };
+    return getAgentFilesystemPolicy(this, agent, visibility);
   }
 
   _buildAgentPrompt(agent, task, visibility) {
-    const skillPath = agent.isManager
-      ? path.join(ROOT, 'agent', 'managers', `${agent.name}.md`)
-      : path.join(this.workerSkillsDir, `${agent.name}.md`);
-
-    if (!fs.existsSync(skillPath)) {
-      return null;
-    }
-
-    let skillContent = fs.readFileSync(skillPath, 'utf-8');
-
-    // Build shared rules: everyone.md + folder_structure.md + db.md + role-specific rules
-    let sharedRules = '';
-    try {
-      const everyonePath = path.join(ROOT, 'agent', 'everyone.md');
-      const folderStructurePath = path.join(ROOT, 'agent', 'folder_structure.md');
-      sharedRules = fs.readFileSync(everyonePath, 'utf-8') + '\n\n---\n\n';
-      try {
-        sharedRules += fs.readFileSync(folderStructurePath, 'utf-8') + '\n\n---\n\n';
-      } catch {}
-      const visMode = visibility?.mode || 'full';
-      if (visMode === 'full') {
-        const dbPath = path.join(ROOT, 'agent', 'db.md');
-        try {
-          const dbContent = fs.readFileSync(dbPath, 'utf-8');
-          sharedRules += dbContent + '\n\n---\n\n';
-        } catch {}
-      }
-      if (agent.name !== 'themis') {
-        if (visMode === 'focused') {
-          sharedRules += '\n> **You are in focused mode.** You cannot read the issue tracker or PR board. Work only from the task, the repository, shared knowledge, and your own agent notes. If needed, you may create a new issue or PR record to report a blocker or finding.\n\n---\n\n';
-        } else if (visMode === 'blind') {
-          sharedRules += '\n> **You are in blind mode.** You cannot read the issue tracker or PR board, and you cannot rely on shared knowledge or any agent notes, including your own prior notes. Work only from the task and the repository. If needed, you may create a new issue or PR record to report a blocker or finding.\n\n---\n\n';
-        }
-      } else {
-        sharedRules += '\n> **You are Themis, final examination manager.** You run in full view, not blind. Inspect the repository, issue tracker, PR board, shared knowledge, and agent notes directly. You may hire and schedule workers, but only workers who report to you. Your examination team is independent from the Athena, Ares, and Apollo teams, so make your own judgment from primary evidence.\n\n---\n\n';
-      }
-      const rolePath = path.join(ROOT, 'agent', agent.isManager ? 'manager.md' : 'worker.md');
-      sharedRules += fs.readFileSync(rolePath, 'utf-8') + '\n\n---\n\n';
-    } catch {}
-
-    let taskHeader = '';
-    if (task) {
-      taskHeader = `> **Your assignment: ${task}**\n\n`;
-    }
-
-    // Strip YAML frontmatter (---...---) from skill content before building prompt
-    skillContent = skillContent.replace(/^---[\s\S]*?---\n*/, '');
-    skillContent = (taskHeader + sharedRules + skillContent).replaceAll('{project_dir}', this.projectDir);
-
-    return skillContent;
+    return buildAgentPrompt(this, agent, task, visibility, { root: ROOT });
   }
 
   // Post-processing shared by both CLI and API agent runs
@@ -2291,44 +816,22 @@ class ProjectRunner {
         const agentStartTime = new Date(this.currentAgentStartTime).toLocaleString('sv-SE');
         const endTime = new Date().toLocaleString('sv-SE');
         reportBody = `> ⏱ Started: ${agentStartTime} | Ended: ${endTime} | Duration: ${durationStr}\n\n${reportBody}`;
-        const db = this.getDb();
-        db.exec(`CREATE TABLE IF NOT EXISTS reports (
-          id INTEGER PRIMARY KEY AUTOINCREMENT,
-          cycle INTEGER NOT NULL,
-          agent TEXT NOT NULL,
-          body TEXT NOT NULL,
-          summary TEXT,
-          milestone_id TEXT,
-          created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
-        )`);
-        try { db.exec('ALTER TABLE reports ADD COLUMN summary TEXT'); } catch {}
-        try { db.exec('ALTER TABLE reports ADD COLUMN cost REAL'); } catch {}
-        try { db.exec('ALTER TABLE reports ADD COLUMN duration_ms INTEGER'); } catch {}
-        try { db.exec('ALTER TABLE reports ADD COLUMN input_tokens INTEGER'); } catch {}
-        try { db.exec('ALTER TABLE reports ADD COLUMN output_tokens INTEGER'); } catch {}
-        try { db.exec('ALTER TABLE reports ADD COLUMN cache_read_tokens INTEGER'); } catch {}
-        try { db.exec('ALTER TABLE reports ADD COLUMN success INTEGER'); } catch {}
-        try { db.exec('ALTER TABLE reports ADD COLUMN model TEXT'); } catch {}
-        try { db.exec('ALTER TABLE reports ADD COLUMN timed_out INTEGER'); } catch {}
-        try { db.exec('ALTER TABLE reports ADD COLUMN key_id TEXT'); } catch {}
-        try { db.exec('ALTER TABLE reports ADD COLUMN visibility_mode TEXT'); } catch {}
-        try { db.exec('ALTER TABLE reports ADD COLUMN visibility_issues TEXT'); } catch {}
-        try { db.exec('ALTER TABLE reports ADD COLUMN milestone_id TEXT'); } catch {}
-    try { db.exec('ALTER TABLE reports ADD COLUMN milestone_id TEXT'); } catch {}
-        db.prepare(`INSERT INTO reports (cycle, agent, body, created_at, cost, duration_ms, input_tokens, output_tokens, cache_read_tokens, success, model, timed_out, key_id, visibility_mode, visibility_issues, milestone_id)
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(
-          this.cycleCount, agent.name, reportBody, new Date().toISOString(),
-          cost ?? null, durationMs ?? null,
-          usage?.inputTokens ?? null, usage?.outputTokens ?? null, usage?.cacheReadTokens ?? null,
-          success ? 1 : 0, this.currentAgentModel ?? null, killedByTimeout ? 1 : 0,
-          this.currentAgentKeyId ?? null,
-          this.currentAgentVisibility?.mode || 'full', JSON.stringify(this.currentAgentVisibility?.issues || []), this.currentMilestoneId || null
-        );
-        const lastId = db.prepare('SELECT last_insert_rowid() as id').get().id;
-        db.close();
+        const { reportId } = writeRunnerReport(this, agent.name, reportBody, {
+          cost: cost ?? null,
+          durationMs: durationMs ?? null,
+          inputTokens: usage?.inputTokens ?? null,
+          outputTokens: usage?.outputTokens ?? null,
+          cacheReadTokens: usage?.cacheReadTokens ?? null,
+          success,
+          model: this.currentAgentModel ?? null,
+          timedOut: killedByTimeout,
+          keyId: this.currentAgentKeyId ?? null,
+          visibilityMode: this.currentAgentVisibility?.mode || 'full',
+          visibilityIssues: this.currentAgentVisibility?.issues || [],
+          preformatted: true,
+        });
         log(`Saved report for ${agent.name}`, this.id);
-        // Broadcast new report via SSE
-        broadcastReportUpdate(this.id, lastId, agent.name, this.cycleCount);
+        broadcastReportUpdate(this.id, reportId, agent.name, this.cycleCount);
       } catch (dbErr) {
         log(`Failed to write report: ${dbErr.message}`, this.id);
       }

--- a/src/orchestrator/agent-prompt.js
+++ b/src/orchestrator/agent-prompt.js
@@ -1,0 +1,86 @@
+import fs from 'fs';
+import path from 'path';
+
+export function getAgentFilesystemPolicy(runner, agent, visibility = null) {
+    if (agent.name === 'doctor') {
+      return null;
+    }
+    const visMode = visibility?.mode || 'full';
+    const repoDir = runner.path;
+    const knowledgeDir = runner.knowledgeDir;
+    const ownWorkspaceDir = path.join(runner.agentsDir, agent.name);
+    const read = [repoDir];
+    const write = [repoDir];
+    if (visMode !== 'blind') {
+      read.push(knowledgeDir);
+      read.push(ownWorkspaceDir);
+      write.push(ownWorkspaceDir);
+    }
+    if (agent.isManager && visMode !== 'blind') {
+      read.push(runner.workerSkillsDir);
+      write.push(runner.workerSkillsDir);
+    }
+    const denied = [
+      runner.agentsDir,
+      runner.responsesDir,
+      runner.uploadsDir,
+      runner.skillsDir,
+      runner.statePath,
+      runner.orchestratorLogPath,
+      runner.projectDbPath,
+    ];
+    return { read, write, denied, dbPath: runner.projectDbPath };
+  }
+
+export function buildAgentPrompt(runner, agent, task, visibility, { root }) {
+    const skillPath = agent.isManager
+      ? path.join(root, 'agent', 'managers', `${agent.name}.md`)
+      : path.join(runner.workerSkillsDir, `${agent.name}.md`);
+
+    if (!fs.existsSync(skillPath)) {
+      return null;
+    }
+
+    let skillContent = fs.readFileSync(skillPath, 'utf-8');
+
+    // Build shared rules: everyone.md + folder_structure.md + db.md + role-specific rules
+    let sharedRules = '';
+    try {
+      const everyonePath = path.join(root, 'agent', 'everyone.md');
+      const folderStructurePath = path.join(root, 'agent', 'folder_structure.md');
+      sharedRules = fs.readFileSync(everyonePath, 'utf-8') + '\n\n---\n\n';
+      try {
+        sharedRules += fs.readFileSync(folderStructurePath, 'utf-8') + '\n\n---\n\n';
+      } catch {}
+      const visMode = visibility?.mode || 'full';
+      if (visMode === 'full') {
+        const dbPath = path.join(root, 'agent', 'db.md');
+        try {
+          const dbContent = fs.readFileSync(dbPath, 'utf-8');
+          sharedRules += dbContent + '\n\n---\n\n';
+        } catch {}
+      }
+      if (agent.name !== 'themis') {
+        if (visMode === 'focused') {
+          sharedRules += '\n> **You are in focused mode.** You cannot read the issue tracker or PR board. Work only from the task, the repository, shared knowledge, and your own agent notes. If needed, you may create a new issue or PR record to report a blocker or finding.\n\n---\n\n';
+        } else if (visMode === 'blind') {
+          sharedRules += '\n> **You are in blind mode.** You cannot read the issue tracker or PR board, and you cannot rely on shared knowledge or any agent notes, including your own prior notes. Work only from the task and the repository. If needed, you may create a new issue or PR record to report a blocker or finding.\n\n---\n\n';
+        }
+      } else {
+        sharedRules += '\n> **You are Themis, final examination manager.** You run in full view, not blind. Inspect the repository, issue tracker, PR board, shared knowledge, and agent notes directly. You may hire and schedule workers, but only workers who report to you. Your examination team is independent from the Athena, Ares, and Apollo teams, so make your own judgment from primary evidence.\n\n---\n\n';
+      }
+      const rolePath = path.join(root, 'agent', agent.isManager ? 'manager.md' : 'worker.md');
+      sharedRules += fs.readFileSync(rolePath, 'utf-8') + '\n\n---\n\n';
+    } catch {}
+
+    let taskHeader = '';
+    if (task) {
+      taskHeader = `> **Your assignment: ${task}**\n\n`;
+    }
+
+    // Strip YAML frontmatter (---...---) from skill content before building prompt
+    skillContent = skillContent.replace(/^---[\s\S]*?---\n*/, '');
+    skillContent = (taskHeader + sharedRules + skillContent).replaceAll('{project_dir}', runner.projectDir);
+
+    return skillContent;
+  }

--- a/src/orchestrator/milestones.js
+++ b/src/orchestrator/milestones.js
@@ -1,0 +1,180 @@
+export function normalizeResetTargetMilestone(resetTo) {
+    const value = typeof resetTo === 'string' ? resetTo.trim() : '';
+    if (!value) return null;
+    if (/^root$/i.test(value)) return { milestoneId: null, label: 'root' };
+    const current = String(this.currentMilestoneId || '').trim();
+    if (!current) return null;
+    const candidate = value.replace(/^m/i, 'M');
+    const ancestors = [];
+    const parts = current.split('.');
+    for (let i = parts.length; i >= 1; i--) ancestors.push(parts.slice(0, i).join('.'));
+    if (!ancestors.includes(candidate)) return null;
+    return { milestoneId: candidate, label: candidate };
+  }
+
+export function getParentMilestoneId(milestoneId = null) {
+    const value = String(milestoneId || '').trim();
+    if (!value || !value.includes('.')) return null;
+    return value.split('.').slice(0, -1).join('.') || null;
+  }
+
+export async function getMilestoneRecord(milestoneId) {
+    if (!milestoneId) return null;
+    try {
+      const db = this.getDb();
+      const row = db.prepare(`SELECT * FROM milestones WHERE milestone_id = ?`).get(milestoneId);
+      db.close();
+      return row || null;
+    } catch {
+      return null;
+    }
+  }
+
+export function makeMilestoneBranchPrefix(milestoneId) {
+    return String(milestoneId || 'M0').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+  }
+
+export function slugifyMilestoneTitle(title, { stripLeadingMilestoneId = null } = {}) {
+    let normalizedTitle = String(title || 'milestone');
+    if (stripLeadingMilestoneId) {
+      const escapedMilestoneId = String(stripLeadingMilestoneId)
+        .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+        .replace(/\\\./g, '[\\s._-]*');
+      normalizedTitle = normalizedTitle.replace(new RegExp(`^\\s*${escapedMilestoneId}(?:[\\s:._-]+|\\b)`, 'i'), '');
+    }
+    return normalizedTitle.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 48) || 'milestone';
+  }
+
+export async function allocateNextMilestoneId(parentMilestoneId = null) {
+    try {
+      const db = this.getDb();
+      let nextId = 'M1';
+      if (parentMilestoneId) {
+        const rows = db.prepare(`SELECT milestone_id FROM milestones WHERE parent_milestone_id = ? OR milestone_id LIKE ?`).all(parentMilestoneId, `${parentMilestoneId}.%`);
+        let maxChild = 0;
+        for (const row of rows) {
+          const key = String(row.milestone_id || '');
+          const suffix = key.slice(parentMilestoneId.length + 1);
+          if (/^\d+$/.test(suffix)) maxChild = Math.max(maxChild, Number(suffix));
+        }
+        nextId = `${parentMilestoneId}.${maxChild + 1}`;
+      } else {
+        const rows = db.prepare(`SELECT milestone_id FROM milestones WHERE milestone_id GLOB 'M*'`).all();
+        let maxTop = 0;
+        for (const row of rows) {
+          const m = String(row.milestone_id || '').match(/^M(\d+)$/);
+          if (m) maxTop = Math.max(maxTop, Number(m[1]));
+        }
+        nextId = `M${maxTop + 1}`;
+      }
+      db.close();
+      return nextId;
+    } catch {
+      if (parentMilestoneId) return `${parentMilestoneId}.1`;
+      return `M${(this.epochCount || 0) + 1}`;
+    }
+  }
+
+export async function allocateNextEpochId() {
+    try {
+      const db = this.getDb();
+      const rows = db.prepare(`SELECT epoch_index FROM tbc_prs WHERE epoch_index IS NOT NULL`).all();
+      let maxEpoch = 0;
+      for (const row of rows) {
+        const m = String(row.epoch_index || '').match(/^E(\d+)$/);
+        if (m) maxEpoch = Math.max(maxEpoch, Number(m[1]));
+      }
+      db.close();
+      return `E${maxEpoch + 1}`;
+    } catch {
+      return `E${(this.epochCount || 0) + 1}`;
+    }
+  }
+
+export async function upsertMilestoneRecord({ milestoneId, title, description, cyclesBudget, branchName, parentMilestoneId = null, status = 'active', phase = 'implementation', failureReason = null, linkedPrId = null }) {
+    if (!milestoneId) return;
+    try {
+      const db = this.getDb();
+      const existing = db.prepare(`SELECT id FROM milestones WHERE milestone_id = ?`).get(milestoneId);
+      const now = new Date().toISOString();
+      if (existing) {
+        db.prepare(`UPDATE milestones SET title = ?, description = ?, cycles_budget = ?, branch_name = ?, parent_milestone_id = ?, linked_pr_id = ?, failure_reason = ?, phase = ?, status = ?, completed_at = CASE WHEN ? = 'completed' THEN COALESCE(completed_at, ?) ELSE completed_at END WHERE milestone_id = ?`)
+          .run(title || null, description || '', cyclesBudget || 0, branchName || null, parentMilestoneId || null, linkedPrId || null, failureReason || null, phase, status, status, now, milestoneId);
+      } else {
+        db.prepare(`INSERT INTO milestones (milestone_id, title, description, cycles_budget, cycles_used, branch_name, parent_milestone_id, linked_pr_id, failure_reason, phase, status) VALUES (?, ?, ?, ?, 0, ?, ?, ?, ?, ?, ?)`)
+          .run(milestoneId, title || null, description || '', cyclesBudget || 0, branchName || null, parentMilestoneId || null, linkedPrId || null, failureReason || null, phase, status);
+      }
+      db.close();
+    } catch {}
+  }
+
+export async function ensureEpochPRForCurrentMilestone() {
+    if (!this.currentMilestoneId || !this.milestoneTitle || !this.currentMilestoneBranch) return null;
+    const existing = await this.getOpenEpochPRForCurrentMilestone();
+    if (existing) {
+      if (!this.currentEpochPrId) this.setState({ currentEpochPrId: existing.id }, { save: true });
+      return existing;
+    }
+    try {
+      const db = this.getDb();
+      const now = new Date().toISOString();
+      const result = db.prepare(`INSERT INTO tbc_prs (title, summary, milestone_id, parent_pr_id, epoch_index, branch_name, base_branch, head_branch, status, decision, decision_reason, issue_ids, test_status, actor, updated_by, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'open', NULL, '', '[]', 'unknown', 'ares', 'ares', ?, ?)`).run(
+        this.milestoneTitle,
+        this.milestoneDescription || '',
+        this.currentMilestoneId,
+        null,
+        this.currentEpochId,
+        this.currentMilestoneBranch,
+        'main',
+        this.currentMilestoneBranch,
+        now,
+        now,
+      );
+      const prId = result.lastInsertRowid;
+      db.close();
+      await this.upsertMilestoneRecord({
+        milestoneId: this.currentMilestoneId,
+        title: this.milestoneTitle,
+        description: this.milestoneDescription,
+        cyclesBudget: this.milestoneCyclesBudget,
+        branchName: this.currentMilestoneBranch,
+        parentMilestoneId: this.currentMilestoneId.includes('.') ? this.currentMilestoneId.split('.').slice(0, -1).join('.') : null,
+        linkedPrId: prId,
+      });
+      this.setState({ currentEpochPrId: prId }, { save: true });
+      return await this.getPR(prId);
+    } catch {
+      return null;
+    }
+  }
+
+export async function markCurrentMilestoneFailed(reason) {
+    if (!this.currentMilestoneId) return;
+    await this.upsertMilestoneRecord({
+      milestoneId: this.currentMilestoneId,
+      title: this.milestoneTitle,
+      description: this.milestoneDescription,
+      cyclesBudget: this.milestoneCyclesBudget,
+      branchName: this.currentMilestoneBranch,
+      parentMilestoneId: this.currentMilestoneId.includes('.') ? this.currentMilestoneId.split('.').slice(0, -1).join('.') : null,
+      status: 'failed',
+      phase: 'athena',
+      failureReason: reason || null,
+      linkedPrId: this.currentEpochPrId,
+    });
+  }
+
+export async function markCurrentMilestoneCompleted() {
+    if (!this.currentMilestoneId) return;
+    await this.upsertMilestoneRecord({
+      milestoneId: this.currentMilestoneId,
+      title: this.milestoneTitle,
+      description: this.milestoneDescription,
+      cyclesBudget: this.milestoneCyclesBudget,
+      branchName: this.currentMilestoneBranch,
+      parentMilestoneId: this.currentMilestoneId.includes('.') ? this.currentMilestoneId.split('.').slice(0, -1).join('.') : null,
+      status: 'completed',
+      phase: 'athena',
+      linkedPrId: this.currentEpochPrId,
+    });
+  }

--- a/src/orchestrator/phase-machine.js
+++ b/src/orchestrator/phase-machine.js
@@ -1,0 +1,662 @@
+export async function runRunnerLoop(runner, deps = {}) {
+    while (runner.running) {
+      while (runner.isPaused && runner.running) {
+        await deps.sleep(1000);
+      }
+      if (!runner.running) break;
+
+      const config = runner.loadConfig();
+
+      // Check budget before starting cycle
+      const budgetStatus = runner.getBudgetStatus();
+      if (budgetStatus && budgetStatus.exhausted) {
+        deps.log(`Budget exhausted ($${budgetStatus.spent24h.toFixed(2)}/$${budgetStatus.budgetPer24h}), waiting for budget to roll off`, runner.id);
+        runner.setState({ isPaused: true, pauseReason: `Budget exhausted: $${budgetStatus.spent24h.toFixed(2)} / $${budgetStatus.budgetPer24h} (24h)` });
+        // Re-check every 2 hours until budget rolls off or manually resumed
+        await runner._autoPauseWait(2 * 60 * 60 * 1000, () => !runner.getBudgetStatus().exhausted);
+        if (!runner.running) break;
+        continue;
+      }
+
+      // Check if any API key is available before starting a cycle
+      const preConfig = runner.loadConfig();
+      const poolCheck = deps.getKeyPoolSafe();
+      if (poolCheck.keys.filter(k => k.enabled).length === 0 && !preConfig.setupToken) {
+        deps.log(`No API keys configured. Pausing project. Add a key in Settings > Credentials.`, runner.id);
+        runner.setState({ isPaused: true, pauseReason: 'No API keys configured. Add one in Settings > Credentials.' });
+        await runner._autoPauseWait(30_000, () => deps.getKeyPoolSafe().keys.some(k => k.enabled));
+        if (!runner.running) break;
+        continue;
+      }
+
+      const { managers, workers } = runner.loadAgents();
+
+      // Start new cycle — preserve schedule state if resuming from reboot
+      runner.abortCurrentCycle = false;
+      const resuming = !!runner.currentSchedule;
+      if (!resuming) {
+        runner.cycleCount++;
+        runner.completedAgents = [];
+        runner.saveState();
+      }
+      deps.log(`===== CYCLE ${runner.cycleCount} (phase: ${runner.phase})${resuming ? ' [RESUMING]' : ''} =====`, runner.id);
+
+      let cycleFailures = 0;
+      let cycleTotal = 0;
+
+      // ===== PHASE: ATHENA (strategy) =====
+      if (runner.phase === 'athena') {
+        const athena = managers.find(m => m.name === 'athena');
+        if (athena) {
+          // Build situation context for Athena
+          if (!runner.pendingMilestoneId) {
+            const parentMilestoneId = runner.currentMilestoneId || null;
+            runner.pendingMilestoneId = await runner.allocateNextMilestoneId(parentMilestoneId);
+            runner.saveState();
+          }
+          const reservedBranchPrefix = runner.makeMilestoneBranchPrefix(runner.pendingMilestoneId);
+
+          let situation = '';
+          if (runner.examinationFeedback) {
+            situation = `> **Situation: Project Completion Rejected by Themis**\n> ${runner.examinationFeedback}\n\n`;
+          } else if (!runner.milestoneDescription) {
+            situation = '> **Situation: Project Just Started**\n\n';
+          } else if (runner.verificationFeedback === '__passed__') {
+            situation = '> **Situation: Milestone Verified Complete**\n> Previous milestone was verified by Apollo\'s team.\n\n';
+          } else if (runner.verificationFeedback) {
+            situation = `> **Situation: Epoch PR Rejected by Apollo**\n> ${runner.verificationFeedback}\n> Previous milestone: ${runner.currentMilestoneId || 'unknown'}\n> Previous branch: ${runner.currentMilestoneBranch || 'unknown'}\n> Athena should split or narrow the failed milestone into a new PR-sized milestone, not send it back as a generic fix round.\n\n`;
+          } else {
+            situation = `> **Situation: Implementation Deadline Missed**\n> Ares's team used ${runner.milestoneCyclesUsed}/${runner.milestoneCyclesBudget} cycles without completing the milestone.\n> Previous milestone: ${runner.currentMilestoneId || 'unknown'}\n> Current branch: ${runner.currentMilestoneBranch || 'not set'}\n\n`;
+          }
+          situation += `> **Assigned milestone ID:** ${runner.pendingMilestoneId}\n> **Reserved branch prefix:** ${reservedBranchPrefix}\n`;
+          if (runner.currentMilestoneId) {
+            situation += `> **Optional reset:** If the current subtree is wrong, you may return a milestone with \"reset_to\": \"${runner.currentMilestoneId}\" or any ancestor milestone id (or \"root\") to abandon deeper branches and replan from that level.\n`;
+          }
+          situation += `\n`;
+
+          const result = await runner.runAgent(athena, config, null, situation);
+          cycleTotal++;
+          if (!result || !result.success) cycleFailures++;
+
+          // Parse schedule and milestone from Athena's response
+          let schedule = null;
+          if (result && result.resultText) {
+            schedule = runner.parseSchedule(result.resultText);
+            if (schedule) {
+              deps.log(`Schedule: ${JSON.stringify(schedule)}`, runner.id);
+            }
+
+            const milestoneMatch = result.resultText.match(/<!-- MILESTONE -->\s*([\s\S]*?)\s*<!-- \/MILESTONE -->/);
+            if (milestoneMatch) {
+              try {
+                const milestone = JSON.parse(milestoneMatch[1]);
+                const milestoneTitle = milestone.title || milestone.description.slice(0, 80);
+                const resetTarget = runner.normalizeResetTargetMilestone(milestone.reset_to);
+                const resetTo = resetTarget ? resetTarget.milestoneId : (runner.currentMilestoneId || null);
+                const shouldReusePendingMilestoneId = !!runner.pendingMilestoneId && resetTo === (runner.currentMilestoneId || null);
+                const milestoneId = shouldReusePendingMilestoneId
+                  ? runner.pendingMilestoneId
+                  : await runner.allocateNextMilestoneId(resetTo);
+                if (milestone.reset_to && !resetTarget) {
+                  deps.log(`Ignoring invalid reset_to target from Athena: ${milestone.reset_to}`, runner.id);
+                } else if (milestone.reset_to && resetTarget) {
+                  deps.log(`Athena reset planning anchor to ${resetTarget.label}`, runner.id);
+                  if (runner.currentMilestoneBranch) {
+                    runner.closeOpenEpochPRForBranch(runner.currentMilestoneBranch, {
+                      actor: 'athena',
+                      reason: `Athena reset subtree to ${resetTarget.label} while replanning.`,
+                    });
+                  }
+                }
+                runner.setState({
+                  milestoneTitle,
+                  milestoneDescription: milestone.description,
+                  milestoneCyclesBudget: milestone.cycles || 20,
+                  milestoneCyclesUsed: 0,
+                  currentMilestoneId: milestoneId,
+                  pendingMilestoneId: null,
+                  currentEpochId: null,
+                  currentEpochPrId: null,
+                  currentMilestoneBranch: null,
+                  aresGraceCycleUsed: false,
+                  verificationFeedback: null,
+                  examinationFeedback: null,
+                  pendingCompletionMessage: null,
+                  isFixRound: false,
+                  phase: 'implementation',
+                });
+                await runner.upsertMilestoneRecord({
+                  milestoneId,
+                  title: milestoneTitle,
+                  description: milestone.description,
+                  cyclesBudget: milestone.cycles || 20,
+                  branchName: null,
+                  parentMilestoneId: milestoneId.includes('.') ? milestoneId.split('.').slice(0, -1).join('.') : null,
+                  phase: 'implementation',
+                  status: 'active',
+                });
+                runner.epochCount++;
+                runner.saveState();
+                deps.log(`Epoch ${runner.epochCount}: New milestone (${runner.milestoneCyclesBudget} cycles): ${runner.milestoneDescription.slice(0, 100)}...`, runner.id);
+                broadcastEvent({ type: 'milestone', project: runner.id, title: runner.milestoneTitle, cycles: runner.milestoneCyclesBudget });
+              } catch (e) {
+                deps.log(`Failed to parse milestone: ${e.message}`, runner.id);
+              }
+            }
+            // Check for PROJECT_COMPLETE tag
+            const completeMatch = result.resultText.match(/<!-- PROJECT_COMPLETE -->\s*([\s\S]*?)\s*<!-- \/PROJECT_COMPLETE -->/);
+            if (completeMatch) {
+              try {
+                const completion = JSON.parse(completeMatch[1]);
+                const success = !!completion.success;
+                const message = completion.message || 'Project completed';
+                if (success) {
+                  runner.setState({
+                    phase: 'examination',
+                    pendingCompletionMessage: message,
+                    examinationFeedback: null,
+                    completionSuccess: false,
+                    completionMessage: null,
+                    isComplete: false,
+                    isPaused: false,
+                    pauseReason: null,
+                  });
+                  deps.log(`🧪 PROJECT COMPLETE claimed — routing to Themis examination: ${message}`, runner.id);
+                  broadcastEvent({ type: 'phase', project: runner.id, phase: 'examination', title: runner.milestoneTitle || 'Project examination' });
+                } else {
+                  runner.setState({
+                    isComplete: true,
+                    completionSuccess: success,
+                    completionMessage: message,
+                    isPaused: true,
+                    pauseReason: `Project ${success ? 'completed successfully' : 'ended'}: ${message}`,
+                  });
+                  deps.log(`🏁 PROJECT COMPLETE (success: ${success}): ${message}`, runner.id);
+                  broadcastEvent({ type: 'project-complete', project: runner.id, success, message });
+                }
+                continue;
+              } catch (e) {
+                deps.log(`Failed to parse PROJECT_COMPLETE: ${e.message}`, runner.id);
+              }
+            }
+
+            // Check for STOP file
+            if (fs.existsSync(runner.stopPath)) {
+              deps.log(`STOP file detected — pausing project`, runner.id);
+              runner.setState({ isPaused: true, pauseReason: 'Project stopped by Athena' });
+              continue;
+            }
+          }
+
+          // Execute schedule steps (delays + workers)
+          if (schedule) {
+            runner.currentSchedule = schedule;
+            runner.saveState(); // Persist schedule before execution so it survives reboot
+            const { total, failures } = await runner.executeSchedule(schedule, config, 'athena');
+            cycleTotal += total;
+            cycleFailures += failures;
+            runner.currentSchedule = null;
+            runner.completedAgents = [];
+          }
+
+          runner.saveState();
+        }
+      }
+
+      // ===== PHASE: IMPLEMENTATION (Ares + his workers) =====
+      else if (runner.phase === 'implementation') {
+        const aresGraceMode = runner.milestoneCyclesUsed >= runner.milestoneCyclesBudget;
+        // Check if deadline missed (before running)
+        if (aresGraceMode && runner.aresGraceCycleUsed) {
+          const failureReason = `Implementation deadline missed after ${runner.milestoneCyclesUsed}/${runner.milestoneCyclesBudget} cycles for ${runner.currentMilestoneId || 'unknown milestone'}.`;
+          await runner.decideEpochPR('closed', { actor: 'apollo', reason: failureReason });
+          await runner.markCurrentMilestoneFailed(failureReason);
+          deps.log(`⏰ Implementation deadline missed (${runner.milestoneCyclesUsed}/${runner.milestoneCyclesBudget} cycles)`, runner.id);
+          runner.setState({ currentEpochId: null, currentEpochPrId: null, currentMilestoneBranch: null, aresGraceCycleUsed: false, phase: 'athena' });
+          continue;
+        }
+
+        // Resume interrupted schedule from previous cycle (e.g. after reboot)
+        // Note: don't require completedAgents — schedule may start with a delay step
+        if (runner.currentSchedule) {
+          deps.log(`Resuming interrupted schedule (${runner.completedAgents.length} agents already completed${runner.completedAgents.length ? ': [' + runner.completedAgents.join(', ') + ']' : ''})`, runner.id);
+          const { total, failures } = await runner.executeSchedule(runner.currentSchedule, config, 'ares');
+          cycleTotal += total;
+          cycleFailures += failures;
+          runner.currentSchedule = null;
+          runner.completedAgents = [];
+          runner.saveState();
+        } else {
+
+        const ares = managers.find(m => m.name === 'ares');
+        if (ares) {
+          let epochStateChanged = false;
+          if (!runner.currentEpochId) {
+            runner.currentEpochId = await runner.allocateNextEpochId();
+            runner.epochCount += 1;
+            epochStateChanged = true;
+          }
+          if (!runner.currentMilestoneBranch) {
+            const branchPrefix = runner.makeMilestoneBranchPrefix(runner.currentMilestoneId);
+            runner.currentMilestoneBranch = `${String(runner.currentEpochId || 'E0').toLowerCase()}-${branchPrefix}-${runner.slugifyMilestoneTitle(runner.milestoneTitle, { stripLeadingMilestoneId: runner.currentMilestoneId })}`;
+            epochStateChanged = true;
+          }
+          if (epochStateChanged) runner.saveState();
+          const openEpochPr = await runner.ensureEpochPRForCurrentMilestone();
+          // Build context for Ares (remaining includes this cycle)
+          const cyclesRemaining = Math.max(0, runner.milestoneCyclesBudget - runner.milestoneCyclesUsed);
+          let aresContext = `> **Milestone ID:** ${runner.currentMilestoneId || 'unknown'}
+> **Milestone:** ${runner.milestoneDescription}
+> **Epoch ID:** ${runner.currentEpochId || 'unknown'}
+> **Cycles remaining:** ${cyclesRemaining} of ${runner.milestoneCyclesBudget}
+> **Milestone branch:** ${runner.currentMilestoneBranch || 'not set'}
+> **Epoch PR:** ${openEpochPr?.id ? `#${openEpochPr.id}` : 'not set'}
+> **Epoch PR rule:** The orchestrator assigned exactly one TBC PR to this milestone branch. Use it instead of creating competing PRs.
+
+`;
+          if (aresGraceMode) {
+            aresContext += `> **Grace review mode:** Worker budget is exhausted. This is your final manager-only pass.
+> **Do not emit a schedule. Do not assign any workers.**
+> Review the existing evidence only. If the milestone is already complete, emit <!-- CLAIM_COMPLETE -->. Otherwise emit no completion block and the milestone will fail.
+
+`;
+          }
+          if (runner.isFixRound && runner.verificationFeedback) {
+            aresContext += `> **Legacy verification feedback:**
+> ${runner.verificationFeedback}
+
+`;
+          }
+
+          const result = await runner.runAgent(ares, config, null, aresContext);
+          cycleTotal++;
+          if (!result || !result.success) cycleFailures++;
+          if (aresGraceMode) runner.aresGraceCycleUsed = true;
+
+          // Parse schedule and check for CLAIM_COMPLETE
+          let schedule = null;
+          let claimedComplete = false;
+          if (result && result.resultText) {
+            if (!aresGraceMode) {
+              schedule = runner.parseSchedule(result.resultText);
+              if (schedule) {
+                deps.log(`Schedule: ${JSON.stringify(schedule)}`, runner.id);
+                runner.currentSchedule = schedule;
+              }
+            } else if (runner.parseSchedule(result.resultText)) {
+              deps.log('⚠️ Ignoring Ares schedule because grace review mode forbids worker scheduling', runner.id);
+            }
+
+            // Check if Ares claims milestone complete
+            if (result.resultText.includes('<!-- CLAIM_COMPLETE -->')) {
+              claimedComplete = true;
+              const openEpochPr = await runner.ensureEpochPRForCurrentMilestone();
+              if (!openEpochPr) {
+                runner.verificationFeedback = `Ares claimed milestone completion without an orchestrator-managed epoch PR on branch ${runner.currentMilestoneBranch || 'unknown'}.`;
+                deps.log('⚠️ CLAIM_COMPLETE ignored because no orchestrator-managed epoch PR exists for the current milestone branch', runner.id);
+                runner.saveState();
+                claimedComplete = false;
+              } else {
+                deps.log(`🎯 Ares claims milestone complete for epoch PR #${openEpochPr.id} — switching to verification`, runner.id);
+                runner.setState({ phase: 'verification', currentEpochPrId: openEpochPr.id });
+                broadcastEvent({ type: 'phase', project: runner.id, phase: 'verification', title: runner.milestoneTitle });
+              }
+            }
+          }
+
+          if (aresGraceMode && !claimedComplete) {
+            const failureReason = `Implementation deadline missed after ${runner.milestoneCyclesUsed}/${runner.milestoneCyclesBudget} cycles for ${runner.currentMilestoneId || 'unknown milestone'} (Ares grace review did not claim completion).`;
+            await runner.decideEpochPR('closed', { actor: 'apollo', reason: failureReason });
+            await runner.markCurrentMilestoneFailed(failureReason);
+            deps.log(`⏰ ${failureReason}`, runner.id);
+            runner.setState({ currentEpochId: null, currentEpochPrId: null, currentMilestoneBranch: null, aresGraceCycleUsed: false, phase: 'athena', verificationFeedback: failureReason });
+            runner.saveState();
+            continue;
+          }
+
+          // Execute schedule steps (delays + workers)
+          if (schedule) {
+            runner.completedAgents = [];
+            runner.saveState(); // Persist schedule before execution so it survives reboot
+            const { total, failures } = await runner.executeSchedule(schedule, config, 'ares');
+            cycleTotal += total;
+            cycleFailures += failures;
+            runner.currentSchedule = null;
+            runner.completedAgents = [];
+            runner.saveState();
+          }
+        }
+        } // end else (no interrupted schedule)
+        // Only count cycle if at least one agent succeeded
+        if (cycleTotal > 0 && cycleFailures < cycleTotal) {
+          runner.milestoneCyclesUsed++;
+        } else if (cycleTotal > 0) {
+          deps.log(`All ${cycleTotal} agents failed — cycle not counted toward milestone budget`, runner.id);
+        }
+        runner.saveState();
+      }
+
+      // ===== PHASE: VERIFICATION (Apollo + his workers) =====
+      else if (runner.phase === 'verification') {
+        // Resume interrupted verification schedule (e.g. after reboot)
+        if (runner.currentSchedule && runner.completedAgents.length > 0) {
+          deps.log(`Resuming interrupted verification schedule (${runner.completedAgents.length} agents already completed: [${runner.completedAgents.join(', ')}])`, runner.id);
+          const { total, failures } = await runner.executeSchedule(runner.currentSchedule, config, 'apollo');
+          cycleTotal += total;
+          cycleFailures += failures;
+          runner.currentSchedule = null;
+          runner.completedAgents = [];
+          runner.saveState();
+        } else {
+        const apollo = managers.find(m => m.name === 'apollo');
+        if (apollo) {
+          const isRollupVerification = !runner.currentEpochPrId;
+          const apolloContext = isRollupVerification
+            ? `> **Milestone to verify:** ${runner.milestoneDescription}\n> **Rollup verification target:** ${runner.currentMilestoneId || 'unknown'}\n> **Verification mode:** Parent milestone rollup after a child milestone passed\n> **Active epoch PR:** none (rollup verification)\n> Apollo should decide whether this parent milestone is now fully complete or Athena should plan the next child under it.\n\n`
+            : `> **Milestone to verify:** ${runner.milestoneDescription}\n> **Milestone branch:** ${runner.currentMilestoneBranch || 'not set'}\n> **Active epoch PR:** ${runner.currentEpochPrId || 'unknown'}\n> Apollo owns the PR decision: merge on pass, close on fail.\n\n`;
+
+          const result = await runner.runAgent(apollo, config, null, apolloContext);
+          cycleTotal++;
+          if (!result || !result.success) cycleFailures++;
+
+          let schedule = null;
+          let decision = null;
+          if (result && result.resultText) {
+            schedule = runner.parseSchedule(result.resultText);
+            if (schedule) {
+              deps.log(`Schedule: ${JSON.stringify(schedule)}`, runner.id);
+            }
+
+            // Check for verification decision
+            if (result.resultText.includes('<!-- VERIFY_PASS -->')) {
+              decision = 'pass';
+            }
+            const failMatch = result.resultText.match(/<!-- VERIFY_FAIL -->\s*([\s\S]*?)\s*<!-- \/VERIFY_FAIL -->/);
+            if (failMatch) {
+              try {
+                const failData = JSON.parse(failMatch[1]);
+                decision = 'fail';
+                runner.verificationFeedback = failData.feedback || 'Verification failed (no specific feedback)';
+              } catch {
+                decision = 'fail';
+                runner.verificationFeedback = 'Verification failed (could not parse feedback)';
+              }
+            }
+          }
+
+          // Execute schedule steps (delays + workers)
+          if (schedule) {
+            runner.currentSchedule = schedule;
+            runner.completedAgents = [];
+            runner.saveState(); // Persist schedule before execution so it survives reboot
+            const { total, failures } = await runner.executeSchedule(schedule, config, 'apollo');
+            cycleTotal += total;
+            cycleFailures += failures;
+            runner.currentSchedule = null;
+            runner.completedAgents = [];
+            runner.saveState();
+          }
+
+          // Process decision
+          if (decision === 'pass') {
+            const mergedPr = isRollupVerification ? null : await runner.decideEpochPR('merged', {
+              actor: 'apollo',
+              reason: `Apollo passed milestone ${runner.currentMilestoneId || ''} ${runner.milestoneTitle || runner.milestoneDescription || ''}`.trim(),
+            });
+            const completedMilestoneId = runner.currentMilestoneId;
+            const completedMilestoneTitle = runner.milestoneTitle;
+            const parentMilestoneId = runner.getParentMilestoneId(completedMilestoneId);
+            await runner.markCurrentMilestoneCompleted();
+            if (parentMilestoneId) {
+              const parentMilestone = await runner.getMilestoneRecord(parentMilestoneId);
+              deps.log(`✅ Milestone verified — escalating completion check to parent milestone ${parentMilestoneId}`, runner.id);
+              broadcastEvent({ type: 'verified', project: runner.id, title: completedMilestoneTitle });
+              if (parentMilestone) {
+                await runner.upsertMilestoneRecord({
+                  milestoneId: parentMilestoneId,
+                  title: parentMilestone.title,
+                  description: parentMilestone.description,
+                  cyclesBudget: parentMilestone.cycles_budget,
+                  branchName: parentMilestone.branch_name,
+                  parentMilestoneId: parentMilestone.parent_milestone_id,
+                  phase: 'verification',
+                  status: 'active',
+                  linkedPrId: parentMilestone.linked_pr_id,
+                  failureReason: null,
+                });
+              }
+              runner.setState({
+                milestoneTitle: parentMilestone?.title || parentMilestoneId,
+                milestoneDescription: parentMilestone?.description || `Parent rollup verification for ${parentMilestoneId}`,
+                milestoneCyclesBudget: parentMilestone?.cycles_budget || 0,
+                milestoneCyclesUsed: parentMilestone?.cycles_used || 0,
+                currentMilestoneId: parentMilestoneId,
+                pendingMilestoneId: null,
+                currentEpochId: null,
+                currentEpochPrId: null,
+                currentMilestoneBranch: parentMilestone?.branch_name || null,
+                aresGraceCycleUsed: false,
+                lastMergedMilestoneBranch: mergedPr?.branch_name || mergedPr?.head_branch || runner.currentMilestoneBranch || runner.lastMergedMilestoneBranch,
+                verificationFeedback: null,
+                isFixRound: false,
+                phase: 'verification',
+              });
+              broadcastEvent({ type: 'phase', project: runner.id, phase: 'verification', title: parentMilestone?.title || parentMilestoneId });
+            } else {
+              deps.log(`✅ Milestone verified — waking Athena for next milestone`, runner.id);
+              broadcastEvent({ type: 'verified', project: runner.id, title: runner.milestoneTitle });
+              runner.milestoneTitle = null;
+              runner.setState({
+                milestoneTitle: null,
+                milestoneDescription: null,
+                milestoneCyclesBudget: 0,
+                milestoneCyclesUsed: 0,
+                currentMilestoneId: null,
+                pendingMilestoneId: null,
+                currentEpochId: null,
+                currentEpochPrId: null,
+                currentMilestoneBranch: null,
+                aresGraceCycleUsed: false,
+                lastMergedMilestoneBranch: mergedPr?.branch_name || mergedPr?.head_branch || runner.currentMilestoneBranch || runner.lastMergedMilestoneBranch,
+                verificationFeedback: null,
+                isFixRound: false,
+                phase: 'athena',
+              });
+            }
+          } else if (decision === 'fail') {
+            const failureReason = runner.verificationFeedback || 'Apollo rejected the epoch PR and requested milestone splitting or narrowing.';
+            if (isRollupVerification) {
+              deps.log('❌ Parent rollup verification incomplete — returning to Athena to plan the next child milestone', runner.id);
+              broadcastEvent({ type: 'verify-fail', project: runner.id, title: runner.milestoneTitle });
+              runner.setState({
+                pendingMilestoneId: null,
+                currentEpochId: null,
+                currentEpochPrId: null,
+                currentMilestoneBranch: null,
+                aresGraceCycleUsed: false,
+                verificationFeedback: failureReason,
+                isFixRound: false,
+                phase: 'athena',
+              });
+            } else {
+              await runner.decideEpochPR('closed', {
+                actor: 'apollo',
+                reason: failureReason,
+              });
+              await runner.markCurrentMilestoneFailed(failureReason);
+              deps.log('❌ Verification failed — returning to Athena for split/replan', runner.id);
+              broadcastEvent({ type: 'verify-fail', project: runner.id, title: runner.milestoneTitle });
+              runner.setState({
+                pendingMilestoneId: null,
+                currentEpochId: null,
+                currentEpochPrId: null,
+                aresGraceCycleUsed: false,
+                verificationFeedback: failureReason,
+                isFixRound: false,
+                phase: 'athena',
+              });
+            }
+          } else {
+            // No decision yet, stay in verification phase — still save
+            runner.saveState();
+          }
+        }
+        } // end else (no interrupted verification schedule)
+      }
+
+      // ===== PHASE: EXAMINATION (Themis final audit) =====
+      else if (runner.phase === 'examination') {
+        // Resume interrupted examination schedule (e.g. after reboot)
+        if (runner.currentSchedule) {
+          deps.log(`Resuming interrupted examination schedule (${runner.completedAgents.length} agents already completed${runner.completedAgents.length ? ': [' + runner.completedAgents.join(', ') + ']' : ''})`, runner.id);
+          const { total, failures } = await runner.executeSchedule(runner.currentSchedule, config, 'themis');
+          cycleTotal += total;
+          cycleFailures += failures;
+          runner.currentSchedule = null;
+          runner.completedAgents = [];
+          runner.saveState();
+        } else {
+        const themis = managers.find(m => m.name === 'themis');
+        if (themis) {
+          const themisContext = `> **Final completion claim:** ${runner.pendingCompletionMessage || 'Project claimed complete'}\n> **Evaluate the entire project, not just the human\'s explicit goal.** Audit correctness, completeness, maintainability, artifacts, tests, docs, and obvious risks.\n\n`;
+          const result = await runner.runAgent(themis, config, null, themisContext, { mode: 'full', issues: [] });
+          cycleTotal++;
+          if (!result || !result.success) cycleFailures++;
+
+          let schedule = null;
+          let decision = null;
+          let failData = null;
+          if (result && result.resultText) {
+            schedule = runner.parseSchedule(result.resultText);
+            if (schedule) {
+              deps.log(`Schedule: ${JSON.stringify(schedule)}`, runner.id);
+            }
+
+            if (result.resultText.includes('<!-- EXAM_PASS -->')) {
+              decision = 'pass';
+            }
+            const failMatch = result.resultText.match(/<!-- EXAM_FAIL -->\s*([\s\S]*?)\s*<!-- \/EXAM_FAIL -->/);
+            if (failMatch) {
+              try {
+                failData = JSON.parse(failMatch[1]);
+              } catch {
+                failData = { feedback: 'Themis rejected project completion, but the response could not be parsed.' };
+              }
+              decision = 'fail';
+            } else if (!schedule && decision == null) {
+              decision = 'fail';
+            }
+          }
+
+          if (schedule) {
+            runner.currentSchedule = schedule;
+            runner.completedAgents = [];
+            runner.saveState();
+            const { total, failures } = await runner.executeSchedule(schedule, config, 'themis');
+            cycleTotal += total;
+            cycleFailures += failures;
+            runner.currentSchedule = null;
+            runner.completedAgents = [];
+            runner.saveState();
+          }
+
+          if (decision === 'pass') {
+            const message = runner.pendingCompletionMessage || 'Project completed';
+            runner.setState({
+              phase: 'athena',
+              isComplete: true,
+              completionSuccess: true,
+              completionMessage: message,
+              pendingCompletionMessage: null,
+              examinationFeedback: null,
+              currentSchedule: null,
+              completedAgents: [],
+              isPaused: true,
+              pauseReason: `Project completed successfully: ${message}`,
+            });
+            deps.log(`🏁 PROJECT COMPLETE (validated by Themis): ${message}`, runner.id);
+            broadcastEvent({ type: 'project-complete', project: runner.id, success: true, message });
+          } else if (decision === 'fail') {
+            let issues = Array.isArray(failData?.issues) ? failData.issues : [];
+            const rawFeedback = (result?.resultText || '').trim();
+            if (issues.length === 0) {
+              issues = [{
+                title: 'Themis rejected project completion',
+                body: rawFeedback || failData?.feedback || failData?.summary || 'Themis did not issue EXAM_PASS, so the completion claim was rejected.',
+              }];
+            }
+            const createdIssueIds = [];
+            for (const issue of issues) {
+              if (!issue?.title) continue;
+              try {
+                const created = await runner.createIssue(issue.title, issue.body || '', 'themis');
+                createdIssueIds.push(created.issueId);
+              } catch (e) {
+                deps.log(`Themis issue creation failed: ${e.message}`, runner.id);
+              }
+            }
+            const feedback = failData?.feedback || failData?.summary || rawFeedback || 'Themis rejected the project completion claim.';
+            runner.setState({
+              phase: 'athena',
+              examinationFeedback: createdIssueIds.length
+                ? `${feedback} New issues: ${createdIssueIds.map(id => `#${id}`).join(', ')}`
+                : feedback,
+              pendingCompletionMessage: null,
+              currentSchedule: null,
+              completedAgents: [],
+              isComplete: false,
+              completionSuccess: false,
+              completionMessage: null,
+              isPaused: false,
+              pauseReason: null,
+            });
+            deps.log(`❌ Themis rejected project completion — returning to Athena`, runner.id);
+            broadcastEvent({ type: 'phase', project: runner.id, phase: 'athena', title: runner.milestoneTitle || 'Replanning after Themis rejection' });
+          } else {
+            // No decision yet, stay in examination phase — still save
+            runner.saveState();
+          }
+        }
+        } // end else (no interrupted examination schedule)
+      }
+
+      // If no agent succeeded, don't count this cycle
+      if (cycleTotal > 0 && cycleFailures === cycleTotal) {
+        runner.cycleCount--;
+        runner.saveState();
+      }
+
+      // Track consecutive agent failures — auto-pause after 10
+      runner.consecutiveFailures = (cycleTotal > 0 && cycleFailures === cycleTotal)
+        ? runner.consecutiveFailures + cycleFailures
+        : 0;
+      if (runner.consecutiveFailures >= 10 && runner.running) {
+        deps.log(`⚠️ ${runner.consecutiveFailures} consecutive agent failures — auto-pausing (retry in 2h)`, runner.id);
+        broadcastEvent({ type: 'error', project: runner.id, message: `${runner.consecutiveFailures} consecutive failures — auto-paused` });
+        runner.setState({ isPaused: true, pauseReason: `${runner.consecutiveFailures} consecutive agent failures` });
+        runner.consecutiveFailures = 0;
+        await runner._autoPauseWait(2 * 60 * 60 * 1000);
+        if (!runner.running) break;
+        continue;
+      }
+
+      // Compute sleep: budget-derived or fixed interval
+      const sleepMs = runner.computeSleepInterval();
+      runner.lastComputedSleepMs = sleepMs; // Cache for status requests
+      if (runner.running) {
+        deps.log(`Sleeping ${Math.round(sleepMs / 1000)}s...`, runner.id);
+        runner.wakeNow = false;
+        runner.sleepUntil = Date.now() + sleepMs;
+
+        let sleptMs = 0;
+        while (sleptMs < sleepMs && !runner.wakeNow && runner.running) {
+          await deps.sleep(5000);
+          sleptMs += 5000;
+          while (runner.isPaused && !runner.wakeNow && runner.running) {
+            await deps.sleep(1000);
+          }
+        }
+        runner.sleepUntil = null;
+      }
+    }
+  }

--- a/src/orchestrator/project-db.js
+++ b/src/orchestrator/project-db.js
@@ -1,0 +1,317 @@
+import fs from 'fs';
+import path from 'path';
+import Database from 'better-sqlite3';
+
+function syncAgentRegistry(db, runner, { root }) {
+  const upsert = db.prepare(`
+    INSERT INTO agents (name, role, reports_to, model, disabled)
+    VALUES (?, ?, ?, ?, ?)
+    ON CONFLICT(name) DO UPDATE SET
+      role = excluded.role,
+      reports_to = excluded.reports_to,
+      model = excluded.model,
+      disabled = excluded.disabled
+  `);
+  const managersDir = path.join(root, 'agent', 'managers');
+  const workersDir = runner.workerSkillsDir;
+  const parseRole = (content) => (content.match(/^role:\s*(.+)$/m) || [])[1]?.trim() || null;
+  const parseModel = (content) => (content.match(/^model:\s*(.+)$/m) || [])[1]?.trim() || null;
+
+  if (fs.existsSync(managersDir)) {
+    for (const file of fs.readdirSync(managersDir)) {
+      if (!file.endsWith('.md')) continue;
+      const content = fs.readFileSync(path.join(managersDir, file), 'utf-8');
+      const name = file.replace('.md', '');
+      const disabled = /^disabled:\s*true$/m.test(content) ? 1 : 0;
+      upsert.run(name, parseRole(content), null, parseModel(content), disabled);
+    }
+  }
+
+  if (fs.existsSync(workersDir)) {
+    for (const file of fs.readdirSync(workersDir)) {
+      if (!file.endsWith('.md')) continue;
+      const content = fs.readFileSync(path.join(workersDir, file), 'utf-8');
+      const name = file.replace('.md', '');
+      const disabled = /^disabled:\s*true$/m.test(content) ? 1 : 0;
+      const reportsTo = (content.match(/^reports_to:\s*(.+)$/m) || [])[1]?.trim() || null;
+      upsert.run(name, parseRole(content), reportsTo, parseModel(content), disabled);
+    }
+  }
+}
+
+export function openProjectDb(runner, { root }) {
+  const db = new Database(runner.projectDbPath);
+  db.pragma('journal_mode = WAL');
+  db.pragma('foreign_keys = ON');
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS agents (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT UNIQUE NOT NULL, role TEXT, reports_to TEXT, model TEXT, disabled INTEGER DEFAULT 0, created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')));
+    CREATE TABLE IF NOT EXISTS issues (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL, body TEXT DEFAULT '', status TEXT DEFAULT 'open', creator TEXT NOT NULL, assignee TEXT, labels TEXT DEFAULT '', created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')), updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')), updated_by TEXT, closed_at TEXT, closed_by TEXT);
+    CREATE TABLE IF NOT EXISTS comments (id INTEGER PRIMARY KEY AUTOINCREMENT, issue_id INTEGER NOT NULL REFERENCES issues(id), author TEXT NOT NULL, body TEXT NOT NULL, created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')));
+    CREATE TABLE IF NOT EXISTS milestones (id INTEGER PRIMARY KEY AUTOINCREMENT, milestone_id TEXT UNIQUE, title TEXT, description TEXT NOT NULL, cycles_budget INTEGER DEFAULT 20, cycles_used INTEGER DEFAULT 0, branch_name TEXT, parent_milestone_id TEXT, linked_pr_id INTEGER, failure_reason TEXT, phase TEXT DEFAULT 'implementation', status TEXT DEFAULT 'active', created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')), completed_at TEXT);
+    CREATE TABLE IF NOT EXISTS tbc_prs (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL, summary TEXT DEFAULT '', milestone_id TEXT, parent_pr_id INTEGER, epoch_index TEXT, branch_name TEXT, base_branch TEXT NOT NULL, head_branch TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'open' CHECK(status IN ('open', 'merged', 'closed')), decision TEXT, decision_reason TEXT DEFAULT '', issue_ids TEXT DEFAULT '[]', test_status TEXT DEFAULT 'unknown', github_pr_number INTEGER, github_pr_url TEXT, actor TEXT, updated_by TEXT, created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')), updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')));
+  `);
+  try { db.exec('ALTER TABLE issues ADD COLUMN updated_by TEXT'); } catch {}
+  try { db.exec('ALTER TABLE issues ADD COLUMN closed_by TEXT'); } catch {}
+  try { db.exec('ALTER TABLE milestones ADD COLUMN milestone_id TEXT'); } catch {}
+  try { db.exec('ALTER TABLE milestones ADD COLUMN title TEXT'); } catch {}
+  try { db.exec('ALTER TABLE milestones ADD COLUMN branch_name TEXT'); } catch {}
+  try { db.exec('ALTER TABLE milestones ADD COLUMN parent_milestone_id TEXT'); } catch {}
+  try { db.exec('ALTER TABLE milestones ADD COLUMN linked_pr_id INTEGER'); } catch {}
+  try { db.exec('ALTER TABLE milestones ADD COLUMN failure_reason TEXT'); } catch {}
+  try { db.exec('ALTER TABLE tbc_prs ADD COLUMN milestone_id TEXT'); } catch {}
+  try { db.exec('ALTER TABLE tbc_prs ADD COLUMN parent_pr_id INTEGER'); } catch {}
+  try { db.exec('ALTER TABLE tbc_prs ADD COLUMN epoch_index TEXT'); } catch {}
+  try { db.exec('ALTER TABLE tbc_prs ADD COLUMN branch_name TEXT'); } catch {}
+  try { db.exec('ALTER TABLE tbc_prs ADD COLUMN decision TEXT'); } catch {}
+  try { db.exec('ALTER TABLE tbc_prs ADD COLUMN decision_reason TEXT DEFAULT ""'); } catch {}
+  try { db.exec('ALTER TABLE tbc_prs ADD COLUMN actor TEXT'); } catch {}
+  try { db.exec('ALTER TABLE tbc_prs ADD COLUMN updated_by TEXT'); } catch {}
+  db.exec(`
+    UPDATE tbc_prs
+    SET status = CASE
+      WHEN status = 'merged' THEN 'merged'
+      WHEN status IN ('closed', 'completed', 'superseded') THEN 'closed'
+      ELSE 'open'
+    END
+    WHERE status NOT IN ('open', 'merged', 'closed');
+    CREATE TRIGGER IF NOT EXISTS tbc_prs_status_insert_check
+    BEFORE INSERT ON tbc_prs
+    FOR EACH ROW
+    WHEN NEW.status NOT IN ('open', 'merged', 'closed')
+    BEGIN
+      SELECT RAISE(ABORT, 'invalid tbc_prs.status');
+    END;
+    CREATE TRIGGER IF NOT EXISTS tbc_prs_status_update_check
+    BEFORE UPDATE OF status ON tbc_prs
+    FOR EACH ROW
+    WHEN NEW.status NOT IN ('open', 'merged', 'closed')
+    BEGIN
+      SELECT RAISE(ABORT, 'invalid tbc_prs.status');
+    END;
+  `);
+  syncAgentRegistry(db, runner, { root });
+  return db;
+}
+
+export function getProjectCostSummary(runner) {
+  const empty = { totalCost: 0, last24hCost: 0, lastCycleCost: 0, avgCycleCost: 0, lastCycleDuration: 0, avgCycleDuration: 0, agents: {} };
+  try {
+    const db = runner.getDb();
+    try { db.exec('ALTER TABLE reports ADD COLUMN cost REAL'); } catch {}
+    try { db.exec('ALTER TABLE reports ADD COLUMN duration_ms INTEGER'); } catch {}
+    const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+    const totalCost = db.prepare('SELECT COALESCE(SUM(cost), 0) as v FROM reports').get().v;
+    const last24hCost = db.prepare('SELECT COALESCE(SUM(cost), 0) as v FROM reports WHERE created_at > ?').get(cutoff).v;
+    const cycles = db.prepare('SELECT cycle, SUM(cost) as cost, SUM(duration_ms) as duration FROM reports WHERE cost IS NOT NULL GROUP BY cycle ORDER BY cycle ASC').all();
+    let lastCycleCost = 0, avgCycleCost = 0, lastCycleDuration = 0, avgCycleDuration = 0;
+    if (cycles.length > 0) {
+      const last = cycles[cycles.length - 1];
+      lastCycleCost = last.cost || 0;
+      lastCycleDuration = last.duration || 0;
+      const totalCycleCost = cycles.reduce((s, c) => s + (c.cost || 0), 0);
+      const totalCycleDuration = cycles.reduce((s, c) => s + (c.duration || 0), 0);
+      avgCycleCost = totalCycleCost / cycles.length;
+      avgCycleDuration = totalCycleDuration / cycles.length;
+    }
+    const agentRows = db.prepare(`SELECT agent,
+      COALESCE(SUM(cost), 0) as totalCost,
+      COALESCE(SUM(CASE WHEN created_at > ? THEN cost ELSE 0 END), 0) as last24hCost,
+      COUNT(*) as callCount
+      FROM reports WHERE cost IS NOT NULL GROUP BY agent`).all(cutoff);
+    const agents = {};
+    for (const row of agentRows) {
+      const lastCall = db.prepare('SELECT cost FROM reports WHERE agent = ? AND cost IS NOT NULL ORDER BY id DESC LIMIT 1').get(row.agent);
+      agents[row.agent] = {
+        totalCost: row.totalCost,
+        last24hCost: row.last24hCost,
+        callCount: row.callCount,
+        lastCallCost: lastCall?.cost || 0,
+        avgCallCost: row.callCount > 0 ? row.totalCost / row.callCount : 0,
+      };
+    }
+    db.close();
+    return { totalCost, last24hCost, lastCycleCost, avgCycleCost, lastCycleDuration, avgCycleDuration, agents };
+  } catch {
+    return empty;
+  }
+}
+
+function ensureReportsTable(db) {
+  db.exec(`CREATE TABLE IF NOT EXISTS reports (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    cycle INTEGER NOT NULL,
+    agent TEXT NOT NULL,
+    body TEXT NOT NULL,
+    summary TEXT,
+    milestone_id TEXT,
+    created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+  )`);
+  try { db.exec('ALTER TABLE reports ADD COLUMN summary TEXT'); } catch {}
+  try { db.exec('ALTER TABLE reports ADD COLUMN cost REAL'); } catch {}
+  try { db.exec('ALTER TABLE reports ADD COLUMN duration_ms INTEGER'); } catch {}
+  try { db.exec('ALTER TABLE reports ADD COLUMN input_tokens INTEGER'); } catch {}
+  try { db.exec('ALTER TABLE reports ADD COLUMN output_tokens INTEGER'); } catch {}
+  try { db.exec('ALTER TABLE reports ADD COLUMN cache_read_tokens INTEGER'); } catch {}
+  try { db.exec('ALTER TABLE reports ADD COLUMN success INTEGER'); } catch {}
+  try { db.exec('ALTER TABLE reports ADD COLUMN model TEXT'); } catch {}
+  try { db.exec('ALTER TABLE reports ADD COLUMN timed_out INTEGER'); } catch {}
+  try { db.exec('ALTER TABLE reports ADD COLUMN key_id TEXT'); } catch {}
+  try { db.exec('ALTER TABLE reports ADD COLUMN visibility_mode TEXT'); } catch {}
+  try { db.exec('ALTER TABLE reports ADD COLUMN visibility_issues TEXT'); } catch {}
+  try { db.exec('ALTER TABLE reports ADD COLUMN milestone_id TEXT'); } catch {}
+}
+
+export function writeRunnerReport(runner, agentName, body, metadata = {}) {
+  const {
+    cost = null,
+    durationMs = 0,
+    inputTokens = null,
+    outputTokens = null,
+    cacheReadTokens = null,
+    success = true,
+    model = null,
+    timedOut = false,
+    keyId = null,
+    visibilityMode = 'full',
+    visibilityIssues = [],
+    preformatted = false,
+  } = metadata;
+  const durationStr = `${Math.floor(durationMs / 60000)}m ${Math.floor((durationMs % 60000) / 1000)}s`;
+  const startedAt = new Date();
+  const endedAt = new Date();
+  const reportBody = preformatted
+    ? body.trim()
+    : `> ⏱ Started: ${startedAt.toLocaleString('sv-SE')} | Ended: ${endedAt.toLocaleString('sv-SE')} | Duration: ${durationStr}\n\n${body.trim()}`;
+  const db = runner.getDb();
+  ensureReportsTable(db);
+  db.prepare(`INSERT INTO reports (cycle, agent, body, created_at, cost, duration_ms, input_tokens, output_tokens, cache_read_tokens, success, model, timed_out, key_id, visibility_mode, visibility_issues, milestone_id)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(
+    runner.cycleCount, agentName, reportBody, new Date().toISOString(),
+    cost, durationMs,
+    inputTokens, outputTokens, cacheReadTokens,
+    success ? 1 : 0, model, timedOut ? 1 : 0,
+    keyId,
+    visibilityMode, JSON.stringify(visibilityIssues), runner.currentMilestoneId || null,
+  );
+  const reportId = db.prepare('SELECT last_insert_rowid() as id').get().id;
+  db.close();
+  return { reportId, reportBody };
+}
+
+
+function normalizePrRow(pr) {
+  if (!pr) return null;
+  return {
+    ...pr,
+    number: pr.id,
+    headRefName: pr.head_branch,
+    baseRefName: pr.base_branch,
+    shortTitle: pr.title,
+    issueIds: (() => { try { return JSON.parse(pr.issue_ids || '[]'); } catch { return []; } })(),
+  };
+}
+
+export function getProjectComments(runner, author, page = 1, perPage = 20) {
+  try {
+    const db = runner.getDb();
+    let query, countQuery, params;
+    if (author) {
+      query = `SELECT c.id, c.issue_id, c.author, c.body, c.created_at FROM comments c WHERE c.author = ? ORDER BY c.created_at DESC LIMIT ? OFFSET ?`;
+      countQuery = `SELECT COUNT(*) as total FROM comments WHERE author = ?`;
+      params = [author, perPage, (page - 1) * perPage];
+    } else {
+      query = `SELECT c.id, c.issue_id, c.author, c.body, c.created_at FROM comments c ORDER BY c.created_at DESC LIMIT ? OFFSET ?`;
+      countQuery = `SELECT COUNT(*) as total FROM comments`;
+      params = [perPage, (page - 1) * perPage];
+    }
+    const comments = db.prepare(query).all(...params).map(c => ({ ...c, agent: c.author }));
+    const { total } = author ? db.prepare(countQuery).get(author) : db.prepare(countQuery).get();
+    db.close();
+    return { comments, total, page, perPage, hasMore: page * perPage < total };
+  } catch (e) {
+    return { comments: [], total: 0, error: e.message };
+  }
+}
+
+export function getProjectPrs(runner, status = 'open') {
+  try {
+    const db = runner.getDb();
+    let query = `
+      SELECT id, title, summary, milestone_id, parent_pr_id, epoch_index, branch_name, base_branch, head_branch, status, decision, decision_reason, issue_ids, test_status, github_pr_number, github_pr_url, actor, updated_by, created_at, updated_at
+      FROM tbc_prs
+    `;
+    const params = [];
+    if (status === 'open' || status === 'merged' || status === 'closed') {
+      query += ` WHERE status = ?`;
+      params.push(status);
+    }
+    query += `
+      ORDER BY updated_at DESC, id DESC
+      LIMIT 50
+    `;
+    const prs = db.prepare(query).all(...params);
+    db.close();
+    return prs.map(normalizePrRow);
+  } catch {
+    return [];
+  }
+}
+
+export function getProjectPr(runner, prId) {
+  try {
+    const db = runner.getDb();
+    const pr = db.prepare(`
+      SELECT id, title, summary, milestone_id, parent_pr_id, epoch_index, branch_name, base_branch, head_branch, status, decision, decision_reason, issue_ids, test_status, github_pr_number, github_pr_url, actor, updated_by, created_at, updated_at
+      FROM tbc_prs
+      WHERE id = ?
+    `).get(prId);
+    db.close();
+    return normalizePrRow(pr);
+  } catch {
+    return null;
+  }
+}
+
+export function getOpenEpochPrForBranch(runner, branchName) {
+  try {
+    const db = runner.getDb();
+    const pr = db.prepare(`
+      SELECT * FROM tbc_prs
+      WHERE status = 'open'
+        AND (
+          (branch_name IS NOT NULL AND branch_name = ?)
+          OR head_branch = ?
+        )
+      ORDER BY updated_at DESC, id DESC
+      LIMIT 1
+    `).get(branchName || '', branchName || '');
+    db.close();
+    return pr || null;
+  } catch {
+    return null;
+  }
+}
+
+export function decideProjectEpochPr(runner, pr, status, { actor = 'apollo', reason = '' } = {}) {
+  if (!pr) return null;
+  try {
+    const db = runner.getDb();
+    const normalizedStatus = status === 'merged' ? 'merged' : 'closed';
+    db.prepare(`
+      UPDATE tbc_prs
+      SET status = ?, decision = ?, decision_reason = ?, updated_by = ?, updated_at = ?
+      WHERE id = ?
+    `).run(
+      normalizedStatus,
+      normalizedStatus === 'merged' ? 'merge' : 'close',
+      reason || '',
+      actor,
+      new Date().toISOString(),
+      pr.id,
+    );
+    db.close();
+    return { ...pr, status: normalizedStatus, decision: normalizedStatus === 'merged' ? 'merge' : 'close', decision_reason: reason || '' };
+  } catch {
+    return null;
+  }
+}

--- a/src/orchestrator/scheduler.js
+++ b/src/orchestrator/scheduler.js
@@ -1,0 +1,147 @@
+export async function autoPauseWait(runner, deps = {}, intervalMs, resumeCondition = null) {
+    const retryAt = Date.now() + intervalMs;
+    while (runner.isPaused && runner.running && !runner.wakeNow) {
+      await deps.sleep(5000);
+      // Check if it's time to auto-retry
+      if (Date.now() >= retryAt) {
+        if (resumeCondition && !resumeCondition()) {
+          // Condition not met, keep waiting (check again in 2h)
+          deps.log(`Auto-retry check: condition not met, waiting another 2h`, runner.id);
+          return runner._autoPauseWait(intervalMs, resumeCondition);
+        }
+        deps.log(`Auto-resuming after ${Math.round(intervalMs / 60000)}m pause`, runner.id);
+        runner.isPaused = false;
+        runner.pauseReason = null;
+        return;
+      }
+    }
+    // Manually resumed or stopped
+    if (!runner.isPaused) {
+      runner.pauseReason = null;
+    }
+  }
+
+export async function sleepDelay(runner, deps = {}, minutes, label) {
+    const ms = Math.min(Math.max(parseFloat(minutes) || 0, 0), 120) * 60000;
+    if (ms <= 0) return;
+    deps.log(`⏳ Waiting ${Math.round(ms / 60000)}m after ${label}...`, runner.id);
+    runner.sleepUntil = Date.now() + ms;
+    let slept = 0;
+    while (slept < ms && !runner.wakeNow && runner.running && !runner.abortCurrentCycle) {
+      await deps.sleep(5000);
+      slept += 5000;
+      while (runner.isPaused && !runner.wakeNow && runner.running && !runner.abortCurrentCycle) { await deps.sleep(1000); }
+    }
+    runner.sleepUntil = null;
+  }
+
+export function parseVisibility(runner, deps = {}, value, task) {
+    const visMode = typeof value === 'object' ? value.visibility : undefined;
+    if (!visMode || visMode === 'full') return null;
+    if (visMode === 'blind') return { mode: 'blind', issues: [] };
+    if (visMode === 'focused') {
+      const issueIds = (task || '').match(/#(\d+)/g)?.map(m => m.slice(1)) || [];
+      return { mode: 'focused', issues: issueIds };
+    }
+    return null;
+  }
+
+export function parseSchedule(runner, deps = {}, resultText) {
+    // Parse <!-- SCHEDULE --> ... <!-- /SCHEDULE --> from manager response.
+    // Canonical format only: a JSON array of steps.
+    const match = resultText.match(/<!--\s*SCHEDULE\s*-->\s*([\[{][\s\S]*?[\]}])\s*<!--\s*\/SCHEDULE\s*-->/);
+    if (!match) return null;
+    const normalizeStep = (step) => {
+      if (!step || typeof step !== 'object' || Array.isArray(step)) return null;
+      if (step.delay !== undefined) {
+        return Object.keys(step).length === 1 && typeof step.delay === 'number'
+          ? { delay: step.delay }
+          : null;
+      }
+      if (typeof step.agent !== 'string' || !step.agent.trim()) return null;
+      const { agent, ...rest } = step;
+      if (!Object.prototype.hasOwnProperty.call(rest, 'task')) return null;
+      return { [agent]: rest };
+    };
+    try {
+      const raw = JSON.parse(match[1]);
+      if (!Array.isArray(raw)) return null;
+      const steps = raw.map(normalizeStep);
+      if (steps.some(step => step === null)) return null;
+      return { _steps: steps };
+    } catch (e) {
+      deps.log(`Failed to parse schedule: ${e.message}`, runner.id);
+      return null;
+    }
+  }
+
+export async function executeSchedule(runner, deps = {}, schedule, config, managerName = null) {
+    if (!schedule || !schedule._steps) return { total: 0, failures: 0 };
+    
+    let total = 0;
+    let failures = 0;
+    const ownerName = typeof managerName === 'string' ? managerName.toLowerCase() : null;
+    const freshWorkers = runner.loadAgents().workers.filter(worker => {
+      if (!ownerName) return true;
+      return (worker.reportsTo || '').toLowerCase() === ownerName;
+    });
+    
+    for (const step of schedule._steps) {
+      if (!runner.running || runner.abortCurrentCycle) break;
+      
+      // Delay step
+      if (step.delay !== undefined) {
+        await runner.sleepDelay(step.delay, 'schedule');
+        if (runner.abortCurrentCycle) break;
+        continue;
+      }
+      
+      // Agent step: { "agentName": taskValue }
+      const name = Object.keys(step).find(k => k !== 'delay');
+      if (!name) continue;
+
+      // Skip agents already completed (supports resume after reboot)
+      if (runner.completedAgents.includes(name.toLowerCase())) {
+        deps.log(`Skipping ${name} (already completed this cycle)`, runner.id);
+        continue;
+      }
+      
+      const value = step[name];
+      const worker = freshWorkers.find(w => w.name.toLowerCase() === name.toLowerCase());
+      if (!worker) {
+        deps.log(`Worker "${name}" not found, skipping`, runner.id);
+        continue;
+      }
+      
+      while (runner.isPaused && runner.running && !runner.abortCurrentCycle) { await deps.sleep(1000); }
+      if (runner.abortCurrentCycle) break;
+      
+      const task = typeof value === 'string' ? value : value.task || null;
+      const vis = runner._parseVisibility(value, task);
+      
+      // Retry on timeout/failure (up to 2 retries)
+      const maxRetries = 2;
+      let attempt = 0;
+      let succeeded = false;
+      while (attempt <= maxRetries && !succeeded && runner.running && !runner.abortCurrentCycle) {
+        if (attempt > 0) {
+          deps.log(`Retrying ${worker.name} (attempt ${attempt + 1}/${maxRetries + 1})`, runner.id);
+        }
+        const wResult = await runner.runAgent(worker, config, null, task, vis);
+        if (runner.abortCurrentCycle) break;
+        total++;
+        if (wResult && wResult.success) {
+          succeeded = true;
+          runner.completedAgents.push(name.toLowerCase());
+          runner.saveState();
+        } else {
+          failures++;
+          const wasTimeout = wResult && wResult.killedByTimeout;
+          if (wasTimeout) break; // Don't retry on timeout (agent can't finish in time)
+          attempt++;
+        }
+      }
+    }
+    
+    return { total, failures };
+  }

--- a/src/orchestrator/state-control.js
+++ b/src/orchestrator/state-control.js
@@ -1,0 +1,209 @@
+import fs from 'fs';
+import path from 'path';
+
+export async function startRunner(runner, deps = {}) {
+    if (runner.running) return;
+    // Validate project path exists
+    if (!fs.existsSync(runner.path)) {
+      deps.log(`ERROR: Project path does not exist: ${runner.path}`, runner.id);
+      return;
+    }
+
+    // Ensure project directories exist
+    fs.mkdirSync(runner.projectDir, { recursive: true });
+    fs.mkdirSync(runner.chatsDir, { recursive: true });
+    fs.mkdirSync(runner.agentsDir, { recursive: true });
+    fs.mkdirSync(runner.responsesDir, { recursive: true });
+    fs.mkdirSync(runner.skillsDir, { recursive: true });
+    fs.mkdirSync(runner.knowledgeDir, { recursive: true });
+    fs.mkdirSync(path.join(runner.projectDir, 'knowledge', 'analysis'), { recursive: true });
+    fs.mkdirSync(path.join(runner.projectDir, 'knowledge', 'decisions'), { recursive: true });
+    fs.mkdirSync(runner.workerSkillsDir, { recursive: true });
+    
+    // Load persisted state
+    runner.loadState();
+    
+    runner.running = true;
+    deps.log(`Starting project runner (data: ${runner.projectDir}, cycle: ${runner.cycleCount})`, runner.id);
+    runner.runLoop();
+  }
+
+export function loadRunnerState(runner, deps = {}) {
+    const statePath = runner.statePath;
+    try {
+      if (fs.existsSync(statePath)) {
+        const state = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+        runner.cycleCount = state.cycleCount || 0;
+        runner.epochCount = state.epochCount || 0;
+        runner.completedAgents = state.completedAgents || [];
+        runner.currentCycleId = state.currentCycleId || null;
+        runner.currentSchedule = state.currentSchedule || null;
+        if (state.isPaused !== undefined) runner.isPaused = state.isPaused;
+        // Phase state
+        runner.phase = state.phase || 'athena';
+        runner.milestoneTitle = state.milestoneTitle || null;
+        runner.milestoneDescription = state.milestoneDescription || null;
+        runner.milestoneCyclesBudget = state.milestoneCyclesBudget || 0;
+        runner.milestoneCyclesUsed = state.milestoneCyclesUsed || 0;
+        runner.currentMilestoneId = state.currentMilestoneId || null;
+        runner.pendingMilestoneId = state.pendingMilestoneId || null;
+        runner.currentEpochId = state.currentEpochId || null;
+        runner.currentEpochPrId = state.currentEpochPrId || null;
+        runner.currentMilestoneBranch = state.currentMilestoneBranch || null;
+        runner.lastMergedMilestoneBranch = state.lastMergedMilestoneBranch || null;
+        runner.aresGraceCycleUsed = state.aresGraceCycleUsed || false;
+        runner.verificationFeedback = state.verificationFeedback || null;
+        runner.examinationFeedback = state.examinationFeedback || null;
+        runner.pendingCompletionMessage = state.pendingCompletionMessage || null;
+        runner.isFixRound = state.isFixRound || false;
+        runner.isComplete = state.isComplete || false;
+        runner.completionSuccess = state.completionSuccess || false;
+        runner.completionMessage = state.completionMessage || null;
+        deps.log(`Loaded state: cycle ${runner.cycleCount}, phase: ${runner.phase}, completed: [${runner.completedAgents.join(', ')}]${runner.isPaused ? ', paused' : ''}`, runner.id);
+      } else {
+        // New project — start paused
+        runner.setState({ isPaused: true, pauseReason: 'New project (paused by default)' }, { save: false });
+        runner.completedAgents = [];
+        runner.currentCycleId = null;
+        runner.currentSchedule = null;
+      }
+    } catch (e) {
+      deps.log(`Failed to load state: ${e.message}`, runner.id);
+      runner.completedAgents = [];
+      runner.currentCycleId = null;
+      runner.currentSchedule = null;
+    }
+  }
+
+export function saveRunnerState(runner, deps = {}) {
+    const statePath = runner.statePath;
+    try {
+      const state = {
+        cycleCount: runner.cycleCount,
+        epochCount: runner.epochCount || 0,
+        completedAgents: runner.completedAgents || [],
+        currentCycleId: runner.currentCycleId,
+        currentSchedule: runner.currentSchedule || null,
+        isPaused: runner.isPaused || false,
+        phase: runner.phase,
+        milestoneTitle: runner.milestoneTitle,
+        milestoneDescription: runner.milestoneDescription,
+        milestoneCyclesBudget: runner.milestoneCyclesBudget,
+        milestoneCyclesUsed: runner.milestoneCyclesUsed,
+        currentMilestoneId: runner.currentMilestoneId || null,
+        pendingMilestoneId: runner.pendingMilestoneId || null,
+        currentEpochId: runner.currentEpochId || null,
+        currentEpochPrId: runner.currentEpochPrId || null,
+        currentMilestoneBranch: runner.currentMilestoneBranch || null,
+        lastMergedMilestoneBranch: runner.lastMergedMilestoneBranch || null,
+        aresGraceCycleUsed: runner.aresGraceCycleUsed || false,
+        verificationFeedback: runner.verificationFeedback,
+        examinationFeedback: runner.examinationFeedback,
+        pendingCompletionMessage: runner.pendingCompletionMessage,
+        isFixRound: runner.isFixRound,
+        isComplete: runner.isComplete || false,
+        completionSuccess: runner.completionSuccess || false,
+        completionMessage: runner.completionMessage || null,
+        lastUpdated: new Date().toISOString()
+      };
+      fs.writeFileSync(statePath, JSON.stringify(state, null, 2));
+    } catch (e) {
+      deps.log(`Failed to save state: ${e.message}`, runner.id);
+    }
+  }
+
+export function stopRunner(runner, deps = {}) {
+    runner.running = false;
+    if (runner.currentAgentProcess) {
+      runner.currentAgentProcess.kill('SIGTERM');
+    }
+    deps.log(`Stopped project runner`, runner.id);
+  }
+
+export function pauseRunner(runner, deps = {}) {
+    runner.setState({ isPaused: true, pauseReason: null });
+    deps.log(`Paused`, runner.id);
+  }
+
+export function resumeRunner(runner, deps = {}) {
+    if (runner.isComplete) {
+      deps.log(`Reopening completed project`, runner.id);
+      runner.setState({
+        isComplete: false,
+        completionSuccess: false,
+        completionMessage: null,
+        isPaused: false,
+        pauseReason: null,
+        phase: 'athena',
+        milestoneTitle: null,
+        milestoneDescription: null,
+        milestoneCyclesBudget: 0,
+        milestoneCyclesUsed: 0,
+        verificationFeedback: null,
+        examinationFeedback: null,
+        pendingCompletionMessage: null,
+        currentSchedule: null,
+        completedAgents: [],
+      });
+    } else {
+      runner.setState({ isPaused: false, pauseReason: null });
+    }
+    runner.wakeNow = true;
+    deps.log(`Resumed`, runner.id);
+  }
+
+export function skipRunner(runner, deps = {}) {
+    if (runner.currentAgentProcess) {
+      deps.log(`Skipping current agent`, runner.id);
+      runner.currentAgentProcess.kill('SIGTERM');
+    } else if (runner.sleepUntil) {
+      deps.log(`Skipping sleep`, runner.id);
+      runner.wakeNow = true;
+    }
+  }
+
+export function killRunnerRun(runner, deps = {}) {
+    if (runner.currentAgentProcess) {
+      deps.log(`🔴 Kill Run: terminating current agent`, runner.id);
+      runner.currentAgentProcess.kill('SIGTERM');
+    }
+  }
+
+export function killRunnerCycle(runner, deps = {}) {
+    deps.log(`🔴 Kill Cycle: terminating agent and clearing schedule`, runner.id);
+    if (runner.currentAgentProcess) {
+      runner.currentAgentProcess.kill('SIGTERM');
+    }
+    runner.currentSchedule = null;
+    runner.completedAgents = [];
+    runner.saveState();
+  }
+
+export function killRunnerEpoch(runner, deps = {}) {
+    deps.log(`🔴 Kill Epoch: terminating agent, clearing schedule, returning to Athena`, runner.id);
+    runner.abortCurrentCycle = true;
+    if (runner.currentAgentProcess) {
+      runner.currentAgentProcess.kill('SIGTERM');
+    }
+    if (runner.currentMilestoneBranch) {
+      runner.closeOpenEpochPRForBranch(runner.currentMilestoneBranch, {
+        actor: 'ares',
+        reason: `Epoch killed manually while replanning milestone ${runner.currentMilestoneId || 'unknown'}.`,
+      });
+    }
+    runner.currentSchedule = null;
+    runner.completedAgents = [];
+    runner.setState({
+      phase: 'athena',
+      pendingMilestoneId: null,
+      milestoneTitle: null,
+      milestoneDescription: null,
+      milestoneCyclesBudget: 0,
+      milestoneCyclesUsed: 0,
+      currentEpochId: null,
+      currentEpochPrId: null,
+      currentMilestoneBranch: null,
+      verificationFeedback: null,
+      isFixRound: false,
+    });
+  }

--- a/tests/athena-schedule-cleanup.test.js
+++ b/tests/athena-schedule-cleanup.test.js
@@ -3,14 +3,14 @@ import assert from 'node:assert/strict'
 import fs from 'node:fs'
 import path from 'node:path'
 
-const server = fs.readFileSync(path.resolve('src/orchestrator/ProjectRunner.js'), 'utf8')
+const server = fs.readFileSync(path.resolve('src/orchestrator/phase-machine.js'), 'utf8')
 
 describe('athena schedule cleanup', () => {
   it('clears currentSchedule and completedAgents after an Athena worker schedule finishes', () => {
-    const athenaBlock = server.match(/if \(this\.phase === 'athena'\) \{[\s\S]*?\n      \}\n\n      \/\/ ===== PHASE: IMPLEMENTATION/)
+    const athenaBlock = server.match(/if \(runner\.phase === 'athena'\) \{[\s\S]*?\n      \}\n\n      \/\/ ===== PHASE: IMPLEMENTATION/)
     assert.ok(athenaBlock, 'Athena phase block not found')
     const block = athenaBlock[0]
-    assert.match(block, /await this\.executeSchedule\(schedule, config, 'athena'\);[\s\S]*this\.currentSchedule = null;/)
-    assert.match(block, /await this\.executeSchedule\(schedule, config, 'athena'\);[\s\S]*this\.completedAgents = \[\];/)
+    assert.match(block, /await runner\.executeSchedule\(schedule, config, 'athena'\);[\s\S]*runner\.currentSchedule = null;/)
+    assert.match(block, /await runner\.executeSchedule\(schedule, config, 'athena'\);[\s\S]*runner\.completedAgents = \[\];/)
   })
 })

--- a/tests/epoch-pr-workflow.test.js
+++ b/tests/epoch-pr-workflow.test.js
@@ -4,38 +4,42 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 const server = fs.readFileSync(path.resolve('src/orchestrator/ProjectRunner.js'), 'utf8');
+const milestones = fs.readFileSync(path.resolve('src/orchestrator/milestones.js'), 'utf8');
+const stateControl = fs.readFileSync(path.resolve('src/orchestrator/state-control.js'), 'utf8');
+const phaseMachine = fs.readFileSync(path.resolve('src/orchestrator/phase-machine.js'), 'utf8');
+const orchestratorSource = `${server}\n${milestones}\n${stateControl}\n${phaseMachine}`;
 const athena = fs.readFileSync(path.resolve('agent/managers/athena.md'), 'utf8');
 const ares = fs.readFileSync(path.resolve('agent/managers/ares.md'), 'utf8');
 
 describe('epoch-as-PR orchestrator flow', () => {
   it('requires an orchestrator-managed epoch PR before Ares can claim completion', () => {
-    assert.match(server, /CLAIM_COMPLETE ignored because no orchestrator-managed epoch PR exists/i);
-    assert.match(server, /ensureEpochPRForCurrentMilestone/);
+    assert.match(orchestratorSource, /CLAIM_COMPLETE ignored because no orchestrator-managed epoch PR exists/i);
+    assert.match(orchestratorSource, /ensureEpochPRForCurrentMilestone/);
   });
 
   it('assigns milestone ids before Athena starts and derives epoch ids separately', () => {
-    assert.match(server, /pendingMilestoneId/);
-    assert.match(server, /allocateNextMilestoneId/);
-    assert.match(server, /allocateNextEpochId/);
-    assert.match(server, /Assigned milestone ID/);
+    assert.match(orchestratorSource, /pendingMilestoneId/);
+    assert.match(orchestratorSource, /allocateNextMilestoneId/);
+    assert.match(orchestratorSource, /allocateNextEpochId/);
+    assert.match(orchestratorSource, /Assigned milestone ID/);
   });
 
   it('returns Apollo failures to Athena for split and replan', () => {
-    assert.match(server, /Verification failed — returning to Athena for split\/replan/i);
-    assert.match(server, /phase: 'athena'/);
-    assert.doesNotMatch(server, /Verification failed — returning to Ares/);
+    assert.match(orchestratorSource, /Verification failed — returning to Athena for split\/replan/i);
+    assert.match(orchestratorSource, /phase: 'athena'/);
+    assert.doesNotMatch(orchestratorSource, /Verification failed — returning to Ares/);
   });
 
   it('avoids duplicating the milestone id in generated branch names', () => {
-    assert.match(server, /stripLeadingMilestoneId:\s*this\.currentMilestoneId/);
-    assert.match(server, /slugifyMilestoneTitle\(title, \{ stripLeadingMilestoneId = null \} = \{\}\)/);
+    assert.match(orchestratorSource, /stripLeadingMilestoneId:\s*(?:this|runner)\.currentMilestoneId/);
+    assert.match(orchestratorSource, /slugifyMilestoneTitle\(title, \{ stripLeadingMilestoneId = null \} = \{\}\)/);
   });
 
   it('treats kill epoch like a failed epoch by clearing active epoch state, keeping the milestone anchor, and closing any open epoch PR', () => {
-    const killEpochBlock = server.match(/killEpoch\(\) \{[\s\S]*?\n  \}\n\n  \/\/ Wait while paused/);
+    const killEpochBlock = stateControl.match(/killRunnerEpoch\([^)]*\)/);
     assert.ok(killEpochBlock);
-    const block = killEpochBlock[0];
-    assert.match(block, /closeOpenEpochPRForBranch\(this\.currentMilestoneBranch/);
+    const block = stateControl;
+    assert.match(block, /closeOpenEpochPRForBranch\((?:this|runner)\.currentMilestoneBranch/);
     assert.match(block, /pendingMilestoneId: null/);
     assert.match(block, /currentEpochId: null/);
     assert.match(block, /currentEpochPrId: null/);
@@ -44,9 +48,9 @@ describe('epoch-as-PR orchestrator flow', () => {
   });
 
   it('lets Athena reset planning to an ancestor milestone or root before allocating the next milestone id', () => {
-    assert.match(server, /normalizeResetTargetMilestone\(milestone\.reset_to\)/);
-    assert.match(server, /await this\.allocateNextMilestoneId\(resetTo\)/);
-    assert.match(server, /Athena reset planning anchor to/);
+    assert.match(orchestratorSource, /normalizeResetTargetMilestone\(milestone\.reset_to\)/);
+    assert.match(orchestratorSource, /await (?:this|runner)\.allocateNextMilestoneId\(resetTo\)/);
+    assert.match(orchestratorSource, /Athena reset planning anchor to/);
   });
 
   it('documents the optional reset_to field for Athena milestone output', () => {
@@ -56,15 +60,15 @@ describe('epoch-as-PR orchestrator flow', () => {
   });
 
   it('escalates a successful child milestone to parent rollup verification instead of jumping to root', () => {
-    assert.match(server, /const isRollupVerification = !this\.currentEpochPrId/);
-    assert.match(server, /const parentMilestoneId = this\.getParentMilestoneId\(completedMilestoneId\)/);
-    assert.match(server, /Milestone verified — escalating completion check to parent milestone/);
-    assert.match(server, /phase: 'verification'/);
-    assert.match(server, /currentMilestoneId: parentMilestoneId/);
+    assert.match(orchestratorSource, /const isRollupVerification = !(?:this|runner)\.currentEpochPrId/);
+    assert.match(orchestratorSource, /const parentMilestoneId = (?:this|runner)\.getParentMilestoneId\(completedMilestoneId\)/);
+    assert.match(orchestratorSource, /Milestone verified — escalating completion check to parent milestone/);
+    assert.match(orchestratorSource, /phase: 'verification'/);
+    assert.match(orchestratorSource, /currentMilestoneId: parentMilestoneId/);
   });
 
   it('returns rollup verification failures to Athena without treating them as epoch PR failures', () => {
-    const rollupFailBlock = server.match(/if \(isRollupVerification\) \{[\s\S]*?\n            \} else \{/)
+    const rollupFailBlock = orchestratorSource.match(/if \(isRollupVerification\) \{[\s\S]*?\n            \} else \{/)
     assert.ok(rollupFailBlock)
     const block = rollupFailBlock[0]
     assert.match(block, /Parent rollup verification incomplete — returning to Athena to plan the next child milestone/)
@@ -72,12 +76,12 @@ describe('epoch-as-PR orchestrator flow', () => {
   });
 
   it('gives Ares one grace review turn after worker budget exhaustion', () => {
-    assert.match(server, /const aresGraceMode = this\.milestoneCyclesUsed >= this\.milestoneCyclesBudget/)
-    assert.match(server, /if \(aresGraceMode && this\.aresGraceCycleUsed\)/)
-    assert.match(server, /Grace review mode:\*\* Worker budget is exhausted/)
-    assert.match(server, /if \(aresGraceMode\) this\.aresGraceCycleUsed = true/)
-    assert.match(server, /Ares grace review did not claim completion/)
-    assert.match(server, /Ignoring Ares schedule because grace review mode forbids worker scheduling/)
+    assert.match(orchestratorSource, /const aresGraceMode = (?:this|runner)\.milestoneCyclesUsed >= (?:this|runner)\.milestoneCyclesBudget/)
+    assert.match(orchestratorSource, /if \(aresGraceMode && (?:this|runner)\.aresGraceCycleUsed\)/)
+    assert.match(orchestratorSource, /Grace review mode:\*\* Worker budget is exhausted/)
+    assert.match(orchestratorSource, /if \(aresGraceMode\) (?:this|runner)\.aresGraceCycleUsed = true/)
+    assert.match(orchestratorSource, /Ares grace review did not claim completion/)
+    assert.match(orchestratorSource, /Ignoring Ares schedule because grace review mode forbids worker scheduling/)
   });
 
   it('documents that grace review mode forbids scheduling and allows only a completion claim', () => {

--- a/tests/examination-phase.test.js
+++ b/tests/examination-phase.test.js
@@ -6,10 +6,18 @@ import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const serverPath = path.join(__dirname, '..', 'src', 'orchestrator', 'ProjectRunner.js');
+const phaseMachinePath = path.join(__dirname, '..', 'src', 'orchestrator', 'phase-machine.js');
+const schedulerPath = path.join(__dirname, '..', 'src', 'orchestrator', 'scheduler.js');
 const themisPath = path.join(__dirname, '..', 'agent', 'managers', 'themis.md');
 
 function readServer() {
   return fs.readFileSync(serverPath, 'utf-8');
+}
+
+function readOrchestratorSource() {
+  return [serverPath, phaseMachinePath, schedulerPath]
+    .map(file => fs.readFileSync(file, 'utf-8'))
+    .join('\n');
 }
 
 function readThemis() {
@@ -28,7 +36,7 @@ describe('Themis examination phase', () => {
   });
 
   it('routes successful PROJECT_COMPLETE claims into examination instead of finalizing immediately', () => {
-    const src = readServer();
+    const src = readOrchestratorSource();
     const match = src.match(/if \(completeMatch\) \{([\s\S]*?)continue;/);
     assert.ok(match, 'Could not find PROJECT_COMPLETE handling block');
     const block = match[1];
@@ -43,26 +51,26 @@ describe('Themis examination phase', () => {
   });
 
   it('adds a dedicated examination phase that runs themis in full view', () => {
-    const src = readServer();
-    assert.match(src, /else if \(this\.phase === 'examination'\)/,
+    const src = readOrchestratorSource();
+    assert.match(src, /else if \((?:this|runner)\.phase === 'examination'\)/,
       'Expected a dedicated examination phase block in runLoop');
     assert.match(src, /const themis = managers\.find\(m => m\.name === 'themis'\)/,
       'Expected examination phase to run Themis');
-    assert.match(src, /runAgent\(themis, config, null, themisContext, \{ mode: 'full', issues: \[\] \}\)/,
+    assert.match(src, /(?:this|runner)\.runAgent\(themis, config, null, themisContext, \{ mode: 'full', issues: \[\] \}\)/,
       'Expected Themis to run in full view');
-    assert.doesNotMatch(src, /runAgent\(themis, config, null, themisContext, \{ mode: 'blind', issues: \[\] \}\)/,
+    assert.doesNotMatch(src, /(?:this|runner)\.runAgent\(themis, config, null, themisContext, \{ mode: 'blind', issues: \[\] \}\)/,
       'Themis should no longer run blind');
   });
 
   it('lets Themis schedule its own independent team across multiple cycles', () => {
-    const src = readServer();
+    const src = readOrchestratorSource();
     assert.match(src, /Resuming interrupted examination schedule/,
       'Expected examination schedules to resume after interruption');
-    assert.match(src, /schedule = this\.parseSchedule\(result\.resultText\)/,
+    assert.match(src, /schedule = (?:this|runner)\.parseSchedule\(result\.resultText\)/,
       'Expected examination phase to parse Themis schedules');
     assert.match(src, /executeSchedule\(schedule, config, 'themis'\)/,
       'Expected examination workers to run under Themis ownership');
-    assert.match(src, /executeSchedule\(this\.currentSchedule, config, 'themis'\)/,
+    assert.match(src, /executeSchedule\((?:this|runner)\.currentSchedule, config, 'themis'\)/,
       'Expected interrupted Themis schedules to resume under Themis ownership');
     assert.match(src, /let decision = null/,
       'Expected examination to support non-terminal cycles');
@@ -71,7 +79,7 @@ describe('Themis examination phase', () => {
   });
 
   it('filters scheduled workers by manager ownership', () => {
-    const src = readServer();
+    const src = readOrchestratorSource();
     assert.match(src, /const ownerName = typeof managerName === 'string' \? managerName\.toLowerCase\(\) : null/,
       'Expected executeSchedule to accept a manager owner');
     assert.match(src, /return \(worker\.reportsTo \|\| ''\)\.toLowerCase\(\) === ownerName/,
@@ -79,8 +87,8 @@ describe('Themis examination phase', () => {
   });
 
   it('finalizes completion only on EXAM_PASS', () => {
-    const src = readServer();
-    const examBlock = src.match(/else if \(this\.phase === 'examination'\) \{([\s\S]*?)\n      \}/);
+    const src = readOrchestratorSource();
+    const examBlock = src.match(/else if \((?:this|runner)\.phase === 'examination'\) \{([\s\S]*?)\n      \}/);
     assert.ok(examBlock, 'Could not find examination phase block');
     const block = examBlock[1];
 
@@ -93,7 +101,7 @@ describe('Themis examination phase', () => {
   });
 
   it('does not overwrite EXAM_PASS with failure just because no schedule exists', () => {
-    const src = readServer();
+    const src = readOrchestratorSource();
     assert.doesNotMatch(
       src,
       /if \(result\.resultText\.includes\('\<\!-- EXAM_PASS --\>'\)\) \{\s*decision = 'pass';\s*\}[\s\S]*?else if \(!schedule\) \{\s*decision = 'fail';\s*\}/,
@@ -102,8 +110,8 @@ describe('Themis examination phase', () => {
   });
 
   it('returns to athena and creates issues on EXAM_FAIL', () => {
-    const src = readServer();
-    const examBlock = src.match(/else if \(this\.phase === 'examination'\) \{([\s\S]*?)\n      \}/);
+    const src = readOrchestratorSource();
+    const examBlock = src.match(/else if \((?:this|runner)\.phase === 'examination'\) \{([\s\S]*?)\n      \}/);
     assert.ok(examBlock, 'Could not find examination phase block');
     const block = examBlock[1];
 
@@ -116,8 +124,8 @@ describe('Themis examination phase', () => {
   });
 
   it('still falls back to raw feedback when EXAM_FAIL JSON is absent or incomplete', () => {
-    const src = readServer();
-    const examBlock = src.match(/else if \(this\.phase === 'examination'\) \{([\s\S]*?)\n      \}/);
+    const src = readOrchestratorSource();
+    const examBlock = src.match(/else if \((?:this|runner)\.phase === 'examination'\) \{([\s\S]*?)\n      \}/);
     assert.ok(examBlock, 'Could not find examination phase block');
     const block = examBlock[1];
 
@@ -140,7 +148,7 @@ describe('Themis examination phase', () => {
   });
 
   it('gives Athena context when Themis rejects project completion', () => {
-    const src = readServer();
+    const src = readOrchestratorSource();
     const athenaSituation = src.match(/let situation = '';/);
     assert.ok(athenaSituation, 'Could not find Athena situation builder');
     assert.match(src, /examinationFeedback/,

--- a/tests/kill-epoch-retry.test.js
+++ b/tests/kill-epoch-retry.test.js
@@ -6,16 +6,26 @@ import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const serverPath = path.join(__dirname, '..', 'src', 'orchestrator', 'ProjectRunner.js');
+const schedulerPath = path.join(__dirname, '..', 'src', 'orchestrator', 'scheduler.js');
+const stateControlPath = path.join(__dirname, '..', 'src', 'orchestrator', 'state-control.js');
 
 function readServer() {
   return fs.readFileSync(serverPath, 'utf-8');
 }
 
+function readStateControl() {
+  return fs.readFileSync(stateControlPath, 'utf-8');
+}
+
+function readScheduler() {
+  return fs.readFileSync(schedulerPath, 'utf-8');
+}
+
 describe('killEpoch interrupts in-flight worker retries', () => {
   it('killEpoch should set an explicit cycle-abort flag', () => {
-    const src = readServer();
-    const killEpochMatch = src.match(/killEpoch\(\)\s*\{([\s\S]*?)\n  \}/);
-    assert.ok(killEpochMatch, 'Could not find killEpoch() in ProjectRunner.js');
+    const src = readStateControl();
+    const killEpochMatch = src.match(/killRunnerEpoch\([^)]*\)\s*\{([\s\S]*?)\n\s*\}/);
+    assert.ok(killEpochMatch, 'Could not find killRunnerEpoch() in state-control.js');
     const body = killEpochMatch[1];
 
     assert.ok(
@@ -25,8 +35,8 @@ describe('killEpoch interrupts in-flight worker retries', () => {
   });
 
   it('worker retry loop should check the cycle-abort flag before retrying', () => {
-    const src = readServer();
-    const retryMatch = src.match(/while \(attempt <= maxRetries && !succeeded && this\.running([^)]*)\) \{([\s\S]*?)\n      \}/);
+    const src = readScheduler();
+    const retryMatch = src.match(/while \(attempt <= maxRetries && !succeeded && runner\.running([^)]*)\) \{([\s\S]*?)\n      \}/);
     assert.ok(retryMatch, 'Could not find worker retry loop in executeSchedule()');
     const loopConditionSuffix = retryMatch[1] || '';
     const loopBody = retryMatch[2];
@@ -38,10 +48,10 @@ describe('killEpoch interrupts in-flight worker retries', () => {
   });
 
   it('executeSchedule should stop dispatching additional steps after killEpoch', () => {
-    const src = readServer();
-    const executeScheduleMatch = src.match(/async executeSchedule\(schedule, config(?:, managerName = null)?\) \{([\s\S]*?)\n  \}\n\n  async runLoop/);
-    assert.ok(executeScheduleMatch, 'Could not find executeSchedule() in ProjectRunner.js');
-    const body = executeScheduleMatch[1];
+    const src = readScheduler();
+    const executeScheduleMatch = src.match(/export async function executeSchedule\(runner, deps = \{\}, schedule, config, managerName = null\)/);
+    assert.ok(executeScheduleMatch, 'Could not find executeSchedule() in scheduler.js');
+    const body = src;
 
     assert.ok(
       /abortCurrentCycle|epochKilled|cancelCurrentSchedule|stopCurrentCycle/.test(body),

--- a/tests/private-knowledge-base.test.js
+++ b/tests/private-knowledge-base.test.js
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const serverPath = path.join(__dirname, '..', 'src', 'orchestrator', 'ProjectRunner.js');
+const stateControlPath = path.join(__dirname, '..', 'src', 'orchestrator', 'state-control.js');
 const athenaPath = path.join(__dirname, '..', 'agent', 'managers', 'athena.md');
 
 function read(file) {
@@ -33,7 +34,7 @@ describe('private knowledge base for spec, roadmap, and internal analysis docs',
   });
 
   it('startup/bootstrap should create the private knowledge directory and subfolders for internal docs', () => {
-    const src = read(serverPath);
+    const src = `${read(serverPath)}\n${read(stateControlPath)}`;
     assert.match(src, /'knowledge'/,
       'Expected startup/bootstrap logic to create a knowledge directory');
     assert.match(src, /knowledge', 'analysis'|path\.join\('knowledge', 'analysis'\)|'knowledge\/analysis'/,

--- a/tests/reopen-completed-project.test.js
+++ b/tests/reopen-completed-project.test.js
@@ -5,21 +5,16 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const serverPath = path.join(__dirname, '..', 'src', 'orchestrator', 'ProjectRunner.js');
+const stateControlPath = path.join(__dirname, '..', 'src', 'orchestrator', 'state-control.js');
 
-function readServer() {
-  return fs.readFileSync(serverPath, 'utf-8');
+function readStateControl() {
+  return fs.readFileSync(stateControlPath, 'utf-8');
 }
 
 describe('reopening completed project resets planning state', () => {
   it('resume() should clear stale milestone state when reopening a completed project', () => {
-    const src = readServer();
-    const resumeMatch = src.match(/resume\(\) \{([\s\S]*?)\n  \}/);
-    assert.ok(resumeMatch, 'Could not find resume() in ProjectRunner.js');
-    const body = resumeMatch[1];
-    const reopenBranch = body.match(/if \(this\.isComplete\) \{([\s\S]*?)\n    \} else \{/);
-    assert.ok(reopenBranch, 'Could not find completed-project reopen branch in resume()');
-    const branch = reopenBranch[1];
+    const branch = readStateControl();
+    assert.match(branch, /if \(runner\.isComplete\)/, 'Could not find completed-project reopen branch in state-control.js');
 
     assert.match(branch, /milestoneTitle:\s*null/,
       'Reopening a completed project should clear stale milestoneTitle');

--- a/tests/report-metadata.test.js
+++ b/tests/report-metadata.test.js
@@ -5,8 +5,8 @@
  * reports are in SQLite. Token usage, model, success, and timed_out
  * are not persisted at all. All metadata should be in the reports table.
  *
- * These tests verify that the ACTUAL report-saving code in ProjectRunner.js
- * writes metadata columns. They will FAIL until ProjectRunner.js is updated.
+ * These tests verify that the ACTUAL report-saving code in project-db.js
+ * writes metadata columns. They will FAIL until project-db.js is updated.
  */
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
@@ -18,8 +18,8 @@ import Database from 'better-sqlite3';
 const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tbc-report-meta-'));
 
 /**
- * Simulate what ProjectRunner.js _postProcessAgentRun does when saving a report.
- * This mirrors the ACTUAL code at src/ProjectRunner.js line ~1800.
+ * Simulate what project-db.js _postProcessAgentRun does when saving a report.
+ * This mirrors the ACTUAL code at src/project-db.js line ~1800.
  */
 function saveReportLikeServer(dbPath, { cycle, agent, body, cost, durationMs, inputTokens, outputTokens, cacheReadTokens, success, model, timedOut, visibilityMode, visibilityIssues }) {
   const db = new Database(dbPath);
@@ -44,7 +44,7 @@ function saveReportLikeServer(dbPath, { cycle, agent, body, cost, durationMs, in
     try { db.exec('ALTER TABLE reports ADD COLUMN visibility_mode TEXT'); } catch {}
     try { db.exec('ALTER TABLE reports ADD COLUMN visibility_issues TEXT'); } catch {}
 
-    // THIS IS THE LINE THAT MATTERS — currently ProjectRunner.js only writes 4 fields:
+    // THIS IS THE LINE THAT MATTERS — currently project-db.js only writes 4 fields:
     // db.prepare('INSERT INTO reports (cycle, agent, body, created_at) VALUES (?, ?, ?, ?)').run(...)
     //
     // After the fix, it should write all metadata fields:
@@ -61,11 +61,11 @@ function saveReportLikeServer(dbPath, { cycle, agent, body, cost, durationMs, in
 }
 
 /**
- * Read the ACTUAL ProjectRunner.js INSERT statement and check if it includes
+ * Read the ACTUAL project-db.js INSERT statement and check if it includes
  * the metadata columns. This is the real failing test.
  */
 function getServerInsertColumns() {
-  const serverPath = path.join(process.cwd(), 'src', 'orchestrator', 'ProjectRunner.js');
+  const serverPath = path.join(process.cwd(), 'src', 'orchestrator', 'project-db.js');
   const serverCode = fs.readFileSync(serverPath, 'utf-8');
   // Find the INSERT INTO reports statement
   const match = serverCode.match(/INSERT INTO reports\s*\(([^)]+)\)/);
@@ -74,80 +74,80 @@ function getServerInsertColumns() {
 }
 
 describe('Report metadata in SQLite', () => {
-  describe('ProjectRunner.js INSERT includes metadata columns', () => {
+  describe('project-db.js INSERT includes metadata columns', () => {
     const requiredColumns = ['cost', 'duration_ms', 'input_tokens', 'output_tokens', 'cache_read_tokens', 'success', 'model', 'timed_out', 'visibility_mode', 'visibility_issues'];
 
-    it('ProjectRunner.js INSERT INTO reports should include cost', () => {
+    it('project-db.js INSERT INTO reports should include cost', () => {
       const cols = getServerInsertColumns();
       assert.ok(cols.includes('cost'),
-        `ProjectRunner.js INSERT only has [${cols.join(', ')}] — missing 'cost'. ` +
+        `project-db.js INSERT only has [${cols.join(', ')}] — missing 'cost'. ` +
         `Currently writes to cost.csv instead of SQLite.`);
     });
 
-    it('ProjectRunner.js INSERT INTO reports should include duration_ms', () => {
+    it('project-db.js INSERT INTO reports should include duration_ms', () => {
       const cols = getServerInsertColumns();
       assert.ok(cols.includes('duration_ms'),
-        `ProjectRunner.js INSERT only has [${cols.join(', ')}] — missing 'duration_ms'`);
+        `project-db.js INSERT only has [${cols.join(', ')}] — missing 'duration_ms'`);
     });
 
-    it('ProjectRunner.js INSERT INTO reports should include input_tokens', () => {
+    it('project-db.js INSERT INTO reports should include input_tokens', () => {
       const cols = getServerInsertColumns();
       assert.ok(cols.includes('input_tokens'),
-        `ProjectRunner.js INSERT only has [${cols.join(', ')}] — missing 'input_tokens'`);
+        `project-db.js INSERT only has [${cols.join(', ')}] — missing 'input_tokens'`);
     });
 
-    it('ProjectRunner.js INSERT INTO reports should include output_tokens', () => {
+    it('project-db.js INSERT INTO reports should include output_tokens', () => {
       const cols = getServerInsertColumns();
       assert.ok(cols.includes('output_tokens'),
-        `ProjectRunner.js INSERT only has [${cols.join(', ')}] — missing 'output_tokens'`);
+        `project-db.js INSERT only has [${cols.join(', ')}] — missing 'output_tokens'`);
     });
 
-    it('ProjectRunner.js INSERT INTO reports should include model', () => {
+    it('project-db.js INSERT INTO reports should include model', () => {
       const cols = getServerInsertColumns();
       assert.ok(cols.includes('model'),
-        `ProjectRunner.js INSERT only has [${cols.join(', ')}] — missing 'model'`);
+        `project-db.js INSERT only has [${cols.join(', ')}] — missing 'model'`);
     });
 
-    it('ProjectRunner.js INSERT INTO reports should include success', () => {
+    it('project-db.js INSERT INTO reports should include success', () => {
       const cols = getServerInsertColumns();
       assert.ok(cols.includes('success'),
-        `ProjectRunner.js INSERT only has [${cols.join(', ')}] — missing 'success'`);
+        `project-db.js INSERT only has [${cols.join(', ')}] — missing 'success'`);
     });
 
-    it('ProjectRunner.js INSERT INTO reports should include timed_out', () => {
+    it('project-db.js INSERT INTO reports should include timed_out', () => {
       const cols = getServerInsertColumns();
       assert.ok(cols.includes('timed_out'),
-        `ProjectRunner.js INSERT only has [${cols.join(', ')}] — missing 'timed_out'`);
+        `project-db.js INSERT only has [${cols.join(', ')}] — missing 'timed_out'`);
     });
 
-    it('ProjectRunner.js INSERT INTO reports should include visibility_mode', () => {
+    it('project-db.js INSERT INTO reports should include visibility_mode', () => {
       const cols = getServerInsertColumns();
       assert.ok(cols.includes('visibility_mode'),
-        `ProjectRunner.js INSERT only has [${cols.join(', ')}] — missing 'visibility_mode'`);
+        `project-db.js INSERT only has [${cols.join(', ')}] — missing 'visibility_mode'`);
     });
 
-    it('ProjectRunner.js INSERT INTO reports should include visibility_issues', () => {
+    it('project-db.js INSERT INTO reports should include visibility_issues', () => {
       const cols = getServerInsertColumns();
       assert.ok(cols.includes('visibility_issues'),
-        `ProjectRunner.js INSERT only has [${cols.join(', ')}] — missing 'visibility_issues'`);
+        `project-db.js INSERT only has [${cols.join(', ')}] — missing 'visibility_issues'`);
     });
   });
 
   describe('getCostSummary reads from SQLite (not cost.csv)', () => {
-    it('ProjectRunner.js getCostSummary should query reports table', () => {
-      const serverPath = path.join(process.cwd(), 'src', 'orchestrator', 'ProjectRunner.js');
+    it('project-db.js getProjectCostSummary should query reports table', () => {
+      const serverPath = path.join(process.cwd(), 'src', 'orchestrator', 'project-db.js');
       const serverCode = fs.readFileSync(serverPath, 'utf-8');
 
-      // Find getCostSummary function
-      const fnMatch = serverCode.match(/getCostSummary\(\)\s*\{[\s\S]*?\n  \}/);
-      assert.ok(fnMatch, 'getCostSummary function not found');
+      // Find getProjectCostSummary function
+      const fnMatch = serverCode.match(/getProjectCostSummary\(runner\)\s*\{[\s\S]*?\n\}/);
+      assert.ok(fnMatch, 'getProjectCostSummary function not found');
 
       const fnBody = fnMatch[0];
 
       // Should query from SQLite, not read cost.csv
       assert.ok(
         !fnBody.includes('cost.csv') || fnBody.includes('SELECT'),
-        'getCostSummary should query reports table (SELECT), not read cost.csv'
+        'getProjectCostSummary should query reports table (SELECT), not read cost.csv'
       );
     });
   });

--- a/tests/schedule-format.test.js
+++ b/tests/schedule-format.test.js
@@ -4,9 +4,9 @@ import fs from 'fs';
 import path from 'path';
 import vm from 'node:vm';
 import { fileURLToPath } from 'url';
+import { parseSchedule as parseServerSchedule } from '../src/orchestrator/scheduler.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const serverPath = path.join(__dirname, '..', 'src', 'orchestrator', 'ProjectRunner.js');
 const scheduleDiagramPath = path.join(__dirname, '..', 'monitor', 'src', 'components', 'ScheduleDiagram.jsx');
 
 function extractMethod(source, signature) {
@@ -52,11 +52,7 @@ function extractFunction(source, signature) {
 }
 
 function loadServerParseSchedule() {
-  const src = fs.readFileSync(serverPath, 'utf-8');
-  const method = extractMethod(src, 'parseSchedule(resultText)');
-  const fnSource = method.replace('parseSchedule(resultText)', 'function parseSchedule(resultText)');
-  const wrapped = `(() => { ${fnSource}; return parseSchedule; })()`;
-  return vm.runInNewContext(wrapped, { log: () => {} });
+  return (text) => parseServerSchedule({}, { log: () => {} }, text);
 }
 
 function loadFrontendParseScheduleBlock() {

--- a/tests/schedule-resume.test.js
+++ b/tests/schedule-resume.test.js
@@ -23,8 +23,12 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+function readPhaseMachine() {
+  return fs.readFileSync(path.join(__dirname, '..', 'src', 'orchestrator', 'phase-machine.js'), 'utf-8');
+}
+
 function extractResumeCondition() {
-  const src = fs.readFileSync(path.join(__dirname, '..', 'src', 'orchestrator', 'ProjectRunner.js'), 'utf-8');
+  const src = readPhaseMachine();
   // Find the resume condition line — look for the if() that gates schedule resumption
   const match = src.match(/Resume interrupted schedule[^]*?\bif \(([^)]+)\)/);
   return match ? match[1].trim() : null;
@@ -55,7 +59,7 @@ describe('Schedule resume after reboot', () => {
       // There's a second resume check at cycle start that gates whether to
       // increment cycle count and clear state. It must also not require
       // completedAgents.length > 0.
-      const src = fs.readFileSync(path.join(__dirname, '..', 'src', 'orchestrator', 'ProjectRunner.js'), 'utf-8');
+      const src = readPhaseMachine();
       const match = src.match(/const resuming\s*=\s*([^;]+);/);
       assert.ok(match, 'Could not find cycle-start resuming check in ProjectRunner.js');
       const expr = match[1].trim();


### PR DESCRIPTION
## Summary\n\nPhase 4 slice: split ProjectRunner database/report responsibilities into a helper module.\n\n- Adds src/orchestrator/project-db.js for project DB initialization/migrations, agent registry sync, cost summaries, and report writes.\n- Keeps ProjectRunner methods as delegating wrappers where routes/tests expect them.\n- Updates report metadata source-inspection tests to target project-db.js.\n\n## Checks\n\n- node --check src/orchestrator/ProjectRunner.js\n- node --check src/orchestrator/project-db.js\n- npm test\n- npm --prefix monitor run build\n