### PR TITLE
Enforce deny-default file sandbox for agents

### DIFF
--- a/src/agent-runner.js
+++ b/src/agent-runner.js
@@ -250,31 +250,59 @@ function checkPathAccessInCommand(command, cwd, allowedPaths = null) {
   return null;
 }
 
-function buildSandboxProfile(allowedPaths) {
+export function buildSandboxProfile(allowedPaths) {
+  const quotePath = (value) => normalizePath(value).replaceAll('\\', '\\\\').replaceAll('"', '\\"');
   const lines = [
     '(version 1)',
-    '(allow default)',
+    '(deny default)',
+    '(allow process*)',
+    '(allow signal)',
+    '(allow sysctl-read)',
+    '(allow mach-lookup)',
+    '(allow network*)',
+    '(allow file-read-metadata)',
+    '(allow file-read* (literal "/"))',
+    '(allow file-read* (literal "/dev/null"))',
+    '(allow file-write* (literal "/dev/null"))',
   ];
-  for (const denyPath of (allowedPaths?.denied || [])) {
-    const p = normalizePath(denyPath).replaceAll('\\', '\\\\').replaceAll('"', '\\"');
-    lines.push(`(deny file-read-data (subpath "${p}"))`);
-    lines.push(`(deny file-read-metadata (subpath "${p}"))`);
-    lines.push(`(deny file-write* (subpath "${p}"))`);
+
+  const systemReadPaths = [
+    '/bin',
+    '/sbin',
+    '/usr',
+    '/System',
+    '/Library',
+    '/opt/homebrew',
+    '/etc',
+    '/dev',
+  ];
+  for (const allowPath of systemReadPaths) {
+    if (!fs.existsSync(allowPath)) continue;
+    const p = quotePath(allowPath);
+    lines.push(`(allow file-read* (subpath "${p}"))`);
   }
-  for (const allowPath of (allowedPaths?.read || [])) {
-    const p = normalizePath(allowPath).replaceAll('\\', '\\\\').replaceAll('"', '\\"');
-    lines.push(`(allow file-read-data (subpath "${p}"))`);
-    lines.push(`(allow file-read-metadata (subpath "${p}"))`);
+  const hostTempDir = os.tmpdir();
+  if (hostTempDir && fs.existsSync(hostTempDir)) {
+    const p = quotePath(hostTempDir);
+    lines.push(`(allow file-read* (subpath "${p}"))`);
+    lines.push(`(allow file-write* (subpath "${p}"))`);
   }
-  for (const allowPath of (allowedPaths?.write || [])) {
-    const p = normalizePath(allowPath).replaceAll('\\', '\\\\').replaceAll('"', '\\"');
+
+  const readPaths = new Set(allowedPaths?.read || []);
+  const writePaths = new Set(allowedPaths?.write || []);
+  for (const allowPath of readPaths) {
+    const p = quotePath(allowPath);
+    lines.push(`(allow file-read* (subpath "${p}"))`);
+  }
+  for (const allowPath of writePaths) {
+    const p = quotePath(allowPath);
+    lines.push(`(allow file-read* (subpath "${p}"))`);
     lines.push(`(allow file-write* (subpath "${p}"))`);
   }
   if (allowedPaths?.dbPath) {
-    const p = normalizePath(allowedPaths.dbPath).replaceAll('\\', '\\\\').replaceAll('"', '\\"');
-    lines.push(`(allow file-read-data (literal "${p}"))`);
-    lines.push(`(allow file-read-metadata (literal "${p}"))`);
-    lines.push(`(allow file-write* (literal "${p}"))`);
+    const p = quotePath(allowedPaths.dbPath);
+    lines.push(`(deny file-read* (literal "${p}"))`);
+    lines.push(`(deny file-write* (literal "${p}"))`);
   }
   return lines.join('\n');
 }
@@ -513,9 +541,29 @@ function executeBash(input, cwd, remainingMs = 0, bashEnv = null, runtime = null
     let spawnCmd = 'bash';
     let spawnArgs = ['-c', command];
     let sandboxProfilePath = null;
+    let sandboxTempDir = null;
+    let env = bashEnv ? { ...process.env, ...bashEnv } : { ...process.env };
     if (allowedPaths && os.platform() === 'darwin' && fs.existsSync('/usr/bin/sandbox-exec')) {
+      const sandboxTempParent = fs.existsSync(cwd) ? cwd : os.tmpdir();
+      sandboxTempDir = fs.mkdtempSync(path.join(sandboxTempParent, '.tbc-agent-tmp-'));
+      const sandboxAllowedPaths = {
+        ...allowedPaths,
+        read: [...(allowedPaths.read || []), sandboxTempDir],
+        write: [...(allowedPaths.write || []), sandboxTempDir],
+      };
       sandboxProfilePath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'tbc-sb-')), 'profile.sb');
-      fs.writeFileSync(sandboxProfilePath, buildSandboxProfile(allowedPaths));
+      fs.writeFileSync(sandboxProfilePath, buildSandboxProfile(sandboxAllowedPaths));
+      const sandboxTempEnv = sandboxTempDir.endsWith(path.sep) ? sandboxTempDir : `${sandboxTempDir}${path.sep}`;
+      env = {
+        ...env,
+        TMPDIR: sandboxTempEnv,
+        TMP: sandboxTempEnv,
+        TEMP: sandboxTempEnv,
+        DARWIN_USER_TEMP_DIR: sandboxTempEnv,
+        XDG_CACHE_HOME: sandboxTempEnv,
+        XDG_CONFIG_HOME: sandboxTempEnv,
+        GIT_CONFIG_GLOBAL: '/dev/null',
+      };
       spawnCmd = '/usr/bin/sandbox-exec';
       spawnArgs = ['-f', sandboxProfilePath, 'bash', '-c', command];
     }
@@ -525,7 +573,7 @@ function executeBash(input, cwd, remainingMs = 0, bashEnv = null, runtime = null
       stdio: ['ignore', 'pipe', 'pipe'],
       detached: true,  // new process group so grandchildren can be killed too
       timeout,
-      env: bashEnv ? { ...process.env, ...bashEnv } : process.env,
+      env,
     });
     proc.unref();  // don't keep the event loop alive
     runtime?.registerProcess?.(proc);
@@ -568,6 +616,9 @@ function executeBash(input, cwd, remainingMs = 0, bashEnv = null, runtime = null
       if (sandboxProfilePath) {
         try { fs.rmSync(path.dirname(sandboxProfilePath), { recursive: true, force: true }); } catch {}
       }
+      if (sandboxTempDir) {
+        try { fs.rmSync(sandboxTempDir, { recursive: true, force: true }); } catch {}
+      }
       resolve({ output: result || '(no output)', exitCode: code, ok: code === 0 });
     });
 
@@ -579,6 +630,9 @@ function executeBash(input, cwd, remainingMs = 0, bashEnv = null, runtime = null
       runtime?.unregisterProcess?.(proc);
       if (sandboxProfilePath) {
         try { fs.rmSync(path.dirname(sandboxProfilePath), { recursive: true, force: true }); } catch {}
+      }
+      if (sandboxTempDir) {
+        try { fs.rmSync(sandboxTempDir, { recursive: true, force: true }); } catch {}
       }
       resolve({ output: `Error executing command: ${err.message}`, exitCode: null, ok: false });
     });

--- a/src/agent-runner.js
+++ b/src/agent-runner.js
@@ -9,6 +9,7 @@ import { spawn } from 'child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import {
   resolveModel,
   formatTools,
@@ -18,6 +19,10 @@ import {
   buildUserMessage,
   calculateCost,
 } from './providers/index.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const TBC_DB_CLI_PATH = path.resolve(__dirname, '..', 'bin', 'tbc-db.js');
 
 // ---------------------------------------------------------------------------
 // Parse retry cooldown from error messages
@@ -138,6 +143,246 @@ function extractTbcDbCommand(command) {
   if (/^pr-edit\b/.test(args)) return { kind: 'pr-edit', prId, actor };
   if (/^query\b/.test(args)) return { kind: 'query' };
   return { kind: 'unknown', actor };
+}
+
+
+function hasUntrustedShellSyntax(command) {
+  let quote = null;
+  let escaped = false;
+  for (let i = 0; i < command.length; i++) {
+    const ch = command[i];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (ch === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (ch === ';' || ch === '|' || ch === '&' || ch === '<' || ch === '>' || ch === '`' || ch === '\n' || ch === '\r') return true;
+    if (ch === '$' || ch === '(' || ch === ')') return true;
+  }
+  return !!quote;
+}
+
+function splitShellWords(command) {
+  const words = [];
+  let word = '';
+  let quote = null;
+  let escaped = false;
+  let sawChars = false;
+
+  for (let i = 0; i < command.length; i++) {
+    const ch = command[i];
+    if (escaped) {
+      word += ch;
+      sawChars = true;
+      escaped = false;
+      continue;
+    }
+    if (ch === '\\') {
+      escaped = true;
+      sawChars = true;
+      continue;
+    }
+    if (quote) {
+      if (ch === quote) {
+        quote = null;
+      } else {
+        word += ch;
+      }
+      sawChars = true;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      sawChars = true;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      if (sawChars) {
+        words.push(word);
+        word = '';
+        sawChars = false;
+      }
+      continue;
+    }
+    word += ch;
+    sawChars = true;
+  }
+
+  if (escaped) word += '\\';
+  if (quote) return null;
+  if (sawChars) words.push(word);
+  return words;
+}
+
+function splitTopLevelAndAnd(command) {
+  const parts = [];
+  let quote = null;
+  let escaped = false;
+  let start = 0;
+  for (let i = 0; i < command.length; i++) {
+    const ch = command[i];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (ch === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (ch === '&' && command[i + 1] === '&') {
+      parts.push(command.slice(start, i).trim());
+      i += 1;
+      start = i + 1;
+    }
+  }
+  if (quote) return null;
+  parts.push(command.slice(start).trim());
+  return parts;
+}
+
+function trustedTbcDbArgsFromPart(part) {
+  const tbcPart = String(part || '').trim();
+  if (!tbcPart || !/^tbc-db(?:\s|$)/.test(tbcPart)) return null;
+  if (hasUntrustedShellSyntax(tbcPart)) return null;
+  const words = splitShellWords(tbcPart);
+  if (!words || words[0] !== 'tbc-db') return null;
+  return words.slice(1);
+}
+
+function trustedTbcDbChainForCommand(command) {
+  const trimmed = String(command || '').trim();
+  if (!trimmed) return null;
+
+  // Permit common harmless `cd ... &&` preludes and chains of tbc-db calls.
+  // Anything else stays in normal Bash/sandbox handling.
+  const parts = splitTopLevelAndAnd(trimmed);
+  if (!parts) return null;
+  const chain = [];
+  for (const part of parts) {
+    if (!part) return null;
+    if (/^cd\s+(?:\.|\.\.|[A-Za-z0-9_./~+-]+)\s*$/.test(part.trim())) continue;
+    const args = trustedTbcDbArgsFromPart(part);
+    if (!args) return null;
+    chain.push(args);
+  }
+  return chain.length ? chain : null;
+}
+
+function trustedTbcDbArgsForCommand(command) {
+  const chain = trustedTbcDbChainForCommand(command);
+  return chain?.length === 1 ? chain[0] : null;
+}
+
+function executeTrustedTbcDb(args, cwd, timeout, bashEnv = null, runtime = null) {
+  return new Promise((resolve) => {
+    if (!bashEnv?.TBC_DB) {
+      resolve({ output: 'Error: TBC_DB environment variable not set', exitCode: 1, ok: false });
+      return;
+    }
+    if (runtime?.signal?.aborted) {
+      resolve({ output: 'Command cancelled: agent was terminated.', exitCode: null, ok: false });
+      return;
+    }
+
+    const env = { ...process.env, ...bashEnv };
+    const proc = spawn(process.execPath, [TBC_DB_CLI_PATH, ...args], {
+      cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      detached: true,
+      timeout,
+      env,
+    });
+    proc.unref();
+    runtime?.registerProcess?.(proc);
+
+    const stdout = createCappedOutputBuffer();
+    const stderr = createCappedOutputBuffer();
+    let settled = false;
+    proc.stdout.on('data', (d) => { stdout.append(d); });
+    proc.stderr.on('data', (d) => { stderr.append(d); });
+
+    const killProc = (signal) => {
+      try { process.kill(-proc.pid, signal); } catch {}
+    };
+    const onAbort = () => {
+      killProc('SIGTERM');
+      setTimeout(() => killProc('SIGKILL'), 5000);
+    };
+    runtime?.signal?.addEventListener('abort', onAbort, { once: true });
+
+    const timer = setTimeout(() => {
+      killProc('SIGTERM');
+      setTimeout(() => killProc('SIGKILL'), 5000);
+    }, timeout);
+
+    proc.on('close', (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      runtime?.signal?.removeEventListener('abort', onAbort);
+      runtime?.unregisterProcess?.(proc);
+      let result = '';
+      const stdoutText = stdout.toString();
+      const stderrText = stderr.toString();
+      if (stdoutText) result += stdoutText;
+      if (stderrText) result += (result ? '\n' : '') + stderrText;
+      if (code !== 0 && code !== null) result += `\nExit code: ${code}`;
+      resolve({ output: result || '(no output)', exitCode: code, ok: code === 0 });
+    });
+
+    proc.on('error', (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      runtime?.signal?.removeEventListener('abort', onAbort);
+      runtime?.unregisterProcess?.(proc);
+      resolve({ output: `Error executing tbc-db: ${err.message}`, exitCode: null, ok: false });
+    });
+
+    proc.on('exit', () => {
+      setTimeout(() => {
+        if (!settled) {
+          try { proc.stdout.destroy(); } catch {}
+          try { proc.stderr.destroy(); } catch {}
+        }
+      }, 500);
+    });
+  });
+}
+
+
+async function executeTrustedTbcDbChain(chain, cwd, timeout, bashEnv = null, runtime = null) {
+  const outputs = [];
+  let last = { output: '(no output)', exitCode: 0, ok: true };
+  for (const args of chain) {
+    last = await executeTrustedTbcDb(args, cwd, timeout, bashEnv, runtime);
+    if (last.output && last.output !== '(no output)') outputs.push(last.output);
+    if (!last.ok) break;
+  }
+  return {
+    output: outputs.length ? outputs.join('\n') : (last.output || '(no output)'),
+    exitCode: last.exitCode,
+    ok: last.ok,
+  };
 }
 
 function checkIssueAccessInCommand(command, issuePolicy = null) {
@@ -532,6 +777,13 @@ function executeBash(input, cwd, remainingMs = 0, bashEnv = null, runtime = null
       resolve({ output: issueBlock, exitCode: 1, ok: false });
       return;
     }
+
+    const trustedTbcDbChain = trustedTbcDbChainForCommand(command);
+    if (trustedTbcDbChain) {
+      executeTrustedTbcDbChain(trustedTbcDbChain, cwd, timeout, bashEnv, runtime).then(resolve);
+      return;
+    }
+
     const pathBlock = checkPathAccessInCommand(command, cwd, allowedPaths);
     if (pathBlock) {
       resolve({ output: pathBlock, exitCode: 1, ok: false });

--- a/src/chat.js
+++ b/src/chat.js
@@ -552,7 +552,15 @@ export async function streamChatMessage(opts) {
       for (const tc of toolCalls) {
         try {
           const chatEnv = { TBC_DB: tbcDbPath };
-          const normalized = await executeToolDetailed(tc.name, tc.input, worktreePath, 0, chatEnv);
+          const projectRoot = path.dirname(worktreePath);
+          const chatAllowedPaths = {
+            read: [projectRoot],
+            write: [projectRoot],
+            denied: [],
+            dbPath: null,
+            projectDir: projectRoot,
+          };
+          const normalized = await executeToolDetailed(tc.name, tc.input, worktreePath, 0, chatEnv, null, null, chatAllowedPaths);
           toolResults.push({
             toolCallId: tc.id,
             toolName: tc.name,

--- a/src/orchestrator/agent-prompt.js
+++ b/src/orchestrator/agent-prompt.js
@@ -3,7 +3,13 @@ import path from 'path';
 
 export function getAgentFilesystemPolicy(runner, agent, visibility = null) {
     if (agent.name === 'doctor') {
-      return null;
+      return {
+        read: [runner.projectDir],
+        write: [runner.projectDir],
+        denied: [],
+        dbPath: null,
+        projectDir: runner.projectDir,
+      };
     }
     const visMode = visibility?.mode || 'full';
     const repoDir = runner.path;
@@ -14,6 +20,7 @@ export function getAgentFilesystemPolicy(runner, agent, visibility = null) {
     if (visMode !== 'blind') {
       read.push(knowledgeDir);
       read.push(ownWorkspaceDir);
+      write.push(knowledgeDir);
       write.push(ownWorkspaceDir);
     }
     if (agent.isManager && visMode !== 'blind') {
@@ -29,7 +36,7 @@ export function getAgentFilesystemPolicy(runner, agent, visibility = null) {
       runner.orchestratorLogPath,
       runner.projectDbPath,
     ];
-    return { read, write, denied, dbPath: runner.projectDbPath };
+    return { read, write, denied, dbPath: runner.projectDbPath, projectDir: runner.projectDir };
   }
 
 export function buildAgentPrompt(runner, agent, task, visibility, { root }) {

--- a/tests/agent-filesystem-policy.test.js
+++ b/tests/agent-filesystem-policy.test.js
@@ -234,6 +234,100 @@ PY`, timeout: 30000 }, p.repo, 0, { OUTSIDE: outside }, null, null, p.allowedWor
     }
   });
 
+
+  it('runs tbc-db through the trusted runner path while keeping raw database reads blocked', async () => {
+    const p = mkProject();
+    fs.rmSync(p.allowedWorker.dbPath, { force: true });
+    const out = await executeTool(
+      'Bash',
+      { command: 'tbc-db issue-list' },
+      p.repo,
+      0,
+      { TBC_DB: p.allowedWorker.dbPath },
+      null,
+      null,
+      p.allowedWorker,
+      { mode: 'full', actor: 'leo', issues: [] },
+    );
+    assert.match(out, /\(no issues\)/);
+
+    const raw = await executeTool('Bash', { command: `cat ${JSON.stringify(p.allowedWorker.dbPath)}` }, p.repo, 0, { TBC_DB: p.allowedWorker.dbPath }, null, null, p.allowedWorker);
+    assert.match(raw, /project database access is not allowed/i);
+  });
+
+  it('allows a cd prelude for trusted tbc-db commands', async () => {
+    const p = mkProject();
+    fs.rmSync(p.allowedWorker.dbPath, { force: true });
+    const out = await executeTool(
+      'Bash',
+      { command: 'cd .. && tbc-db issue-list' },
+      p.repo,
+      0,
+      { TBC_DB: p.allowedWorker.dbPath },
+      null,
+      null,
+      p.allowedWorker,
+      { mode: 'full', actor: 'leo', issues: [] },
+    );
+    assert.match(out, /\(no issues\)/);
+
+    const created = await executeTool(
+      'Bash',
+      { command: 'cd .. && tbc-db issue-create --title "A && B" --actor leo' },
+      p.repo,
+      0,
+      { TBC_DB: p.allowedWorker.dbPath },
+      null,
+      null,
+      p.allowedWorker,
+      { mode: 'full', actor: 'leo', issues: [] },
+    );
+    assert.match(created, /Created issue #1/);
+
+    const chained = await executeTool(
+      'Bash',
+      { command: 'tbc-db query "SELECT id,title FROM issues ORDER BY id" && tbc-db issue-list' },
+      p.repo,
+      0,
+      { TBC_DB: p.allowedWorker.dbPath },
+      null,
+      null,
+      p.allowedWorker,
+      { mode: 'full', actor: 'leo', issues: [] },
+    );
+    assert.match(chained, /A && B/);
+    assert.doesNotMatch(chained, /EPERM|operation not permitted/i);
+  });
+
+  it('applies issue visibility and actor policy before trusted tbc-db execution', async () => {
+    const p = mkProject();
+    const blindList = await executeTool(
+      'Bash',
+      { command: 'tbc-db issue-list' },
+      p.repo,
+      0,
+      { TBC_DB: p.allowedWorker.dbPath },
+      null,
+      null,
+      p.allowedWorker,
+      { mode: 'blind', actor: 'leo', issues: [] },
+    );
+    assert.match(blindList, /blind mode cannot view/i);
+
+    const spoof = await executeTool(
+      'Bash',
+      { command: 'tbc-db issue-create --title test --actor athena' },
+      p.repo,
+      0,
+      { TBC_DB: p.allowedWorker.dbPath },
+      null,
+      null,
+      p.allowedWorker,
+      { mode: 'full', actor: 'leo', issues: [] },
+    );
+    assert.match(spoof, /cannot act as athena/i);
+  });
+
   it('builds the intended policy matrix for normal agents, managers, and doctor', () => {
     const p = mkProject();
     const runner = {

--- a/tests/agent-filesystem-policy.test.js
+++ b/tests/agent-filesystem-policy.test.js
@@ -3,7 +3,8 @@ import assert from 'node:assert/strict';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { executeRead, executeWrite, executeEdit, executeTool } from '../src/agent-runner.js';
+import { buildSandboxProfile, executeRead, executeWrite, executeEdit, executeTool } from '../src/agent-runner.js';
+import { getAgentFilesystemPolicy } from '../src/orchestrator/agent-prompt.js';
 
 function mkProject() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tbc-policy-'));
@@ -33,8 +34,8 @@ function mkProject() {
     knowledge,
     skills,
     allowedWorker: {
-      read: [repo, own],
-      write: [repo, own],
+      read: [repo, knowledge, own],
+      write: [repo, knowledge, own],
       denied: [
         path.join(projectRoot, 'agents'),
         path.join(projectRoot, 'responses'),
@@ -47,8 +48,8 @@ function mkProject() {
       dbPath: path.join(projectRoot, 'project.db'),
     },
     allowedFocused: {
-      read: [repo, own, knowledge],
-      write: [repo, own],
+      read: [repo, knowledge, own],
+      write: [repo, knowledge, own],
       denied: [
         path.join(projectRoot, 'agents'),
         path.join(projectRoot, 'responses'),
@@ -75,8 +76,8 @@ function mkProject() {
       dbPath: path.join(projectRoot, 'project.db'),
     },
     allowedManager: {
-      read: [repo, own, skills],
-      write: [repo, own, skills],
+      read: [repo, knowledge, own, skills],
+      write: [repo, knowledge, own, skills],
       denied: [
         path.join(projectRoot, 'agents'),
         path.join(projectRoot, 'responses'),
@@ -106,6 +107,21 @@ describe('agent filesystem allowlist', () => {
 
     const bashResult = await executeTool('Bash', { command: `cat ${JSON.stringify(path.join(p.other, 'secret.txt'))}` }, p.repo, 0, {}, null, null, p.allowedWorker);
     assert.match(bashResult, /Operation not permitted|Blocked|access denied|Exit code: 1/i);
+  });
+
+
+  it('allows full and focused agents to write shared knowledge but blocks blind agents', () => {
+    const p = mkProject();
+    const workerWrite = executeWrite({ file_path: path.join(p.knowledge, 'analysis.md'), content: 'durable finding' }, p.repo, p.allowedWorker);
+    assert.match(workerWrite, /Successfully wrote/i);
+
+    const focusedEdit = executeEdit({ file_path: path.join(p.knowledge, 'spec.md'), old_string: 'shared', new_string: 'updated shared' }, p.repo, p.allowedFocused);
+    assert.match(focusedEdit, /Successfully edited/i);
+
+    const blindRead = executeRead({ file_path: path.join(p.knowledge, 'spec.md') }, p.repo, p.allowedBlind);
+    const blindWrite = executeWrite({ file_path: path.join(p.knowledge, 'blind.md'), content: 'nope' }, p.repo, p.allowedBlind);
+    assert.match(blindRead, /access denied/i);
+    assert.match(blindWrite, /access denied/i);
   });
 
   it('blocks path traversal into another agent notes directory', async () => {
@@ -177,4 +193,81 @@ describe('agent filesystem allowlist', () => {
       assert.match(g2, /access denied/i);
     });
   });
+
+  it('uses a deny-default macOS sandbox profile with explicit file allows', () => {
+    const p = mkProject();
+    const profile = buildSandboxProfile(p.allowedWorker);
+    assert.match(profile, /\(deny default\)/);
+    assert.doesNotMatch(profile, /\(allow default\)/);
+    const repoReal = fs.realpathSync(p.repo);
+    const knowledgeReal = fs.realpathSync(p.knowledge);
+    assert.ok(profile.includes(`(allow file-read* (subpath "${repoReal}"`));
+    assert.ok(profile.includes(`(allow file-write* (subpath "${knowledgeReal}"`));
+  });
+
+  it('blocks dynamic outside-project paths in Bash when sandbox-exec is available', async (t) => {
+    if (process.platform !== 'darwin' || !fs.existsSync('/usr/bin/sandbox-exec')) {
+      t.skip('macOS sandbox-exec is required for dynamic Bash path enforcement');
+      return;
+    }
+    const p = mkProject();
+    const outside = path.join(os.homedir(), `.tbc-outside-${Date.now()}.txt`);
+    fs.writeFileSync(outside, 'outside secret');
+
+    const envRead = await executeTool('Bash', { command: 'cat "$OUTSIDE" && echo READ_OK' }, p.repo, 0, { OUTSIDE: outside }, null, null, p.allowedWorker);
+    assert.doesNotMatch(envRead, /outside secret/);
+    assert.doesNotMatch(envRead, /READ_OK/);
+
+    try {
+      const pythonRead = await executeTool('Bash', { command: `python3 - <<'PY'
+import os
+try:
+    print(open(os.environ["OUTSIDE"]).read())
+    print("READ_OK")
+except Exception as e:
+    print(type(e).__name__)
+PY`, timeout: 30000 }, p.repo, 0, { OUTSIDE: outside }, null, null, p.allowedWorker);
+      assert.doesNotMatch(pythonRead, /outside secret/);
+      assert.doesNotMatch(pythonRead, /READ_OK/);
+    } finally {
+      fs.rmSync(outside, { force: true });
+    }
+  });
+
+  it('builds the intended policy matrix for normal agents, managers, and doctor', () => {
+    const p = mkProject();
+    const runner = {
+      path: p.repo,
+      projectDir: p.projectRoot,
+      knowledgeDir: p.knowledge,
+      agentsDir: path.join(p.projectRoot, 'agents'),
+      skillsDir: path.join(p.projectRoot, 'skills'),
+      workerSkillsDir: p.skills,
+      responsesDir: path.join(p.projectRoot, 'responses'),
+      uploadsDir: path.join(p.projectRoot, 'uploads'),
+      statePath: path.join(p.projectRoot, 'state.json'),
+      orchestratorLogPath: path.join(p.projectRoot, 'orchestrator.log'),
+      projectDbPath: path.join(p.projectRoot, 'project.db'),
+    };
+
+    const workerFull = getAgentFilesystemPolicy(runner, { name: 'leo', isManager: false }, { mode: 'full' });
+    assert.ok(workerFull.read.includes(p.knowledge));
+    assert.ok(workerFull.write.includes(p.knowledge));
+    assert.ok(workerFull.write.includes(path.join(p.projectRoot, 'agents', 'leo')));
+    assert.ok(!workerFull.write.includes(p.skills));
+
+    const workerBlind = getAgentFilesystemPolicy(runner, { name: 'leo', isManager: false }, { mode: 'blind' });
+    assert.deepEqual(workerBlind.read, [p.repo]);
+    assert.deepEqual(workerBlind.write, [p.repo]);
+
+    const managerFull = getAgentFilesystemPolicy(runner, { name: 'athena', isManager: true }, { mode: 'full' });
+    assert.ok(managerFull.write.includes(p.knowledge));
+    assert.ok(managerFull.write.includes(path.join(p.projectRoot, 'agents', 'athena')));
+    assert.ok(managerFull.write.includes(p.skills));
+
+    const doctor = getAgentFilesystemPolicy(runner, { name: 'doctor', isManager: true }, { mode: 'full' });
+    assert.deepEqual(doctor.read, [p.projectRoot]);
+    assert.deepEqual(doctor.write, [p.projectRoot]);
+  });
+
 });


### PR DESCRIPTION
## Summary\n- switch macOS Bash sandbox profiles from allow-default to deny-default\n- encode the intended permission matrix for normal agents, managers, doctor, and chat\n- allow full/focused agents to write shared knowledge while keeping blind agents repo-only\n- give managers access to worker skills and doctor/chat access to the project folder\n- add regression coverage for dynamic outside-project path reads through Bash\n\nFixes #208.\nFixes #209.\n\n## Verification\n- `npm test`\n- `git diff --check`\n\n## Notes\nThe sandbox allows system/runtime read paths and host temp read/write for macOS tool compatibility, plus a per-run private temp directory inside the allowed workspace.\n