### PR TITLE
fix: raise schedule delay cap to six hours

### DIFF
--- a/agent/manager.md
+++ b/agent/manager.md
@@ -140,7 +140,7 @@ Insert `{"delay": N}` steps wherever you need a pause (waiting for CI, builds, e
 
 - A delay at the start waits after YOU (the manager) finish, before any worker starts
 - A delay between workers waits after the previous worker finishes
-- Maximum 240 minutes per delay
+- Maximum 360 minutes (6 hours) per delay
 - **Only add delays when there is a clear reason** (e.g., waiting for CI to finish, waiting for a build). Do NOT add delays by default or "just in case." If there's no specific reason to wait, don't insert a delay.
 
 

--- a/src/orchestrator/scheduler.js
+++ b/src/orchestrator/scheduler.js
@@ -24,7 +24,7 @@ export async function autoPauseWait(runner, deps = {}, intervalMs, resumeConditi
   }
 
 export async function sleepDelay(runner, deps = {}, minutes, label) {
-    const ms = Math.min(Math.max(parseFloat(minutes) || 0, 0), 120) * 60000;
+    const ms = Math.min(Math.max(parseFloat(minutes) || 0, 0), 360) * 60000;
     if (ms <= 0) return;
     deps.log(`⏳ Waiting ${Math.round(ms / 60000)}m after ${label}...`, runner.id);
     runner.sleepUntil = Date.now() + ms;

--- a/tests/schedule-resume.test.js
+++ b/tests/schedule-resume.test.js
@@ -95,10 +95,11 @@ describe('Schedule resume after reboot', () => {
   });
 
   describe('delay cap', () => {
-    it('caps delay at 120 minutes', () => {
-      // sleepDelay: Math.min(Math.max(parseFloat(minutes) || 0, 0), 120) * 60000
-      const capDelay = (minutes) => Math.min(Math.max(parseFloat(minutes) || 0, 0), 120) * 60000;
-      assert.strictEqual(capDelay(210), 120 * 60000); // 210 capped to 120
+    it('caps delay at 360 minutes', () => {
+      // sleepDelay: Math.min(Math.max(parseFloat(minutes) || 0, 0), 360) * 60000
+      const capDelay = (minutes) => Math.min(Math.max(parseFloat(minutes) || 0, 0), 360) * 60000;
+      assert.strictEqual(capDelay(420), 360 * 60000); // 420 capped to 360
+      assert.strictEqual(capDelay(210), 210 * 60000); // 210 stays 210
       assert.strictEqual(capDelay(60), 60 * 60000);   // 60 stays 60
       assert.strictEqual(capDelay(0), 0);
       assert.strictEqual(capDelay(-5), 0);


### PR DESCRIPTION
## Summary
- raise schedule delay cap from 120 minutes to 360 minutes
- align manager guidance with the 6 hour max wait
- update schedule resume test coverage for the new cap

## Test
- node --test tests/schedule-resume.test.js