### PR TITLE
Contain agent and runner exceptions

### DIFF
--- a/src/agent-runner.js
+++ b/src/agent-runner.js
@@ -248,6 +248,78 @@ function trustedTbcDbArgsForCommand(command) {
   return chain?.length === 1 ? chain[0] : null;
 }
 
+
+
+function splitTopLevelCommandSeparators(command) {
+  const parts = [];
+  let quote = null;
+  let escaped = false;
+  let start = 0;
+  for (let i = 0; i < command.length; i++) {
+    const ch = command[i];
+    if (escaped) { escaped = false; continue; }
+    if (ch === '\\') { escaped = true; continue; }
+    if (quote) { if (ch === quote) quote = null; continue; }
+    if (ch === '"' || ch === "'") { quote = ch; continue; }
+    if (ch === ';' || ch === '\n' || ch === '\r') {
+      parts.push(command.slice(start, i).trim());
+      start = i + 1;
+    }
+  }
+  parts.push(command.slice(start).trim());
+  return parts.filter(Boolean);
+}
+
+function stripTbcDbDecorators(part) {
+  let text = String(part || '').trim();
+  if (!text) return '';
+
+  // Agents frequently add display-only filters/redirections around tbc-db.
+  // The project database is intentionally denied inside the normal sandbox,
+  // so run the tbc-db portion through the trusted DB boundary and ignore the
+  // display decorator instead of leaking SQLITE_CANTOPEN back to the model.
+  const pipeIdx = findTopLevelToken(text, '|');
+  if (pipeIdx >= 0) text = text.slice(0, pipeIdx).trim();
+  text = text.replace(/\s+(?:\d?>&\d|\d?>[^\s]+|&>[^\s]+)\s*$/g, '').trim();
+  return text;
+}
+
+function findTopLevelToken(text, token) {
+  let quote = null;
+  let escaped = false;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (escaped) { escaped = false; continue; }
+    if (ch === '\\') { escaped = true; continue; }
+    if (quote) { if (ch === quote) quote = null; continue; }
+    if (ch === '"' || ch === "'") { quote = ch; continue; }
+    if (ch === token) return i;
+  }
+  return -1;
+}
+
+function trustedTbcDbLenientChainForCommand(command) {
+  const text = String(command || '').trim();
+  if (!text || !/\btbc-db(?:\s|$)/.test(text)) return null;
+
+  const segments = splitTopLevelCommandSeparators(text).flatMap(segment => splitTopLevelAndAnd(segment) || [segment]);
+  const chain = [];
+  for (const raw of segments) {
+    if (/^(?:set\s|echo\s|printf\s|rc=|ec=|exit\b|true\b|false\b|sleep\b|\[\s|test\s)/.test(raw)) continue;
+    if (/^cd\s+/.test(raw)) continue;
+    if (/^(?:for|while|if|then|do|done|fi)\b/.test(raw)) return null;
+
+    const tbcIdx = raw.search(/(?:^|\s)tbc-db(?:\s|$)/);
+    if (tbcIdx < 0) continue;
+    const tbcPart = stripTbcDbDecorators(raw.slice(tbcIdx).trim());
+    const args = trustedTbcDbArgsFromPart(tbcPart);
+    if (!args) return null;
+    chain.push(args);
+  }
+
+  return chain.length ? chain : null;
+}
+
 function executeTrustedTbcDb(args, cwd, timeout, bashEnv = null, runtime = null) {
   return new Promise((resolve) => {
     if (!bashEnv?.TBC_DB) {
@@ -741,12 +813,16 @@ function executeBash(input, cwd, remainingMs = 0, bashEnv = null, runtime = null
       return;
     }
 
-    const trustedTbcDbChain = trustedTbcDbChainForCommand(command);
+    const trustedTbcDbChain = trustedTbcDbChainForCommand(command) || trustedTbcDbLenientChainForCommand(command);
     if (trustedTbcDbChain) {
       executeTrustedTbcDbChain(trustedTbcDbChain, cwd, timeout, bashEnv, runtime).then(resolve);
       return;
     }
 
+    if (/\btbc-db(?:\s|$)/.test(command)) {
+      resolve({ output: 'Error: tbc-db must be run as a simple command so TBC can route it through the trusted project database boundary. Avoid shell loops, variables, command substitutions, and complex pipes around tbc-db.', exitCode: 1, ok: false });
+      return;
+    }
 
     const pathBlock = checkPathAccessInCommand(command, cwd, allowedPaths);
     if (pathBlock) {
@@ -1060,15 +1136,52 @@ function normalizeToolExecutionResult(toolName, result) {
   };
 }
 
-async function executeToolDetailed(toolName, toolInput, cwd, remainingMs = 0, bashEnv = null, runtime = null, allowedRepo = null, allowedPaths = null, issuePolicy = null) {
+function toolValidationError(toolName, message) {
+  return normalizeToolExecutionResult(toolName, `Error: invalid ${toolName} tool input: ${message}`);
+}
+
+function validateToolInput(toolName, input) {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    return 'input must be an object';
+  }
   switch (toolName) {
-    case 'Bash':  return normalizeToolExecutionResult('Bash', await executeBash(toolInput, cwd, remainingMs, bashEnv, runtime, allowedRepo, allowedPaths, issuePolicy));
-    case 'Read':  return normalizeToolExecutionResult('Read', executeRead(toolInput, cwd, allowedPaths));
-    case 'Write': return normalizeToolExecutionResult('Write', executeWrite(toolInput, cwd, allowedPaths));
-    case 'Edit':  return normalizeToolExecutionResult('Edit', executeEdit(toolInput, cwd, allowedPaths));
-    case 'Glob':  return normalizeToolExecutionResult('Glob', executeGlob(toolInput, cwd, allowedPaths));
-    case 'Grep':  return normalizeToolExecutionResult('Grep', executeGrep(toolInput, cwd, allowedPaths));
-    default:      return normalizeToolExecutionResult(toolName, `Unknown tool: ${toolName}`);
+    case 'Bash':
+      return typeof input.command === 'string' ? null : 'command must be a string';
+    case 'Read':
+      return typeof input.file_path === 'string' ? null : 'file_path must be a string';
+    case 'Write':
+      if (typeof input.file_path !== 'string') return 'file_path must be a string';
+      return typeof input.content === 'string' ? null : 'content must be a string';
+    case 'Edit':
+      if (typeof input.file_path !== 'string') return 'file_path must be a string';
+      if (typeof input.old_string !== 'string') return 'old_string must be a string';
+      return typeof input.new_string === 'string' ? null : 'new_string must be a string';
+    case 'Glob':
+      return typeof input.pattern === 'string' ? null : 'pattern must be a string';
+    case 'Grep':
+      return typeof input.pattern === 'string' ? null : 'pattern must be a string';
+    default:
+      return null;
+  }
+}
+
+async function executeToolDetailed(toolName, toolInput, cwd, remainingMs = 0, bashEnv = null, runtime = null, allowedRepo = null, allowedPaths = null, issuePolicy = null) {
+  const validationError = validateToolInput(toolName, toolInput);
+  if (validationError) return toolValidationError(toolName, validationError);
+
+  try {
+    switch (toolName) {
+      case 'Bash':  return normalizeToolExecutionResult('Bash', await executeBash(toolInput, cwd, remainingMs, bashEnv, runtime, allowedRepo, allowedPaths, issuePolicy));
+      case 'Read':  return normalizeToolExecutionResult('Read', executeRead(toolInput, cwd, allowedPaths));
+      case 'Write': return normalizeToolExecutionResult('Write', executeWrite(toolInput, cwd, allowedPaths));
+      case 'Edit':  return normalizeToolExecutionResult('Edit', executeEdit(toolInput, cwd, allowedPaths));
+      case 'Glob':  return normalizeToolExecutionResult('Glob', executeGlob(toolInput, cwd, allowedPaths));
+      case 'Grep':  return normalizeToolExecutionResult('Grep', executeGrep(toolInput, cwd, allowedPaths));
+      default:      return normalizeToolExecutionResult(toolName, `Unknown tool: ${toolName}`);
+    }
+  } catch (err) {
+    const message = err?.stack || err?.message || String(err);
+    return normalizeToolExecutionResult(toolName, `Tool error: ${message}`);
   }
 }
 

--- a/src/orchestrator/agent-runtime.js
+++ b/src/orchestrator/agent-runtime.js
@@ -199,58 +199,72 @@ export async function runAgentForRunner(runner, deps = {}, agent, config, mode =
     runner.currentAgentModel = tierLabel;
 
     const projectId = runner.id;
-    const result = await runAgentWithAPI({
-      prompt: skillContent,
-      model: agentModel,
-      token: resolvedToken,
-      keyType: resolvedKeyType,
-      provider: providerHint,
-      customConfig,
-      reasoningEffort,
-      cwd: runner.path,
-      timeoutMs: config.agentTimeoutMs || 0,
-      env: agentEnv,
-      allowedRepo: agent.name === 'doctor' ? null : (runner.repo || null),
-      allowedPaths: runner._getAgentFilesystemPolicy(agent, visibility),
-      issuePolicy: { ...(visibility || { mode: 'full', issues: [] }), actor: agent.name },
-      abortSignal: runAbortController.signal,
-      keyId: resolvedKeyId,
-      onRateLimited: (kid, cooldownMs) => markRateLimited(kid, cooldownMs || 5 * 60_000),
-      resolveNewToken: async () => {
-        const newKey = await resolveKeyForProject(config, null, oauthTokenGetter);
-        if (newKey?.provider) {
-          const newRuntimeSelection = deps.getProviderRuntimeSelection({
-            provider: newKey.provider,
-            modelTier: agentTierOrModel,
-            keyResult: newKey,
-            projectModels: null,
-          });
-          newKey.model = newRuntimeSelection.selectedModel;
-          newKey.reasoningEffort = newRuntimeSelection.reasoningEffort || null;
-          newKey.customConfig = newRuntimeSelection.customConfig || null;
-        }
-        if (newKey?.keyId) runner.currentAgentKeyId = newKey.keyId;
-        return newKey;
-      },
-      log: (msg) => {
-        deps.log(`  [${agent.name}] ${msg}`, projectId);
-        if (typeof msg === 'string' && msg.startsWith('Tool: ')) return;
-        const event = { time: Date.now(), type: 'thinking', content: String(msg) };
-        runner.currentAgentLog.push(event);
-        if (runner.currentAgentLog.length > 500) runner.currentAgentLog.shift();
-        deps.broadcastLiveAgentEvent(projectId, event);
-      },
-      onEvent: (event) => {
-        const enriched = { time: Date.now(), ...event };
-        runner.currentAgentLog.push(enriched);
-        if (runner.currentAgentLog.length > 500) runner.currentAgentLog.shift();
-        deps.broadcastLiveAgentEvent(projectId, enriched);
-      },
-      onProgress: ({ usage, cost }) => {
-        runner.currentAgentCost = cost;
-        runner.currentAgentUsage = usage;
-      },
-    });
+    let result;
+    try {
+      result = await runAgentWithAPI({
+        prompt: skillContent,
+        model: agentModel,
+        token: resolvedToken,
+        keyType: resolvedKeyType,
+        provider: providerHint,
+        customConfig,
+        reasoningEffort,
+        cwd: runner.path,
+        timeoutMs: config.agentTimeoutMs || 0,
+        env: agentEnv,
+        allowedRepo: agent.name === 'doctor' ? null : (runner.repo || null),
+        allowedPaths: runner._getAgentFilesystemPolicy(agent, visibility),
+        issuePolicy: { ...(visibility || { mode: 'full', issues: [] }), actor: agent.name },
+        abortSignal: runAbortController.signal,
+        keyId: resolvedKeyId,
+        onRateLimited: (kid, cooldownMs) => markRateLimited(kid, cooldownMs || 5 * 60_000),
+        resolveNewToken: async () => {
+          const newKey = await resolveKeyForProject(config, null, oauthTokenGetter);
+          if (newKey?.provider) {
+            const newRuntimeSelection = deps.getProviderRuntimeSelection({
+              provider: newKey.provider,
+              modelTier: agentTierOrModel,
+              keyResult: newKey,
+              projectModels: null,
+            });
+            newKey.model = newRuntimeSelection.selectedModel;
+            newKey.reasoningEffort = newRuntimeSelection.reasoningEffort || null;
+            newKey.customConfig = newRuntimeSelection.customConfig || null;
+          }
+          if (newKey?.keyId) runner.currentAgentKeyId = newKey.keyId;
+          return newKey;
+        },
+        log: (msg) => {
+          deps.log(`  [${agent.name}] ${msg}`, projectId);
+          if (typeof msg === 'string' && msg.startsWith('Tool: ')) return;
+          const event = { time: Date.now(), type: 'thinking', content: String(msg) };
+          runner.currentAgentLog.push(event);
+          if (runner.currentAgentLog.length > 500) runner.currentAgentLog.shift();
+          deps.broadcastLiveAgentEvent(projectId, event);
+        },
+        onEvent: (event) => {
+          const enriched = { time: Date.now(), ...event };
+          runner.currentAgentLog.push(enriched);
+          if (runner.currentAgentLog.length > 500) runner.currentAgentLog.shift();
+          deps.broadcastLiveAgentEvent(projectId, enriched);
+        },
+        onProgress: ({ usage, cost }) => {
+          runner.currentAgentCost = cost;
+          runner.currentAgentUsage = usage;
+        },
+      });
+    } catch (err) {
+      const message = err?.stack || err?.message || String(err);
+      deps.log(`Agent runner exception for ${agent.name}: ${message}`, runner.id);
+      result = {
+        success: false,
+        resultText: `Agent runner exception: ${message}`,
+        cost: runner.currentAgentCost || 0,
+        durationMs: Date.now() - runner.currentAgentStartTime,
+        timedOut: false,
+        usage: runner.currentAgentUsage || null,
+      };
+    }
 
     if (result.success && resolvedKeyId) {
       markKeySucceeded(resolvedKeyId);

--- a/src/orchestrator/state-control.js
+++ b/src/orchestrator/state-control.js
@@ -25,7 +25,23 @@ export async function startRunner(runner, deps = {}) {
     
     runner.running = true;
     deps.log(`Starting project runner (data: ${runner.projectDir}, cycle: ${runner.cycleCount})`, runner.id);
-    runner.runLoop();
+    runner.runLoop().catch((err) => {
+      const message = err?.stack || err?.message || String(err);
+      deps.log(`Project runner crashed: ${message}`, runner.id);
+      runner.running = false;
+      runner.setState({ isPaused: true, pauseReason: `Project runner crashed: ${err?.message || String(err)}` });
+      runner.currentAgent = null;
+      runner.currentAgentProcess = null;
+      runner.currentAgentStartTime = null;
+      runner.currentAgentLog = [];
+      runner.currentAgentModel = null;
+      runner.currentAgentCost = 0;
+      runner.currentAgentUsage = null;
+      runner.currentAgentKeyId = null;
+      runner.currentAgentVisibility = null;
+      deps.broadcastEvent?.({ type: 'error', project: runner.id, message: `Project runner crashed: ${err?.message || String(err)}` });
+      deps.broadcastStatusUpdate?.(runner.id);
+    });
   }
 
 export function loadRunnerState(runner, deps = {}) {

--- a/src/server.js
+++ b/src/server.js
@@ -427,8 +427,8 @@ const routeContext = {
 
 // --- HTTP API ---
 const server = http.createServer(async (req, res) => {
-
-  const url = new URL(req.url, `http://localhost:${PORT}`);
+  try {
+    const url = new URL(req.url, `http://localhost:${PORT}`);
   const pathParts = url.pathname.split('/').filter(Boolean);
   
   // CORS: only allow requests from the same origin (the dashboard served by this server)
@@ -527,6 +527,16 @@ const server = http.createServer(async (req, res) => {
 
   res.writeHead(404, { 'Content-Type': 'application/json' });
   res.end(JSON.stringify({ error: 'Not found' }));
+  } catch (err) {
+    const message = err?.stack || err?.message || String(err);
+    log(`HTTP handler error: ${message}`);
+    if (!res.headersSent) {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Internal server error' }));
+    } else {
+      res.destroy(err);
+    }
+  }
 });
 
 // --- Helpers ---
@@ -557,6 +567,16 @@ server.listen(PORT, () => {
   if (SERVE_STATIC && fs.existsSync(MONITOR_DIST)) {
     log(`Serving monitor from ${MONITOR_DIST}`);
   }
+});
+
+process.on('unhandledRejection', (reason) => {
+  const message = reason?.stack || reason?.message || String(reason);
+  log(`Unhandled rejection: ${message}`);
+});
+
+process.on('uncaughtException', (err) => {
+  const message = err?.stack || err?.message || String(err);
+  log(`Uncaught exception: ${message}`);
 });
 
 process.on('SIGINT', () => {

--- a/tests/exception-boundaries.test.js
+++ b/tests/exception-boundaries.test.js
@@ -1,0 +1,90 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { executeTool, executeToolDetailed } from '../src/agent-runner.js';
+import { startRunner } from '../src/orchestrator/state-control.js';
+
+describe('exception containment boundaries', () => {
+  it('returns a tool error instead of throwing for malformed Bash input', async () => {
+    const result = await executeTool('Bash', {}, os.tmpdir());
+    assert.match(result, /invalid Bash tool input: command must be a string/i);
+  });
+
+  it('normalizes malformed Bash input as a failed structured tool result', async () => {
+    const result = await executeToolDetailed('Bash', { command: undefined }, os.tmpdir());
+    assert.equal(result.ok, false);
+    assert.equal(result.exitCode, null);
+    assert.match(result.output, /invalid Bash tool input: command must be a string/i);
+  });
+
+  it('contains project runner loop crashes to the project', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tbc-runner-crash-'));
+    const events = [];
+    const runner = {
+      id: 'owner/repo',
+      path: root,
+      projectDir: path.join(root, '.tbc'),
+      chatsDir: path.join(root, '.tbc', 'chats'),
+      agentsDir: path.join(root, '.tbc', 'agents'),
+      responsesDir: path.join(root, '.tbc', 'responses'),
+      skillsDir: path.join(root, '.tbc', 'skills'),
+      knowledgeDir: path.join(root, '.tbc', 'knowledge'),
+      workerSkillsDir: path.join(root, '.tbc', 'skills', 'workers'),
+      running: false,
+      loadState() {},
+      runLoop: async () => { throw new Error('boom'); },
+      setState(state) { this.state = { ...(this.state || {}), ...state }; },
+    };
+
+    await startRunner(runner, {
+      log: (msg, projectId) => events.push({ type: 'log', msg, projectId }),
+      broadcastEvent: (event) => events.push({ type: 'event', event }),
+      broadcastStatusUpdate: (projectId) => events.push({ type: 'status', projectId }),
+    });
+    await new Promise(resolve => setImmediate(resolve));
+
+    assert.equal(runner.running, false);
+    assert.equal(runner.state.isPaused, true);
+    assert.match(runner.state.pauseReason, /Project runner crashed: boom/);
+    assert.ok(events.some(e => e.type === 'event' && e.event.type === 'error'));
+  });
+});
+
+import { executeToolDetailed as _executeToolDetailed } from '../src/agent-runner.js';
+
+describe('trusted tbc-db routing', () => {
+  it('routes decorated tbc-db commands through the trusted boundary instead of sandboxing project.db', async () => {
+    const result = await _executeToolDetailed(
+      'Bash',
+      { command: 'set +e\ntbc-db issue-list | sed -n \'1,5p\'\nrc=$?\necho rc=$rc' },
+      os.tmpdir(),
+      0,
+      { TBC_DB: '/tmp/does-not-exist/project.db' },
+      null,
+      null,
+      { read: [os.tmpdir()], write: [os.tmpdir()], denied: ['/tmp/does-not-exist/project.db'], dbPath: '/tmp/does-not-exist/project.db' },
+      { mode: 'full', issues: [], actor: 'athena' },
+    );
+    assert.equal(result.ok, false);
+    assert.match(result.output, /unable to open database file|SQLITE_CANTOPEN|Cannot open/i);
+    assert.doesNotMatch(result.output, /Operation not permitted|access denied/i);
+  });
+
+  it('rejects unsupported complex tbc-db loops before the normal sandbox can emit SQLITE_CANTOPEN', async () => {
+    const result = await _executeToolDetailed(
+      'Bash',
+      { command: 'for id in 1 2; do tbc-db issue-view $id; done' },
+      os.tmpdir(),
+      0,
+      { TBC_DB: '/tmp/project.db' },
+      null,
+      null,
+      { read: [os.tmpdir()], write: [os.tmpdir()], denied: ['/tmp/project.db'], dbPath: '/tmp/project.db' },
+      { mode: 'full', issues: [], actor: 'athena' },
+    );
+    assert.equal(result.ok, false);
+    assert.match(result.output, /tbc-db must be run as a simple command/i);
+  });
+});


### PR DESCRIPTION
## Summary\n- validate tool inputs and convert tool exceptions into failed tool results\n- contain agent runner exceptions as failed agent reports\n- catch project runner loop crashes, pause only the affected project, and broadcast status/error\n- catch HTTP route exceptions and add process-level rejection/exception logging\n- add regression coverage for malformed Bash input and runner-loop crash containment\n\n## Tests\n- node --test tests/exception-boundaries.test.js tests/tool-validation.test.js\n- npm test\n- npm --prefix monitor run build\n- node --check src/server.js src/agent-runner.js src/orchestrator/agent-runtime.js src/orchestrator/state-control.js