### PR TITLE
Fix phase-machine broadcast event crash

### DIFF
--- a/src/orchestrator/ProjectRunner.js
+++ b/src/orchestrator/ProjectRunner.js
@@ -426,7 +426,7 @@ class ProjectRunner {
   }
 
   async runLoop() {
-    return runRunnerLoop(this, { getKeyPoolSafe, log, sleep });
+    return runRunnerLoop(this, { broadcastEvent, getKeyPoolSafe, log, sleep });
   }
 
   // Build the full prompt for an agent (shared across CLI and API paths)

--- a/src/orchestrator/phase-machine.js
+++ b/src/orchestrator/phase-machine.js
@@ -1,4 +1,5 @@
 export async function runRunnerLoop(runner, deps = {}) {
+    const broadcastEvent = deps.broadcastEvent || (() => {});
     while (runner.running) {
       while (runner.isPaused && runner.running) {
         await deps.sleep(1000);

--- a/tests/phase-machine-broadcast.test.js
+++ b/tests/phase-machine-broadcast.test.js
@@ -1,0 +1,33 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function readSource(relativePath) {
+  return fs.readFileSync(path.join(__dirname, '..', relativePath), 'utf-8');
+}
+
+describe('phase-machine broadcast event dependency', () => {
+  it('binds broadcastEvent from deps before phase transitions use it', () => {
+    const src = readSource('src/orchestrator/phase-machine.js');
+
+    assert.match(
+      src,
+      /const\s+broadcastEvent\s*=\s*deps\.broadcastEvent\s*\|\|\s*\(\(\)\s*=>\s*\{\}\);/,
+      'runRunnerLoop should bind broadcastEvent from deps with a no-op fallback'
+    );
+  });
+
+  it('passes broadcastEvent into runRunnerLoop from ProjectRunner', () => {
+    const src = readSource('src/orchestrator/ProjectRunner.js');
+
+    assert.match(
+      src,
+      /runRunnerLoop\(this,\s*\{[^}]*broadcastEvent[^}]*\}\)/s,
+      'ProjectRunner.runLoop should pass broadcastEvent into phase-machine deps'
+    );
+  });
+});


### PR DESCRIPTION
## Summary\n- pass `broadcastEvent` into `runRunnerLoop` from `ProjectRunner`\n- bind `broadcastEvent` from phase-machine deps with a no-op fallback\n- add a regression test for the dependency wiring\n\nFixes #202.\n\n## Verification\n- `node --test tests/phase-machine-broadcast.test.js`\n- `git diff --check`\n\n## Blast radius check\nFull-suite attempt surfaced unrelated prompt-test failures on current main; tracked separately in #203.\n