### PR TITLE
Fix sandboxed SQLite sidecar access

### DIFF
--- a/src/agent-runner.js
+++ b/src/agent-runner.js
@@ -514,8 +514,15 @@ export function buildSandboxProfile(allowedPaths) {
     // Mixed shell commands may invoke the real tbc-db binary inside the
     // sandbox. Preflight command screening still blocks raw project.db paths
     // and $TBC_DB access, but the sanctioned CLI itself needs DB read/write.
+    // SQLite may also create adjacent rollback/WAL sidecar files while opening
+    // the database. Allow only those exact sidecars so sandboxed tbc-db calls
+    // do not fail with SQLITE_CANTOPEN.
     lines.push(`(allow file-read* (literal "${p}"))`);
     lines.push(`(allow file-write* (literal "${p}"))`);
+    for (const suffix of ['-journal', '-wal', '-shm']) {
+      lines.push(`(allow file-read* (literal "${p}${suffix}"))`);
+      lines.push(`(allow file-write* (literal "${p}${suffix}"))`);
+    }
   }
   return lines.join('\n');
 }

--- a/tests/agent-filesystem-policy.test.js
+++ b/tests/agent-filesystem-policy.test.js
@@ -203,6 +203,11 @@ describe('agent filesystem allowlist', () => {
     const knowledgeReal = fs.realpathSync(p.knowledge);
     assert.ok(profile.includes(`(allow file-read* (subpath "${repoReal}"`));
     assert.ok(profile.includes(`(allow file-write* (subpath "${knowledgeReal}"`));
+    const dbReal = fs.realpathSync(p.allowedWorker.dbPath);
+    for (const suffix of ['', '-journal', '-wal', '-shm']) {
+      assert.ok(profile.includes(`(allow file-read* (literal "${dbReal}${suffix}"))`));
+      assert.ok(profile.includes(`(allow file-write* (literal "${dbReal}${suffix}"))`));
+    }
   });
 
   it('blocks dynamic outside-project paths in Bash when sandbox-exec is available', async (t) => {


### PR DESCRIPTION
## Summary
- allow SQLite sidecar files next to the configured project DB in the macOS sandbox
- keep access scoped to exact project.db sidecar literals: -journal, -wal, -shm
- add sandbox profile regression coverage

## Test
- node --test tests/agent-filesystem-policy.test.js