### PR TITLE
refactor: finish ProjectRunner helper extraction

### DIFF
--- a/src/orchestrator/ProjectRunner.js
+++ b/src/orchestrator/ProjectRunner.js
@@ -2,11 +2,12 @@ import fs from 'fs';
 import path from 'path';
 import { execSync } from 'child_process';
 import yaml from 'js-yaml';
-import { runAgentWithAPI } from '../agent-runner.js';
-import { resolveModel, callModel, buildUserMessage } from '../providers/index.js';
-import { resolveKeyForProject, markRateLimited, markKeySucceeded } from '../key-pool.js';
 import { getAgentDetailsForRunner, loadAgentsForRunner } from './agent-loading.js';
 import { decideProjectEpochPr, getOpenEpochPrForBranch, getProjectComments, getProjectCostSummary, getProjectPr, getProjectPrs, openProjectDb, writeRunnerReport } from './project-db.js';
+import { computeSleepInterval, getBudgetStatus } from './budget.js';
+import { createIssue, getIssues, resolveAllowedIssueClosers } from './issues.js';
+import { bootstrap, bootstrapPreview, getStatus, runDoctor } from './lifecycle.js';
+import { postProcessAgentRun, runAgentForRunner } from './agent-runtime.js';
 import { allocateNextEpochId, allocateNextMilestoneId, ensureEpochPRForCurrentMilestone, getMilestoneRecord, getParentMilestoneId, makeMilestoneBranchPrefix, markCurrentMilestoneCompleted, markCurrentMilestoneFailed, normalizeResetTargetMilestone, slugifyMilestoneTitle, upsertMilestoneRecord } from './milestones.js';
 import { buildAgentPrompt, getAgentFilesystemPolicy } from './agent-prompt.js';
 import { killRunnerCycle, killRunnerEpoch, killRunnerRun, loadRunnerState, pauseRunner, resumeRunner, saveRunnerState, skipRunner, startRunner, stopRunner } from './state-control.js';
@@ -26,10 +27,7 @@ export function createProjectRunnerClass(deps) {
     stripMetaBlocks,
     sleep,
     getProviderRuntimeSelection,
-    parseExplicitModelSelection,
     detectProviderFromToken,
-    formatStoredChatErrorMessage,
-    parseSummarizeCooldown,
     getKeyPoolSafe,
     getOAuthAccessToken,
   } = deps;
@@ -247,132 +245,15 @@ class ProjectRunner {
   }
 
   computeSleepInterval() {
-    const config = this.loadConfig();
-    const budgetPer24h = config.budgetPer24h || 0;
-    const MIN_SLEEP = 10000;       // 10s
-    const MAX_SLEEP = 7200000;     // 2h
-
-    // If no budget set, fall back to fixed interval
-    if (budgetPer24h <= 0) {
-      return Math.max(config.cycleIntervalMs || 0, MIN_SLEEP);
-    }
-
-    const minFloor = config.cycleIntervalMs > 0 ? config.cycleIntervalMs : MIN_SLEEP;
-
-    // Query cost data from SQLite reports table
-    const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
-    let cycleCosts = [];
-    let spent24h = 0;
-    let oldestTime24h = Infinity;
-
-    try {
-      const db = this.getDb();
-      try { db.exec('ALTER TABLE reports ADD COLUMN cost REAL'); } catch {}
-      try { db.exec('ALTER TABLE reports ADD COLUMN duration_ms INTEGER'); } catch {}
-
-      spent24h = db.prepare('SELECT COALESCE(SUM(cost), 0) as v FROM reports WHERE created_at > ?').get(cutoff).v;
-      const oldest = db.prepare('SELECT MIN(created_at) as v FROM reports WHERE created_at > ?').get(cutoff);
-      if (oldest?.v) oldestTime24h = new Date(oldest.v).getTime();
-
-      const cycles = db.prepare('SELECT cycle, SUM(cost) as cost, MAX(duration_ms) as duration FROM reports WHERE cost IS NOT NULL GROUP BY cycle ORDER BY cycle ASC').all();
-      cycleCosts = cycles.map(c => ({ cost: c.cost || 0, duration: c.duration || 0 }));
-      db.close();
-    } catch {}
-
-    const remaining = budgetPer24h - spent24h;
-
-    // Budget exhaustion: sleep until oldest entry rolls off
-    if (remaining <= 0) {
-      if (oldestTime24h < Infinity) {
-        const rolloffAt = oldestTime24h + 24 * 60 * 60 * 1000;
-        const waitMs = Math.max(rolloffAt - Date.now(), MIN_SLEEP);
-        log(`Budget exhausted ($${spent24h.toFixed(2)}/$${budgetPer24h}), sleeping until oldest entry rolls off`, this.id);
-        return Math.min(waitMs, MAX_SLEEP);
-      }
-      log(`Budget exhausted, sleeping max`, this.id);
-      return MAX_SLEEP;
-    }
-
-    const n = cycleCosts.length;
-
-    // Cold start: no historical data
-    if (n === 0) {
-      const { managers, workers } = this.loadAgents();
-      const agentCount = managers.length + workers.length || 3;
-      const model = (config.model || '').toLowerCase();
-      let perAgentCost;
-      if (model.includes('opus')) perAgentCost = 2.50;
-      else if (model.includes('haiku')) perAgentCost = 0.50;
-      else perAgentCost = 1.50; // sonnet default
-
-      const estimatedCycleCost = perAgentCost * agentCount;
-      const agentTimeout = config.agentTimeoutMs > 0 ? config.agentTimeoutMs : 900000;
-      const estimatedCycleDuration = (agentTimeout / 2) * agentCount;
-
-      const nAffordable = Math.floor(remaining / (estimatedCycleCost * 1.5)); // k=1.5 for cold start
-      if (nAffordable <= 0) return MAX_SLEEP;
-      const sleepMs = (86400000 / nAffordable) - estimatedCycleDuration;
-      log(`Cold start: est cycle cost $${estimatedCycleCost.toFixed(2)}, affordable=${nAffordable}, sleep=${Math.round(sleepMs / 1000)}s`, this.id);
-      return Math.max(minFloor, Math.min(sleepMs, MAX_SLEEP));
-    }
-
-    // Compute EMA of cycle costs and durations (alpha=0.3) with outlier dampening
-    const alpha = 0.3;
-    let emaCost = cycleCosts[0].cost;
-    let emaDuration = cycleCosts[0].duration;
-
-    for (let i = 1; i < n; i++) {
-      let cycleCost = cycleCosts[i].cost;
-
-      // Outlier dampening: if cost > 3x EMA and we have >= 3 data points, clamp to 2x EMA
-      if (i >= 3 && cycleCost > 3 * emaCost) {
-        cycleCost = 2 * emaCost;
-      }
-
-      emaCost = alpha * cycleCost + (1 - alpha) * emaCost;
-      emaDuration = alpha * cycleCosts[i].duration + (1 - alpha) * emaDuration;
-    }
-
-    // Conservatism factor: k = 1.0 + 0.5 / sqrt(n)
-    const k = 1.0 + 0.5 / Math.sqrt(n);
-
-    const nAffordable = Math.floor(remaining / (emaCost * k));
-    if (nAffordable <= 0) {
-      log(`Budget nearly exhausted (remaining=$${remaining.toFixed(2)}, est/cycle=$${emaCost.toFixed(2)}), sleeping max`, this.id);
-      return MAX_SLEEP;
-    }
-
-    const sleepMs = (86400000 / nAffordable) - emaDuration;
-    log(`Budget: $${spent24h.toFixed(2)}/$${budgetPer24h} spent, est/cycle=$${emaCost.toFixed(2)}, k=${k.toFixed(2)}, affordable=${nAffordable}, sleep=${Math.round(Math.max(minFloor, Math.min(sleepMs, MAX_SLEEP)) / 1000)}s`, this.id);
-    return Math.max(minFloor, Math.min(sleepMs, MAX_SLEEP));
+    return computeSleepInterval(this, { log });
   }
 
   getBudgetStatus() {
-    const config = this.loadConfig();
-    const budgetPer24h = config.budgetPer24h || 0;
-    if (budgetPer24h <= 0) return null;
-
-    const costSummary = this.getCostSummary();
-    const spent24h = costSummary.last24hCost;
-    const remaining24h = budgetPer24h - spent24h;
-    const percentUsed = budgetPer24h > 0 ? (spent24h / budgetPer24h) * 100 : 0;
-    const exhausted = remaining24h <= 0;
-
-    return {
-      budgetPer24h,
-      spent24h,
-      remaining24h,
-      percentUsed,
-      computedSleepMs: this.lastComputedSleepMs, // Use cached value
-      exhausted
-    };
+    return getBudgetStatus(this);
   }
 
   _resolveAllowedIssueClosers(db, issueCreator) {
-    if (issueCreator === 'human' || issueCreator === 'chat') {
-      return { allowed: new Set(['human', 'chat']), special: 'chat-human' };
-    }
-    return { allowed: new Set([issueCreator, 'athena']), special: 'agent-athena' };
+    return resolveAllowedIssueClosers(this, {}, issueCreator);
   }
 
   getDb() {
@@ -450,179 +331,23 @@ class ProjectRunner {
   }
 
   async getIssues() {
-    try {
-      const db = this.getDb();
-      const issues = db.prepare(`
-        SELECT i.*, (SELECT COUNT(*) FROM comments c WHERE c.issue_id = i.id) as comment_count
-        FROM issues i ORDER BY i.created_at DESC
-      `).all();
-      db.close();
-      return issues;
-    } catch {
-      return [];
-    }
+    return getIssues(this);
   }
 
   async createIssue(title, body = '', creator = 'human', assignee = null) {
-    if (!title?.trim()) throw new Error('Missing issue title');
-    try {
-      const db = this.getDb();
-      const now = new Date().toISOString();
-      const result = db.prepare(
-        `INSERT INTO issues (title, body, creator, assignee, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
-      ).run(title.trim(), body.trim(), creator, assignee || null, now, now);
-      db.close();
-      return { success: true, issueId: result.lastInsertRowid };
-    } catch (e) {
-      throw new Error(`Failed to create issue: ${e.message}`);
-    }
+    return createIssue(this, {}, title, body, creator, assignee);
   }
 
   getStatus() {
-    return {
-      id: this.id,
-      path: this.path,
-      repo: this.repo,
-      enabled: this.enabled,
-      archived: this.archived,
-      running: this.running,
-      paused: this.isPaused,
-      pauseReason: this.pauseReason || null,
-      cycleCount: this.cycleCount,
-      epochCount: this.epochCount,
-      currentAgent: this.currentAgent,
-      currentAgentModel: this.currentAgentModel,
-      currentAgentKeyId: this.currentAgentKeyId || null,
-      currentAgentVisibility: this.currentAgentVisibility || { mode: 'full', issues: [] },
-      currentAgentRuntime: this.currentAgentStartTime
-        ? Math.floor((Date.now() - this.currentAgentStartTime) / 1000)
-        : null,
-      sleeping: this.sleepUntil !== null && !this.isPaused,
-      sleepUntil: this.isPaused ? null : this.sleepUntil,
-      schedule: this.currentSchedule || null,
-      phase: this.phase,
-      milestoneTitle: this.milestoneTitle,
-      milestone: this.milestoneDescription,
-      milestoneCyclesBudget: this.milestoneCyclesBudget,
-      milestoneCyclesUsed: this.milestoneCyclesUsed,
-      currentMilestoneId: this.currentMilestoneId,
-      pendingMilestoneId: this.pendingMilestoneId,
-      currentEpochId: this.currentEpochId,
-      currentEpochPrId: this.currentEpochPrId,
-      currentMilestoneBranch: this.currentMilestoneBranch,
-      lastMergedMilestoneBranch: this.lastMergedMilestoneBranch,
-      isFixRound: this.isFixRound,
-      isComplete: this.isComplete || false,
-      completionSuccess: this.completionSuccess || false,
-      completionMessage: this.completionMessage || null,
-      config: this.loadConfig(),
-      agents: this.loadAgents(),
-      cost: this.getCostSummary(),
-      budget: this.getBudgetStatus()
-    };
+    return getStatus(this);
   }
 
   bootstrapPreview() {
-    const projectDataExists = fs.existsSync(this.projectDir);
-    let projectDataContents = [];
-    if (projectDataExists) {
-      projectDataContents = fs.readdirSync(this.projectDir).filter(name => !['repo', 'knowledge', 'skills', 'config.yaml'].includes(name));
-    }
-    // Read spec.md and check roadmap.md from private knowledge base
-    let specContent = null;
-    const specPath = path.join(this.knowledgeDir, 'spec.md');
-    try { specContent = fs.readFileSync(specPath, 'utf-8'); } catch {}
-    const hasRoadmap = fs.existsSync(path.join(this.knowledgeDir, 'roadmap.md'));
-    return { available: true, projectDataEmpty: projectDataContents.length === 0, repo: this.repo, specContent, hasRoadmap };
+    return bootstrapPreview(this);
   }
 
   bootstrap(options = {}) {
-    // 0. Kill any running agent and pause the project
-    if (this.currentAgentProcess) {
-      try { this.currentAgentProcess.kill('SIGKILL'); } catch {}
-      log(`Killed running agent ${this.currentAgent} for bootstrap`, this.id);
-      this.currentAgentProcess = null;
-      this.currentAgent = null;
-      this.currentAgentStartTime = null;
-      this.currentAgentLog = [];
-      this.currentAgentModel = null; this.currentAgentCost = 0; this.currentAgentUsage = null; this.currentAgentKeyId = null; this.currentAgentVisibility = null;
-    }
-    this.isPaused = true;
-    this.pauseReason = 'Bootstrapping';
-    this.completedAgents = [];
-    this.currentCycleId = null;
-    this.currentSchedule = null;
-
-    // 1. Wipe project operational state only, keep repo/knowledge/skills intact
-    for (const target of this.getOperationalPaths()) {
-      if (!fs.existsSync(target)) continue;
-      fs.rmSync(target, { recursive: true, force: true });
-    }
-    log(`Cleared project operational state`, this.id);
-    fs.mkdirSync(this.projectDir, { recursive: true });
-
-    // 2. Reset cycle count, phase, and save state
-    this.setState({
-      cycleCount: 0,
-      epochCount: 0,
-      phase: 'athena',
-      milestoneTitle: null,
-      milestoneDescription: null,
-      milestoneCyclesBudget: 0,
-      milestoneCyclesUsed: 0,
-      currentMilestoneId: null,
-      pendingMilestoneId: null,
-      currentEpochId: null,
-      currentEpochPrId: null,
-      currentMilestoneBranch: null,
-      aresGraceCycleUsed: false,
-      verificationFeedback: null,
-      examinationFeedback: null,
-      pendingCompletionMessage: null,
-      isFixRound: false,
-      isComplete: false,
-      completionSuccess: false,
-      completionMessage: null,
-      isPaused: true,
-      pauseReason: 'Bootstrapped — resume when ready',
-    });
-    log(`Reset cycle count, project paused`, this.id);
-
-    // 3. Remove roadmap.md from private knowledge base if requested
-    if (options.removeRoadmap) {
-      const roadmapPath = path.join(this.knowledgeDir, 'roadmap.md');
-      if (fs.existsSync(roadmapPath)) {
-        try {
-          fs.unlinkSync(roadmapPath);
-          log(`Removed private roadmap.md`, this.id);
-        } catch (e) {
-          log(`Warning: failed to remove private roadmap.md: ${e.message}`, this.id);
-        }
-      }
-    }
-
-    // 4. Update private spec.md if requested
-    if (options.spec && options.spec.mode !== 'keep') {
-      const specPath = path.join(this.knowledgeDir, 'spec.md');
-      let newContent = '';
-      if (options.spec.mode === 'edit') {
-        newContent = options.spec.content || '';
-      } else if (options.spec.mode === 'new') {
-        const what = (options.spec.whatToBuild || '').trim();
-        const criteria = (options.spec.successCriteria || '').trim();
-        newContent = `# Project Spec\n\n## What to Build\n\n${what}\n\n## Success Criteria\n\n${criteria}\n`;
-      }
-      if (newContent) {
-        try {
-          fs.writeFileSync(specPath, newContent);
-          log(`Updated private knowledge/spec.md`, this.id);
-        } catch (e) {
-          log(`Warning: failed to update spec.md: ${e.message}`, this.id);
-        }
-      }
-    }
-
-    return { bootstrapped: true };
+    return bootstrap(this, { log }, options);
   }
 
   _writeReport(agentName, body, { success = true, durationMs = 0 } = {}) {
@@ -633,43 +358,7 @@ class ProjectRunner {
   }
 
   async runDoctor() {
-    const config = this.loadConfig();
-    const doctorAgent = { name: 'doctor', isManager: true, rawModel: 'high' };
-    const task = [
-      'Inspect this project and act only as an AI Doctor agent.',
-      '',
-      'Your job is to inspect and repair project layout drift. Do not rely on any built-in deterministic doctor behavior. You are the doctor.',
-      '',
-      'Canonical layout:',
-      '- repo/',
-      '- knowledge/',
-      '- skills/',
-      '- project.db',
-      '- orchestrator.log',
-      '- responses/',
-      '- agents/',
-      '',
-      'Required behavior:',
-      '- Inspect the actual filesystem.',
-      '- Repair missing or misplaced project files when it is safe.',
-      '- Ensure required directories and files exist after repair.',
-      '- If known agent directories under agents/ are missing, create them.',
-      '- Do not change product code in repo/ unless absolutely necessary for the repair itself.',
-      '- Prefer move/rename over copy when safe.',
-      '',
-      'At the end, write a concise doctor report with these sections exactly:',
-      '## Doctor Check',
-      'Layout status: ...',
-      '',
-      '### Required paths',
-      '- ...',
-      '',
-      '### Repair actions',
-      '- ...',
-      '',
-      'If something could not be fixed, say why clearly.',
-    ].join('\n');
-    return await this.runAgent(doctorAgent, config, 'doctor', task, { mode: 'full', issues: [] });
+    return runDoctor(this);
   }
 
   async start() {
@@ -750,266 +439,12 @@ class ProjectRunner {
   }
 
   // Post-processing shared by both CLI and API agent runs
-  _postProcessAgentRun(agent, config, { resultText, cost, durationMs, killedByTimeout, exitCode, rawOutput, apiSuccess, usage }) {
-    const durationStr = `${Math.floor(durationMs / 60000)}m ${Math.floor((durationMs % 60000) / 1000)}s`;
-    // For API runner: use apiSuccess if provided; for CLI runner: use exitCode
-    const success = !killedByTimeout && (apiSuccess !== undefined ? apiSuccess : (exitCode === 0 || exitCode === undefined));
-
-    // Build token info string for logging
-    let tokenInfo = '';
-    if (cost !== undefined) {
-      tokenInfo = ` | cost: $${cost.toFixed(4)}`;
-    }
-
-    // Log response to agent-specific log file
-    try {
-      const responsesDir = this.responsesDir;
-      fs.mkdirSync(responsesDir, { recursive: true });
-      const timestamp = new Date().toLocaleString('sv-SE', { hour12: false }).replace(',', '');
-      const header = `\n${'='.repeat(60)}\n[${timestamp}] Cycle ${this.cycleCount} | Success: ${success}\n${'='.repeat(60)}\n`;
-
-      // Always log raw output for debugging
-      const rawLogPath = path.join(responsesDir, `${agent.name}.raw.log`);
-      fs.appendFileSync(rawLogPath, header + (rawOutput || resultText || '') + '\n');
-
-      // Log parsed result if available
-      if (resultText) {
-        const agentLogPath = path.join(responsesDir, `${agent.name}.log`);
-        fs.appendFileSync(agentLogPath, header + resultText + '\n');
-      }
-    } catch (e) {
-      log(`Failed to log response for ${agent.name}: ${e.message}`, this.id);
-    }
-
-    // Write agent report to SQLite (cost data included — no longer writes to cost.csv)
-    if (resultText || killedByTimeout || !success) {
-      try {
-        let reportBody;
-        if (killedByTimeout || !success) {
-          const errorType = killedByTimeout ? '⏰ Timeout' : '❌ Error';
-          const errorMsg = killedByTimeout
-            ? `Killed after exceeding the ${Math.floor(config.agentTimeoutMs / 60000)}m timeout limit.`
-            : `Agent failed${exitCode !== undefined ? ` (exit code ${exitCode})` : ''}.`;
-          // Capture partial work on timeout
-          let partialWork = '';
-          if (killedByTimeout) {
-            try {
-              const repoDir = path.join(this.projectDir, 'repo');
-              if (fs.existsSync(path.join(repoDir, '.git'))) {
-                const diffStat = execSync('git diff --stat HEAD 2>/dev/null || true', { cwd: repoDir, encoding: 'utf-8', timeout: 10000 }).trim();
-                const stagedStat = execSync('git diff --stat --cached HEAD 2>/dev/null || true', { cwd: repoDir, encoding: 'utf-8', timeout: 10000 }).trim();
-                if (diffStat || stagedStat) {
-                  partialWork = `\n\n### Partial Work Detected\n\nUncommitted changes found in repo:\n\`\`\`\n${(stagedStat ? 'Staged:\n' + stagedStat + '\n' : '')}${(diffStat ? 'Unstaged:\n' + diffStat : '')}\n\`\`\``;
-                }
-              }
-            } catch {}
-          }
-          reportBody = `## ${errorType}\n\n${errorMsg}\n\n- Duration: ${durationStr}${partialWork}`;
-          // Include partial result text if we have it
-          if (resultText) {
-            reportBody += `\n\n### Partial Response\n\n${resultText.trim()}`;
-          }
-        } else {
-          reportBody = resultText.trim();
-        }
-        // Prepend time log to all reports
-        const agentStartTime = new Date(this.currentAgentStartTime).toLocaleString('sv-SE');
-        const endTime = new Date().toLocaleString('sv-SE');
-        reportBody = `> ⏱ Started: ${agentStartTime} | Ended: ${endTime} | Duration: ${durationStr}\n\n${reportBody}`;
-        const { reportId } = writeRunnerReport(this, agent.name, reportBody, {
-          cost: cost ?? null,
-          durationMs: durationMs ?? null,
-          inputTokens: usage?.inputTokens ?? null,
-          outputTokens: usage?.outputTokens ?? null,
-          cacheReadTokens: usage?.cacheReadTokens ?? null,
-          success,
-          model: this.currentAgentModel ?? null,
-          timedOut: killedByTimeout,
-          keyId: this.currentAgentKeyId ?? null,
-          visibilityMode: this.currentAgentVisibility?.mode || 'full',
-          visibilityIssues: this.currentAgentVisibility?.issues || [],
-          preformatted: true,
-        });
-        log(`Saved report for ${agent.name}`, this.id);
-        broadcastReportUpdate(this.id, reportId, agent.name, this.cycleCount);
-      } catch (dbErr) {
-        log(`Failed to write report: ${dbErr.message}`, this.id);
-      }
-    }
-
-    log(`${agent.name} done (success: ${success})${tokenInfo}`, this.id);
-    const summary = resultText ? stripMetaBlocks(resultText).slice(0, 500).replace(/\n+/g, ' ').trim() : '';
-    broadcastEvent({ type: 'agent-done', project: this.id, agent: agent.name, success, summary });
-    this.currentAgent = null;
-    this.currentAgentProcess = null;
-    this.currentAgentStartTime = null;
-    this.currentAgentLog = [];
-    broadcastStatusUpdate(this.id);
-    this.currentAgentModel = null; this.currentAgentCost = 0; this.currentAgentUsage = null; this.currentAgentKeyId = null; this.currentAgentVisibility = null;
-
-    return { success, resultText, killedByTimeout: !!killedByTimeout };
+  _postProcessAgentRun(agent, config, result) {
+    return postProcessAgentRun(this, { broadcastEvent, broadcastReportUpdate, broadcastStatusUpdate, log, stripMetaBlocks }, agent, config, result);
   }
 
   async runAgent(agent, config, mode = null, task = null, visibility = null) {
-    this.currentAgent = agent.name;
-    this.currentAgentKeyId = null;
-    this.currentAgentVisibility = visibility || { mode: 'full', issues: [] };
-    this.currentAgentStartTime = Date.now();
-    broadcastStatusUpdate(this.id);
-    const runAbortController = new AbortController();
-    this.currentAgentProcess = {
-      kill: () => runAbortController.abort(),
-    };
-    const modeStr = mode ? ` [${mode}]` : '';
-    log(`Running: ${agent.name}${agent.isManager ? ' (manager)' : ''}${modeStr}`, this.id);
-
-    // Ensure agent notes directory exists for this agent
-    const agentNotesDir = this.getAgentNotesDir(agent.name);
-    fs.mkdirSync(agentNotesDir, { recursive: true });
-
-    // Build the prompt (shared between CLI and API paths)
-    const skillContent = this._buildAgentPrompt(agent, task, visibility);
-    if (!skillContent) {
-      const skillPath = agent.isManager
-        ? path.join(ROOT, 'agent', 'managers', `${agent.name}.md`)
-        : path.join(this.workerSkillsDir, `${agent.name}.md`);
-      log(`Skill file not found: ${skillPath}, skipping ${agent.name}`, this.id);
-      this.currentAgent = null;
-      this.currentAgentProcess = null;
-      this.currentAgentStartTime = null;
-      this.currentAgentLog = [];
-      this.currentAgentModel = null; this.currentAgentCost = 0; this.currentAgentUsage = null; this.currentAgentKeyId = null; this.currentAgentVisibility = null;
-      return { success: false, resultText: '' };
-    }
-
-    const agentTierOrModel = agent.rawModel || config.model || 'mid';
-
-    // Resolve token from key pool first — provider comes from the resolved key
-    const oauthTokenGetter = async (authFile, provider) => {
-      return getOAuthAccessToken(provider, this.id);
-    };
-    const keyResult = await resolveKeyForProject(config, null, oauthTokenGetter);
-    let resolvedToken = keyResult?.token || null;
-    let resolvedKeyId = keyResult?.keyId || null;
-    const resolvedKeyType = keyResult?.type || 'api';
-    this.currentAgentKeyId = resolvedKeyId;
-
-    // Fallback: setupToken when project key selection is not configured
-    if (!resolvedToken && config.setupToken) {
-      resolvedToken = config.setupToken;
-    }
-
-    // Derive provider from the resolved key
-    let providerHint;
-    if (keyResult?.provider) {
-      providerHint = keyResult.provider;
-    } else if (config.setupTokenProvider) {
-      providerHint = config.setupTokenProvider;
-    } else if (resolvedToken) {
-      providerHint = detectProviderFromToken(resolvedToken);
-    } else {
-      providerHint = 'anthropic';
-    }
-
-    const runtimeSelection = getProviderRuntimeSelection({
-      provider: providerHint,
-      modelTier: agentTierOrModel,
-      keyResult,
-      projectModels: config.models,
-    });
-    const agentModel = runtimeSelection.selectedModel;
-    const reasoningEffort = runtimeSelection.reasoningEffort || null;
-    const customConfig = runtimeSelection.customConfig || null;
-
-    if (!resolvedToken) {
-      log(`No API token configured for ${agent.name} (model: ${agentModel}). Skipping agent run. Add a key in Settings.`, this.id);
-      this.currentAgent = null;
-      this.currentAgentProcess = null;
-      this.currentAgentStartTime = null;
-      this.currentAgentLog = [];
-      this.currentAgentModel = null; this.currentAgentCost = 0; this.currentAgentUsage = null; this.currentAgentKeyId = null; this.currentAgentVisibility = null;
-      broadcastStatusUpdate(this.id);
-      return { error: 'no_token', message: 'No API key configured. Add one in Settings > Credentials.' };
-    }
-
-    const agentEnv = {
-      CLAUDE_CODE_ENTRYPOINT: 'cli',
-      TBC_DB: this.projectDbPath,
-      TBC_VISIBILITY: visibility?.mode || 'full',
-      TBC_FOCUSED_ISSUES: visibility?.issues?.join(',') || '',
-    };
-
-    const tierLabel = runtimeSelection.reasoningEffort ? `${agentModel} (${runtimeSelection.reasoningEffort})` : agentModel;
-    log(`Using API runner for ${agent.name} (model: ${tierLabel})`, this.id);
-    this.currentAgentModel = tierLabel;
-
-    const projectId = this.id;
-    const result = await runAgentWithAPI({
-      prompt: skillContent,
-      model: agentModel,
-      token: resolvedToken,
-      keyType: resolvedKeyType,
-      provider: providerHint,
-      customConfig,
-      reasoningEffort,
-      cwd: this.path,
-      timeoutMs: config.agentTimeoutMs || 0,
-      env: agentEnv,
-      allowedRepo: agent.name === 'doctor' ? null : (this.repo || null),
-      allowedPaths: this._getAgentFilesystemPolicy(agent, visibility),
-      issuePolicy: { ...(visibility || { mode: 'full', issues: [] }), actor: agent.name },
-      abortSignal: runAbortController.signal,
-      keyId: resolvedKeyId,
-      onRateLimited: (kid, cooldownMs) => markRateLimited(kid, cooldownMs || 5 * 60_000),
-      resolveNewToken: async () => {
-        const newKey = await resolveKeyForProject(config, null, oauthTokenGetter);
-        if (newKey?.provider) {
-          const newRuntimeSelection = getProviderRuntimeSelection({
-            provider: newKey.provider,
-            modelTier: agentTierOrModel,
-            keyResult: newKey,
-            projectModels: null,
-          });
-          newKey.model = newRuntimeSelection.selectedModel;
-          newKey.reasoningEffort = newRuntimeSelection.reasoningEffort || null;
-          newKey.customConfig = newRuntimeSelection.customConfig || null;
-        }
-        if (newKey?.keyId) this.currentAgentKeyId = newKey.keyId;
-        return newKey;
-      },
-      log: (msg) => {
-        log(`  [${agent.name}] ${msg}`, projectId);
-        if (typeof msg === 'string' && msg.startsWith('Tool: ')) return;
-        const event = { time: Date.now(), type: 'thinking', content: String(msg) };
-        this.currentAgentLog.push(event);
-        if (this.currentAgentLog.length > 500) this.currentAgentLog.shift();
-        broadcastLiveAgentEvent(projectId, event);
-      },
-      onEvent: (event) => {
-        const enriched = { time: Date.now(), ...event };
-        this.currentAgentLog.push(enriched);
-        if (this.currentAgentLog.length > 500) this.currentAgentLog.shift();
-        broadcastLiveAgentEvent(projectId, enriched);
-      },
-      onProgress: ({ usage, cost }) => {
-        this.currentAgentCost = cost;
-        this.currentAgentUsage = usage;
-      },
-    });
-
-    if (result.success && resolvedKeyId) {
-      markKeySucceeded(resolvedKeyId);
-    }
-
-    return this._postProcessAgentRun(agent, config, {
-      resultText: result.resultText,
-      cost: result.cost,
-      durationMs: result.durationMs,
-      killedByTimeout: result.timedOut || false,
-      apiSuccess: result.success,
-      usage: result.usage,
-      rawOutput: JSON.stringify({ usage: result.usage, resultText: result.resultText }),
-    });
+    return runAgentForRunner(this, { broadcastEvent, broadcastLiveAgentEvent, broadcastReportUpdate, broadcastStatusUpdate, detectProviderFromToken, getOAuthAccessToken, getProviderRuntimeSelection, log, root: ROOT, stripMetaBlocks }, agent, config, mode, task, visibility);
   }
 }
 

--- a/src/orchestrator/agent-runtime.js
+++ b/src/orchestrator/agent-runtime.js
@@ -1,0 +1,268 @@
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+import { runAgentWithAPI } from '../agent-runner.js';
+import { resolveKeyForProject, markRateLimited, markKeySucceeded } from '../key-pool.js';
+import { writeRunnerReport } from './project-db.js';
+
+export function postProcessAgentRun(runner, deps = {}, agent, config, { resultText, cost, durationMs, killedByTimeout, exitCode, rawOutput, apiSuccess, usage }) {
+    const durationStr = `${Math.floor(durationMs / 60000)}m ${Math.floor((durationMs % 60000) / 1000)}s`;
+    // For API runner: use apiSuccess if provided; for CLI runner: use exitCode
+    const success = !killedByTimeout && (apiSuccess !== undefined ? apiSuccess : (exitCode === 0 || exitCode === undefined));
+
+    // Build token info string for logging
+    let tokenInfo = '';
+    if (cost !== undefined) {
+      tokenInfo = ` | cost: $${cost.toFixed(4)}`;
+    }
+
+    // Log response to agent-specific log file
+    try {
+      const responsesDir = runner.responsesDir;
+      fs.mkdirSync(responsesDir, { recursive: true });
+      const timestamp = new Date().toLocaleString('sv-SE', { hour12: false }).replace(',', '');
+      const header = `\n${'='.repeat(60)}\n[${timestamp}] Cycle ${runner.cycleCount} | Success: ${success}\n${'='.repeat(60)}\n`;
+
+      // Always log raw output for debugging
+      const rawLogPath = path.join(responsesDir, `${agent.name}.raw.log`);
+      fs.appendFileSync(rawLogPath, header + (rawOutput || resultText || '') + '\n');
+
+      // Log parsed result if available
+      if (resultText) {
+        const agentLogPath = path.join(responsesDir, `${agent.name}.log`);
+        fs.appendFileSync(agentLogPath, header + resultText + '\n');
+      }
+    } catch (e) {
+      deps.log(`Failed to log response for ${agent.name}: ${e.message}`, runner.id);
+    }
+
+    // Write agent report to SQLite (cost data included — no longer writes to cost.csv)
+    if (resultText || killedByTimeout || !success) {
+      try {
+        let reportBody;
+        if (killedByTimeout || !success) {
+          const errorType = killedByTimeout ? '⏰ Timeout' : '❌ Error';
+          const errorMsg = killedByTimeout
+            ? `Killed after exceeding the ${Math.floor(config.agentTimeoutMs / 60000)}m timeout limit.`
+            : `Agent failed${exitCode !== undefined ? ` (exit code ${exitCode})` : ''}.`;
+          // Capture partial work on timeout
+          let partialWork = '';
+          if (killedByTimeout) {
+            try {
+              const repoDir = path.join(runner.projectDir, 'repo');
+              if (fs.existsSync(path.join(repoDir, '.git'))) {
+                const diffStat = execSync('git diff --stat HEAD 2>/dev/null || true', { cwd: repoDir, encoding: 'utf-8', timeout: 10000 }).trim();
+                const stagedStat = execSync('git diff --stat --cached HEAD 2>/dev/null || true', { cwd: repoDir, encoding: 'utf-8', timeout: 10000 }).trim();
+                if (diffStat || stagedStat) {
+                  partialWork = `\n\n### Partial Work Detected\n\nUncommitted changes found in repo:\n\`\`\`\n${(stagedStat ? 'Staged:\n' + stagedStat + '\n' : '')}${(diffStat ? 'Unstaged:\n' + diffStat : '')}\n\`\`\``;
+                }
+              }
+            } catch {}
+          }
+          reportBody = `## ${errorType}\n\n${errorMsg}\n\n- Duration: ${durationStr}${partialWork}`;
+          // Include partial result text if we have it
+          if (resultText) {
+            reportBody += `\n\n### Partial Response\n\n${resultText.trim()}`;
+          }
+        } else {
+          reportBody = resultText.trim();
+        }
+        // Prepend time log to all reports
+        const agentStartTime = new Date(runner.currentAgentStartTime).toLocaleString('sv-SE');
+        const endTime = new Date().toLocaleString('sv-SE');
+        reportBody = `> ⏱ Started: ${agentStartTime} | Ended: ${endTime} | Duration: ${durationStr}\n\n${reportBody}`;
+        const { reportId } = writeRunnerReport(this, agent.name, reportBody, {
+          cost: cost ?? null,
+          durationMs: durationMs ?? null,
+          inputTokens: usage?.inputTokens ?? null,
+          outputTokens: usage?.outputTokens ?? null,
+          cacheReadTokens: usage?.cacheReadTokens ?? null,
+          success,
+          model: runner.currentAgentModel ?? null,
+          timedOut: killedByTimeout,
+          keyId: runner.currentAgentKeyId ?? null,
+          visibilityMode: runner.currentAgentVisibility?.mode || 'full',
+          visibilityIssues: runner.currentAgentVisibility?.issues || [],
+          preformatted: true,
+        });
+        deps.log(`Saved report for ${agent.name}`, runner.id);
+        deps.broadcastReportUpdate(runner.id, reportId, agent.name, runner.cycleCount);
+      } catch (dbErr) {
+        deps.log(`Failed to write report: ${dbErr.message}`, runner.id);
+      }
+    }
+
+    deps.log(`${agent.name} done (success: ${success})${tokenInfo}`, runner.id);
+    const summary = resultText ? deps.stripMetaBlocks(resultText).slice(0, 500).replace(/\n+/g, ' ').trim() : '';
+    deps.broadcastEvent({ type: 'agent-done', project: runner.id, agent: agent.name, success, summary });
+    runner.currentAgent = null;
+    runner.currentAgentProcess = null;
+    runner.currentAgentStartTime = null;
+    runner.currentAgentLog = [];
+    deps.broadcastStatusUpdate(runner.id);
+    runner.currentAgentModel = null; runner.currentAgentCost = 0; runner.currentAgentUsage = null; runner.currentAgentKeyId = null; runner.currentAgentVisibility = null;
+
+    return { success, resultText, killedByTimeout: !!killedByTimeout };
+  }
+
+export async function runAgentForRunner(runner, deps = {}, agent, config, mode = null, task = null, visibility = null) {
+    runner.currentAgent = agent.name;
+    runner.currentAgentKeyId = null;
+    runner.currentAgentVisibility = visibility || { mode: 'full', issues: [] };
+    runner.currentAgentStartTime = Date.now();
+    deps.broadcastStatusUpdate(runner.id);
+    const runAbortController = new AbortController();
+    runner.currentAgentProcess = {
+      kill: () => runAbortController.abort(),
+    };
+    const modeStr = mode ? ` [${mode}]` : '';
+    deps.log(`Running: ${agent.name}${agent.isManager ? ' (manager)' : ''}${modeStr}`, runner.id);
+
+    // Ensure agent notes directory exists for this agent
+    const agentNotesDir = runner.getAgentNotesDir(agent.name);
+    fs.mkdirSync(agentNotesDir, { recursive: true });
+
+    // Build the prompt (shared between CLI and API paths)
+    const skillContent = runner._buildAgentPrompt(agent, task, visibility);
+    if (!skillContent) {
+      const skillPath = agent.isManager
+        ? path.join(deps.root, 'agent', 'managers', `${agent.name}.md`)
+        : path.join(runner.workerSkillsDir, `${agent.name}.md`);
+      deps.log(`Skill file not found: ${skillPath}, skipping ${agent.name}`, runner.id);
+      runner.currentAgent = null;
+      runner.currentAgentProcess = null;
+      runner.currentAgentStartTime = null;
+      runner.currentAgentLog = [];
+      runner.currentAgentModel = null; runner.currentAgentCost = 0; runner.currentAgentUsage = null; runner.currentAgentKeyId = null; runner.currentAgentVisibility = null;
+      return { success: false, resultText: '' };
+    }
+
+    const agentTierOrModel = agent.rawModel || config.model || 'mid';
+
+    // Resolve token from key pool first — provider comes from the resolved key
+    const oauthTokenGetter = async (authFile, provider) => {
+      return deps.getOAuthAccessToken(provider, runner.id);
+    };
+    const keyResult = await resolveKeyForProject(config, null, oauthTokenGetter);
+    let resolvedToken = keyResult?.token || null;
+    let resolvedKeyId = keyResult?.keyId || null;
+    const resolvedKeyType = keyResult?.type || 'api';
+    runner.currentAgentKeyId = resolvedKeyId;
+
+    // Fallback: setupToken when project key selection is not configured
+    if (!resolvedToken && config.setupToken) {
+      resolvedToken = config.setupToken;
+    }
+
+    // Derive provider from the resolved key
+    let providerHint;
+    if (keyResult?.provider) {
+      providerHint = keyResult.provider;
+    } else if (config.setupTokenProvider) {
+      providerHint = config.setupTokenProvider;
+    } else if (resolvedToken) {
+      providerHint = deps.detectProviderFromToken(resolvedToken);
+    } else {
+      providerHint = 'anthropic';
+    }
+
+    const runtimeSelection = deps.getProviderRuntimeSelection({
+      provider: providerHint,
+      modelTier: agentTierOrModel,
+      keyResult,
+      projectModels: config.models,
+    });
+    const agentModel = runtimeSelection.selectedModel;
+    const reasoningEffort = runtimeSelection.reasoningEffort || null;
+    const customConfig = runtimeSelection.customConfig || null;
+
+    if (!resolvedToken) {
+      deps.log(`No API token configured for ${agent.name} (model: ${agentModel}). Skipping agent run. Add a key in Settings.`, runner.id);
+      runner.currentAgent = null;
+      runner.currentAgentProcess = null;
+      runner.currentAgentStartTime = null;
+      runner.currentAgentLog = [];
+      runner.currentAgentModel = null; runner.currentAgentCost = 0; runner.currentAgentUsage = null; runner.currentAgentKeyId = null; runner.currentAgentVisibility = null;
+      deps.broadcastStatusUpdate(runner.id);
+      return { error: 'no_token', message: 'No API key configured. Add one in Settings > Credentials.' };
+    }
+
+    const agentEnv = {
+      CLAUDE_CODE_ENTRYPOINT: 'cli',
+      TBC_DB: runner.projectDbPath,
+      TBC_VISIBILITY: visibility?.mode || 'full',
+      TBC_FOCUSED_ISSUES: visibility?.issues?.join(',') || '',
+    };
+
+    const tierLabel = runtimeSelection.reasoningEffort ? `${agentModel} (${runtimeSelection.reasoningEffort})` : agentModel;
+    deps.log(`Using API runner for ${agent.name} (model: ${tierLabel})`, runner.id);
+    runner.currentAgentModel = tierLabel;
+
+    const projectId = runner.id;
+    const result = await runAgentWithAPI({
+      prompt: skillContent,
+      model: agentModel,
+      token: resolvedToken,
+      keyType: resolvedKeyType,
+      provider: providerHint,
+      customConfig,
+      reasoningEffort,
+      cwd: runner.path,
+      timeoutMs: config.agentTimeoutMs || 0,
+      env: agentEnv,
+      allowedRepo: agent.name === 'doctor' ? null : (runner.repo || null),
+      allowedPaths: runner._getAgentFilesystemPolicy(agent, visibility),
+      issuePolicy: { ...(visibility || { mode: 'full', issues: [] }), actor: agent.name },
+      abortSignal: runAbortController.signal,
+      keyId: resolvedKeyId,
+      onRateLimited: (kid, cooldownMs) => markRateLimited(kid, cooldownMs || 5 * 60_000),
+      resolveNewToken: async () => {
+        const newKey = await resolveKeyForProject(config, null, oauthTokenGetter);
+        if (newKey?.provider) {
+          const newRuntimeSelection = deps.getProviderRuntimeSelection({
+            provider: newKey.provider,
+            modelTier: agentTierOrModel,
+            keyResult: newKey,
+            projectModels: null,
+          });
+          newKey.model = newRuntimeSelection.selectedModel;
+          newKey.reasoningEffort = newRuntimeSelection.reasoningEffort || null;
+          newKey.customConfig = newRuntimeSelection.customConfig || null;
+        }
+        if (newKey?.keyId) runner.currentAgentKeyId = newKey.keyId;
+        return newKey;
+      },
+      log: (msg) => {
+        deps.log(`  [${agent.name}] ${msg}`, projectId);
+        if (typeof msg === 'string' && msg.startsWith('Tool: ')) return;
+        const event = { time: Date.now(), type: 'thinking', content: String(msg) };
+        runner.currentAgentLog.push(event);
+        if (runner.currentAgentLog.length > 500) runner.currentAgentLog.shift();
+        deps.broadcastLiveAgentEvent(projectId, event);
+      },
+      onEvent: (event) => {
+        const enriched = { time: Date.now(), ...event };
+        runner.currentAgentLog.push(enriched);
+        if (runner.currentAgentLog.length > 500) runner.currentAgentLog.shift();
+        deps.broadcastLiveAgentEvent(projectId, enriched);
+      },
+      onProgress: ({ usage, cost }) => {
+        runner.currentAgentCost = cost;
+        runner.currentAgentUsage = usage;
+      },
+    });
+
+    if (result.success && resolvedKeyId) {
+      markKeySucceeded(resolvedKeyId);
+    }
+
+    return postProcessAgentRun(runner, deps, agent, config, {
+      resultText: result.resultText,
+      cost: result.cost,
+      durationMs: result.durationMs,
+      killedByTimeout: result.timedOut || false,
+      apiSuccess: result.success,
+      usage: result.usage,
+      rawOutput: JSON.stringify({ usage: result.usage, resultText: result.resultText }),
+    });
+  }

--- a/src/orchestrator/budget.js
+++ b/src/orchestrator/budget.js
@@ -1,0 +1,121 @@
+export function computeSleepInterval(runner, deps = {}) {
+    const config = runner.loadConfig();
+    const budgetPer24h = config.budgetPer24h || 0;
+    const MIN_SLEEP = 10000;       // 10s
+    const MAX_SLEEP = 7200000;     // 2h
+
+    // If no budget set, fall back to fixed interval
+    if (budgetPer24h <= 0) {
+      return Math.max(config.cycleIntervalMs || 0, MIN_SLEEP);
+    }
+
+    const minFloor = config.cycleIntervalMs > 0 ? config.cycleIntervalMs : MIN_SLEEP;
+
+    // Query cost data from SQLite reports table
+    const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+    let cycleCosts = [];
+    let spent24h = 0;
+    let oldestTime24h = Infinity;
+
+    try {
+      const db = runner.getDb();
+      try { db.exec('ALTER TABLE reports ADD COLUMN cost REAL'); } catch {}
+      try { db.exec('ALTER TABLE reports ADD COLUMN duration_ms INTEGER'); } catch {}
+
+      spent24h = db.prepare('SELECT COALESCE(SUM(cost), 0) as v FROM reports WHERE created_at > ?').get(cutoff).v;
+      const oldest = db.prepare('SELECT MIN(created_at) as v FROM reports WHERE created_at > ?').get(cutoff);
+      if (oldest?.v) oldestTime24h = new Date(oldest.v).getTime();
+
+      const cycles = db.prepare('SELECT cycle, SUM(cost) as cost, MAX(duration_ms) as duration FROM reports WHERE cost IS NOT NULL GROUP BY cycle ORDER BY cycle ASC').all();
+      cycleCosts = cycles.map(c => ({ cost: c.cost || 0, duration: c.duration || 0 }));
+      db.close();
+    } catch {}
+
+    const remaining = budgetPer24h - spent24h;
+
+    // Budget exhaustion: sleep until oldest entry rolls off
+    if (remaining <= 0) {
+      if (oldestTime24h < Infinity) {
+        const rolloffAt = oldestTime24h + 24 * 60 * 60 * 1000;
+        const waitMs = Math.max(rolloffAt - Date.now(), MIN_SLEEP);
+        deps.log(`Budget exhausted ($${spent24h.toFixed(2)}/$${budgetPer24h}), sleeping until oldest entry rolls off`, runner.id);
+        return Math.min(waitMs, MAX_SLEEP);
+      }
+      deps.log(`Budget exhausted, sleeping max`, runner.id);
+      return MAX_SLEEP;
+    }
+
+    const n = cycleCosts.length;
+
+    // Cold start: no historical data
+    if (n === 0) {
+      const { managers, workers } = runner.loadAgents();
+      const agentCount = managers.length + workers.length || 3;
+      const model = (config.model || '').toLowerCase();
+      let perAgentCost;
+      if (model.includes('opus')) perAgentCost = 2.50;
+      else if (model.includes('haiku')) perAgentCost = 0.50;
+      else perAgentCost = 1.50; // sonnet default
+
+      const estimatedCycleCost = perAgentCost * agentCount;
+      const agentTimeout = config.agentTimeoutMs > 0 ? config.agentTimeoutMs : 900000;
+      const estimatedCycleDuration = (agentTimeout / 2) * agentCount;
+
+      const nAffordable = Math.floor(remaining / (estimatedCycleCost * 1.5)); // k=1.5 for cold start
+      if (nAffordable <= 0) return MAX_SLEEP;
+      const sleepMs = (86400000 / nAffordable) - estimatedCycleDuration;
+      deps.log(`Cold start: est cycle cost $${estimatedCycleCost.toFixed(2)}, affordable=${nAffordable}, sleep=${Math.round(sleepMs / 1000)}s`, runner.id);
+      return Math.max(minFloor, Math.min(sleepMs, MAX_SLEEP));
+    }
+
+    // Compute EMA of cycle costs and durations (alpha=0.3) with outlier dampening
+    const alpha = 0.3;
+    let emaCost = cycleCosts[0].cost;
+    let emaDuration = cycleCosts[0].duration;
+
+    for (let i = 1; i < n; i++) {
+      let cycleCost = cycleCosts[i].cost;
+
+      // Outlier dampening: if cost > 3x EMA and we have >= 3 data points, clamp to 2x EMA
+      if (i >= 3 && cycleCost > 3 * emaCost) {
+        cycleCost = 2 * emaCost;
+      }
+
+      emaCost = alpha * cycleCost + (1 - alpha) * emaCost;
+      emaDuration = alpha * cycleCosts[i].duration + (1 - alpha) * emaDuration;
+    }
+
+    // Conservatism factor: k = 1.0 + 0.5 / sqrt(n)
+    const k = 1.0 + 0.5 / Math.sqrt(n);
+
+    const nAffordable = Math.floor(remaining / (emaCost * k));
+    if (nAffordable <= 0) {
+      deps.log(`Budget nearly exhausted (remaining=$${remaining.toFixed(2)}, est/cycle=$${emaCost.toFixed(2)}), sleeping max`, runner.id);
+      return MAX_SLEEP;
+    }
+
+    const sleepMs = (86400000 / nAffordable) - emaDuration;
+    deps.log(`Budget: $${spent24h.toFixed(2)}/$${budgetPer24h} spent, est/cycle=$${emaCost.toFixed(2)}, k=${k.toFixed(2)}, affordable=${nAffordable}, sleep=${Math.round(Math.max(minFloor, Math.min(sleepMs, MAX_SLEEP)) / 1000)}s`, runner.id);
+    return Math.max(minFloor, Math.min(sleepMs, MAX_SLEEP));
+  }
+
+export function getBudgetStatus(runner, deps = {}) {
+    const config = runner.loadConfig();
+    const budgetPer24h = config.budgetPer24h || 0;
+    if (budgetPer24h <= 0) return null;
+
+    const costSummary = runner.getCostSummary();
+    const spent24h = costSummary.last24hCost;
+    const remaining24h = budgetPer24h - spent24h;
+    const percentUsed = budgetPer24h > 0 ? (spent24h / budgetPer24h) * 100 : 0;
+    const exhausted = remaining24h <= 0;
+
+    return {
+      budgetPer24h,
+      spent24h,
+      remaining24h,
+      percentUsed,
+      computedSleepMs: runner.lastComputedSleepMs, // Use cached value
+      exhausted
+    };
+  }

--- a/src/orchestrator/issues.js
+++ b/src/orchestrator/issues.js
@@ -1,0 +1,35 @@
+export function resolveAllowedIssueClosers(runner, deps = {}, issueCreator) {
+    if (issueCreator === 'human' || issueCreator === 'chat') {
+      return { allowed: new Set(['human', 'chat']), special: 'chat-human' };
+    }
+    return { allowed: new Set([issueCreator, 'athena']), special: 'agent-athena' };
+  }
+
+export async function getIssues(runner, deps = {}) {
+    try {
+      const db = runner.getDb();
+      const issues = db.prepare(`
+        SELECT i.*, (SELECT COUNT(*) FROM comments c WHERE c.issue_id = i.id) as comment_count
+        FROM issues i ORDER BY i.created_at DESC
+      `).all();
+      db.close();
+      return issues;
+    } catch {
+      return [];
+    }
+  }
+
+export async function createIssue(runner, deps = {}, title, body = '', creator = 'human', assignee = null) {
+    if (!title?.trim()) throw new Error('Missing issue title');
+    try {
+      const db = runner.getDb();
+      const now = new Date().toISOString();
+      const result = db.prepare(
+        `INSERT INTO issues (title, body, creator, assignee, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
+      ).run(title.trim(), body.trim(), creator, assignee || null, now, now);
+      db.close();
+      return { success: true, issueId: result.lastInsertRowid };
+    } catch (e) {
+      throw new Error(`Failed to create issue: ${e.message}`);
+    }
+  }

--- a/src/orchestrator/lifecycle.js
+++ b/src/orchestrator/lifecycle.js
@@ -1,0 +1,189 @@
+import fs from 'fs';
+import path from 'path';
+
+export function getStatus(runner, deps = {}) {
+    return {
+      id: runner.id,
+      path: runner.path,
+      repo: runner.repo,
+      enabled: runner.enabled,
+      archived: runner.archived,
+      running: runner.running,
+      paused: runner.isPaused,
+      pauseReason: runner.pauseReason || null,
+      cycleCount: runner.cycleCount,
+      epochCount: runner.epochCount,
+      currentAgent: runner.currentAgent,
+      currentAgentModel: runner.currentAgentModel,
+      currentAgentKeyId: runner.currentAgentKeyId || null,
+      currentAgentVisibility: runner.currentAgentVisibility || { mode: 'full', issues: [] },
+      currentAgentRuntime: runner.currentAgentStartTime
+        ? Math.floor((Date.now() - runner.currentAgentStartTime) / 1000)
+        : null,
+      sleeping: runner.sleepUntil !== null && !runner.isPaused,
+      sleepUntil: runner.isPaused ? null : runner.sleepUntil,
+      schedule: runner.currentSchedule || null,
+      phase: runner.phase,
+      milestoneTitle: runner.milestoneTitle,
+      milestone: runner.milestoneDescription,
+      milestoneCyclesBudget: runner.milestoneCyclesBudget,
+      milestoneCyclesUsed: runner.milestoneCyclesUsed,
+      currentMilestoneId: runner.currentMilestoneId,
+      pendingMilestoneId: runner.pendingMilestoneId,
+      currentEpochId: runner.currentEpochId,
+      currentEpochPrId: runner.currentEpochPrId,
+      currentMilestoneBranch: runner.currentMilestoneBranch,
+      lastMergedMilestoneBranch: runner.lastMergedMilestoneBranch,
+      isFixRound: runner.isFixRound,
+      isComplete: runner.isComplete || false,
+      completionSuccess: runner.completionSuccess || false,
+      completionMessage: runner.completionMessage || null,
+      config: runner.loadConfig(),
+      agents: runner.loadAgents(),
+      cost: runner.getCostSummary(),
+      budget: runner.getBudgetStatus()
+    };
+  }
+
+export function bootstrapPreview(runner, deps = {}) {
+    const projectDataExists = fs.existsSync(runner.projectDir);
+    let projectDataContents = [];
+    if (projectDataExists) {
+      projectDataContents = fs.readdirSync(runner.projectDir).filter(name => !['repo', 'knowledge', 'skills', 'config.yaml'].includes(name));
+    }
+    // Read spec.md and check roadmap.md from private knowledge base
+    let specContent = null;
+    const specPath = path.join(runner.knowledgeDir, 'spec.md');
+    try { specContent = fs.readFileSync(specPath, 'utf-8'); } catch {}
+    const hasRoadmap = fs.existsSync(path.join(runner.knowledgeDir, 'roadmap.md'));
+    return { available: true, projectDataEmpty: projectDataContents.length === 0, repo: runner.repo, specContent, hasRoadmap };
+  }
+
+export function bootstrap(runner, deps = {}, options = {}) {
+    // 0. Kill any running agent and pause the project
+    if (runner.currentAgentProcess) {
+      try { runner.currentAgentProcess.kill('SIGKILL'); } catch {}
+      deps.log(`Killed running agent ${runner.currentAgent} for bootstrap`, runner.id);
+      runner.currentAgentProcess = null;
+      runner.currentAgent = null;
+      runner.currentAgentStartTime = null;
+      runner.currentAgentLog = [];
+      runner.currentAgentModel = null; runner.currentAgentCost = 0; runner.currentAgentUsage = null; runner.currentAgentKeyId = null; runner.currentAgentVisibility = null;
+    }
+    runner.isPaused = true;
+    runner.pauseReason = 'Bootstrapping';
+    runner.completedAgents = [];
+    runner.currentCycleId = null;
+    runner.currentSchedule = null;
+
+    // 1. Wipe project operational state only, keep repo/knowledge/skills intact
+    for (const target of runner.getOperationalPaths()) {
+      if (!fs.existsSync(target)) continue;
+      fs.rmSync(target, { recursive: true, force: true });
+    }
+    deps.log(`Cleared project operational state`, runner.id);
+    fs.mkdirSync(runner.projectDir, { recursive: true });
+
+    // 2. Reset cycle count, phase, and save state
+    runner.setState({
+      cycleCount: 0,
+      epochCount: 0,
+      phase: 'athena',
+      milestoneTitle: null,
+      milestoneDescription: null,
+      milestoneCyclesBudget: 0,
+      milestoneCyclesUsed: 0,
+      currentMilestoneId: null,
+      pendingMilestoneId: null,
+      currentEpochId: null,
+      currentEpochPrId: null,
+      currentMilestoneBranch: null,
+      aresGraceCycleUsed: false,
+      verificationFeedback: null,
+      examinationFeedback: null,
+      pendingCompletionMessage: null,
+      isFixRound: false,
+      isComplete: false,
+      completionSuccess: false,
+      completionMessage: null,
+      isPaused: true,
+      pauseReason: 'Bootstrapped — resume when ready',
+    });
+    deps.log(`Reset cycle count, project paused`, runner.id);
+
+    // 3. Remove roadmap.md from private knowledge base if requested
+    if (options.removeRoadmap) {
+      const roadmapPath = path.join(runner.knowledgeDir, 'roadmap.md');
+      if (fs.existsSync(roadmapPath)) {
+        try {
+          fs.unlinkSync(roadmapPath);
+          deps.log(`Removed private roadmap.md`, runner.id);
+        } catch (e) {
+          deps.log(`Warning: failed to remove private roadmap.md: ${e.message}`, runner.id);
+        }
+      }
+    }
+
+    // 4. Update private spec.md if requested
+    if (options.spec && options.spec.mode !== 'keep') {
+      const specPath = path.join(runner.knowledgeDir, 'spec.md');
+      let newContent = '';
+      if (options.spec.mode === 'edit') {
+        newContent = options.spec.content || '';
+      } else if (options.spec.mode === 'new') {
+        const what = (options.spec.whatToBuild || '').trim();
+        const criteria = (options.spec.successCriteria || '').trim();
+        newContent = `# Project Spec\n\n## What to Build\n\n${what}\n\n## Success Criteria\n\n${criteria}\n`;
+      }
+      if (newContent) {
+        try {
+          fs.writeFileSync(specPath, newContent);
+          deps.log(`Updated private knowledge/spec.md`, runner.id);
+        } catch (e) {
+          deps.log(`Warning: failed to update spec.md: ${e.message}`, runner.id);
+        }
+      }
+    }
+
+    return { bootstrapped: true };
+  }
+
+export async function runDoctor(runner, deps = {}) {
+    const config = runner.loadConfig();
+    const doctorAgent = { name: 'doctor', isManager: true, rawModel: 'high' };
+    const task = [
+      'Inspect this project and act only as an AI Doctor agent.',
+      '',
+      'Your job is to inspect and repair project layout drift. Do not rely on any built-in deterministic doctor behavior. You are the doctor.',
+      '',
+      'Canonical layout:',
+      '- repo/',
+      '- knowledge/',
+      '- skills/',
+      '- project.db',
+      '- orchestrator.log',
+      '- responses/',
+      '- agents/',
+      '',
+      'Required behavior:',
+      '- Inspect the actual filesystem.',
+      '- Repair missing or misplaced project files when it is safe.',
+      '- Ensure required directories and files exist after repair.',
+      '- If known agent directories under agents/ are missing, create them.',
+      '- Do not change product code in repo/ unless absolutely necessary for the repair itself.',
+      '- Prefer move/rename over copy when safe.',
+      '',
+      'At the end, write a concise doctor report with these sections exactly:',
+      '## Doctor Check',
+      'Layout status: ...',
+      '',
+      '### Required paths',
+      '- ...',
+      '',
+      '### Repair actions',
+      '- ...',
+      '',
+      'If something could not be fixed, say why clearly.',
+    ].join('\n');
+    return await runner.runAgent(doctorAgent, config, 'doctor', task, { mode: 'full', issues: [] });
+  }

--- a/tests/private-knowledge-base.test.js
+++ b/tests/private-knowledge-base.test.js
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const serverPath = path.join(__dirname, '..', 'src', 'orchestrator', 'ProjectRunner.js');
 const stateControlPath = path.join(__dirname, '..', 'src', 'orchestrator', 'state-control.js');
+const lifecyclePath = path.join(__dirname, '..', 'src', 'orchestrator', 'lifecycle.js');
 const athenaPath = path.join(__dirname, '..', 'agent', 'managers', 'athena.md');
 
 function read(file) {
@@ -22,14 +23,14 @@ describe('private knowledge base for spec, roadmap, and internal analysis docs',
   });
 
   it('bootstrap preview should read spec/roadmap from knowledge base, not repo root', () => {
-    const src = read(serverPath);
-    assert.doesNotMatch(src, /path\.join\(this\.path, 'spec\.md'\)/,
+    const src = `${read(serverPath)}\n${read(lifecyclePath)}`;
+    assert.doesNotMatch(src, /path\.join\((?:this|runner)\.path, 'spec\.md'\)/,
       'bootstrap preview should not read spec.md from the repo root');
-    assert.doesNotMatch(src, /path\.join\(this\.path, 'roadmap\.md'\)/,
+    assert.doesNotMatch(src, /path\.join\((?:this|runner)\.path, 'roadmap\.md'\)/,
       'bootstrap preview should not read roadmap.md from the repo root');
-    assert.match(src, /path\.join\(this\.knowledgeDir, 'spec\.md'\)/,
+    assert.match(src, /path\.join\((?:this|runner)\.knowledgeDir, 'spec\.md'\)/,
       'bootstrap preview should read spec.md from private knowledge dir');
-    assert.match(src, /path\.join\(this\.knowledgeDir, 'roadmap\.md'\)/,
+    assert.match(src, /path\.join\((?:this|runner)\.knowledgeDir, 'roadmap\.md'\)/,
       'bootstrap preview should read roadmap.md from private knowledge dir');
   });
 

--- a/tests/worker-skills-path.test.js
+++ b/tests/worker-skills-path.test.js
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const serverPath = path.join(__dirname, '..', 'src', 'orchestrator', 'ProjectRunner.js');
+const stateControlPath = path.join(__dirname, '..', 'src', 'orchestrator', 'state-control.js');
 const managerPromptPath = path.join(__dirname, '..', 'agent', 'manager.md');
 const everyonePromptPath = path.join(__dirname, '..', 'agent', 'everyone.md');
 
@@ -23,9 +24,9 @@ describe('worker skill directory layout', () => {
 
 
   it('creates the new skills/workers control-plane directories at startup', () => {
-    const src = read(serverPath);
-    assert.ok(src.includes("this.workerSkillsDir"), 'Expected startup to create skills/workers');
-    assert.ok(src.includes("this.agentsDir"), 'Expected startup to create agent directories');
+    const src = `${read(serverPath)}\n${read(stateControlPath)}`;
+    assert.ok(/(?:this|runner)\.workerSkillsDir/.test(src), 'Expected startup to create skills/workers');
+    assert.ok(/(?:this|runner)\.agentsDir/.test(src), 'Expected startup to create agent directories');
   });
 
   it('keeps manager-facing prompts on skills/workers', () => {


### PR DESCRIPTION
## Summary
- Extract agent runtime/post-processing into `agent-runtime.js`
- Extract budget/sleep calculations into `budget.js`
- Extract issue helpers into `issues.js`
- Extract status/bootstrap/doctor lifecycle helpers into `lifecycle.js`
- Keep `ProjectRunner` as a thin delegating shell (~453 LOC)

## Verification
- `node --check src/orchestrator/ProjectRunner.js`
- `node --check src/orchestrator/{budget,issues,lifecycle,agent-runtime}.js`
- `npm test`
- `npm --prefix monitor run build`
- `git diff --check`