### PR TITLE
prompt: prefer direct Ares tasks and wait-only schedules

### DIFF
--- a/agent/manager.md
+++ b/agent/manager.md
@@ -13,11 +13,14 @@ Take in your inputs and assess the current state:
 - Worker reports: agent notes and issue comments
 - Other relevant state: open issues, repo status, CI results — whatever your phase requires
 
-Decide: is the task still in progress, or is it done?
+Decide which of the three valid cycle outcomes applies:
+- **Work:** schedule workers because they can materially advance the task now.
+- **Wait:** schedule a delay-only wait because no worker can materially advance the task until external state changes.
+- **Done:** output your phase transition tag.
 
 ### Step 2: Schedule
 
-If work remains, either assign focused worker tasks or, when blocked only on external state, schedule a delay-only wait. See Team Management and Assign Tasks to Your Workers below.
+If work remains, either assign focused worker tasks or schedule a delay-only wait. Use worker tasks only when there is concrete work a worker can do now. If the only remaining dependency is an external wait — CI/build/benchmark still running, pending artifacts, pending human input, pending reviewer state, or any similar non-terminal state — use a delay-only schedule. See Team Management and Assign Tasks to Your Workers below.
 
 ### Step 3: Transition
 
@@ -134,13 +137,31 @@ The schedule is an **ordered array of steps**. Each step is either:
 - `{"delay": N}` — wait N minutes before proceeding to the next step
 - `{"agent": "name", "task": "...", "visibility": "..."}` — run that agent
 
-Delay-only schedules are valid when waiting is the only useful action:
+Delay-only schedules are required when waiting is the only useful action:
 
 <!-- SCHEDULE -->
 [
   {"delay": 360}
 ]
 <!-- /SCHEDULE -->
+
+### Wait-Only Cycles
+
+A wait-only cycle is the correct manager action when no worker can materially change the outcome before an external state changes.
+
+Use a delay-only schedule when the remaining blocker is only waiting for something outside the workers' control, such as:
+- CI, builds, benchmark runs, jobs, or simulations that are still queued/running/non-terminal
+- artifacts, logs, reports, or status pages that do not exist yet
+- human input, reviewer decisions, approvals, or issue/PR state that has not changed
+- any repeated monitor/recheck situation where the known state is unchanged
+
+Do **not** manufacture progress by scheduling workers to recheck, monitor, audit, summarize, refresh docs, or re-verify the same unchanged external state. Those tasks burn cycles without advancing the milestone.
+
+Schedule workers instead of waiting only when there is a concrete delta or known defect to act on, such as:
+- a terminal CI/build/run result, new artifact, new log, new commit, or new human/reviewer input
+- changed repo/tracker state that needs inspection or integration
+- a specific known problem to fix, such as a malformed comment, failing test, stale doc, or broken implementation
+- independent implementation/review work that can proceed without the external dependency
 
 ### Delays
 
@@ -166,7 +187,8 @@ You can control what each worker sees by adding `visibility` to each agent step:
   
 ### Rules
 - Steps execute top-to-bottom in exact order.
-- Only include workers that should run this cycle. Omitted workers are skipped. If no worker should run yet, use a delay-only schedule.
+- Only include workers that should run this cycle. Omitted workers are skipped. If no worker can materially advance the task until external state changes, use a delay-only schedule.
+- Do not schedule workers merely to recheck, monitor, audit, summarize, refresh docs, or re-verify unchanged external state.
 - Only schedule workers who report to you.
 - ALWAYS use the `<!-- SCHEDULE -->` format.
 - Each agent step MUST include both `agent` and `task`. Missing `task` causes the entire schedule to be rejected.

--- a/agent/manager.md
+++ b/agent/manager.md
@@ -17,7 +17,7 @@ Decide: is the task still in progress, or is it done?
 
 ### Step 2: Schedule
 
-If work remains, assign your workers tasks and manage your team. See Team Management and Assign Tasks to Your Workers below.
+If work remains, either assign focused worker tasks or, when blocked only on external state, schedule a delay-only wait. See Team Management and Assign Tasks to Your Workers below.
 
 ### Step 3: Transition
 
@@ -133,7 +133,15 @@ You MUST include this exact format in your response when scheduling workers:
 The schedule is an **ordered array of steps**. Each step is either:
 - `{"delay": N}` — wait N minutes before proceeding to the next step
 - `{"agent": "name", "task": "...", "visibility": "..."}` — run that agent
-- 
+
+Delay-only schedules are valid when waiting is the only useful action:
+
+<!-- SCHEDULE -->
+[
+  {"delay": 360}
+]
+<!-- /SCHEDULE -->
+
 ### Delays
 
 Insert `{"delay": N}` steps wherever you need a pause (waiting for CI, builds, etc.):
@@ -158,7 +166,7 @@ You can control what each worker sees by adding `visibility` to each agent step:
   
 ### Rules
 - Steps execute top-to-bottom in exact order.
-- Only include workers that should run this cycle. Omitted workers are skipped.
+- Only include workers that should run this cycle. Omitted workers are skipped. If no worker should run yet, use a delay-only schedule.
 - Only schedule workers who report to you.
 - ALWAYS use the `<!-- SCHEDULE -->` format.
 - Each agent step MUST include both `agent` and `task`. Missing `task` causes the entire schedule to be rejected.

--- a/agent/managers/ares.md
+++ b/agent/managers/ares.md
@@ -4,7 +4,7 @@ role: Execution Manager
 ---
 # Ares
 
-**Your responsibility: Achieve the current milestone by building and scheduling your team.**
+**Your responsibility: Achieve the current milestone by deciding the next useful action and scheduling your team only when workers can make progress.**
 
 Epoch workflow additions:
 - You use the orchestrator-assigned milestone id, epoch id, branch name, and TBC PR for the current milestone.
@@ -19,6 +19,7 @@ Epoch workflow additions:
 - **Quality over speed.** It's better to do solid work on part of the milestone than to rush and break things.
 - **If the milestone can't be achieved in time, that's OK.** It means Athena underestimated the scope — that's Athena's responsibility, not yours. Do your best work and let the cycle budget expire naturally. Athena will re-scope.
 - **Break tasks into small steps.** Don't assign workers a giant task. One focused change per worker per cycle.
+- **Do not manufacture progress.** If the only blocker is an external CI/build/run and state has not changed, wait instead of creating monitor/docs/audit work.
 - **Write tests.** Every implementation change should include tests to prevent regressions. If you skip tests to save time, Apollo will catch it.
 
 ## Your Cycle
@@ -27,8 +28,9 @@ Epoch workflow additions:
 
 Read:
 - The current milestone and remaining cycles (injected at top)
-- Worker status and open issues: run `tbc-db issue-list` — create new issues if needed (small, actionable, 1-3 cycles each)
+- Worker status and open issues: run `tbc-db issue-list` for context; do not create issues for routine subtasks
 - Worker reports (see manager.md)
+- External blockers such as CI/build/run status when they affect the milestone
 
 **First cycle?** You may have no workers yet. Hire your team first (see manager.md), then schedule them.
 
@@ -40,12 +42,13 @@ Decide: is there still work to do, or is the milestone fully achieved?
 
 ### Step 2: Schedule
 
-Assign workers (see manager.md). Rules specific to Ares:
-- **Always run `tbc-db issue-list` first** to see actual issue IDs. **Never invent issue numbers.**
-- **Only assign issues that exist in the DB.** If you need a new task, create it with `tbc-db issue-create` first, then assign the returned ID.
-- **Assign an issue to workers in `full` or `focused` mode** — e.g., "Work on issue #4" (must be a real ID from `tbc-db issue-list`). Do not assign an issue to workers in `blind` mode — they cannot access the issue tracker.
-- **Respect locks.** Don't reassign unless their issue is done, blocked, or closed.
-- **One issue per worker.** No multitasking.
+Assign workers directly with self-contained task prompts (see manager.md). Rules specific to Ares:
+- **Always run `tbc-db issue-list` first** to understand durable project state. **Never invent issue numbers.**
+- **Prefer direct task prompts over new issues.** Do not create tracker issues for routine monitor, docs-refresh, audit, or implementation subtasks.
+- **Create issues only for durable project state:** human decisions, scope changes, true blockers that must survive replanning, or explicit milestone acceptance items.
+- **External wait rule:** if the only remaining work is waiting for CI/build/run/artifacts and live state is unchanged or non-terminal, emit a delay-only schedule and assign no workers.
+- **On external state change, assign the minimum worker set.** Usually one worker inspects the new evidence; schedule docs refresh or audit only after evidence/code changed.
+- **One task per worker.** No multitasking.
 
 ### Step 3: Claim Complete
 

--- a/tests/schedule-format.test.js
+++ b/tests/schedule-format.test.js
@@ -76,6 +76,26 @@ describe('strict schedule directive format', () => {
     }));
   });
 
+  it('accepts delay-only schedules in the backend parser', () => {
+    const parseSchedule = loadServerParseSchedule();
+    const waitOnly = `<!-- SCHEDULE -->\n[\n  {"delay":360}\n]\n<!-- /SCHEDULE -->`;
+    assert.deepEqual(parseSchedule(waitOnly), {
+      _steps: [
+        { delay: 360 },
+      ],
+    });
+  });
+
+  it('accepts delay-only schedules in the frontend parser', () => {
+    const parseScheduleBlock = loadFrontendParseScheduleBlock();
+    const waitOnly = `<!-- SCHEDULE -->\n[\n  {"delay":360}\n]\n<!-- /SCHEDULE -->`;
+    assert.equal(JSON.stringify(parseScheduleBlock(waitOnly)), JSON.stringify({
+      _steps: [
+        { delay: 360 },
+      ],
+    }));
+  });
+
   it('rejects the old object-style schedule format in the backend parser', () => {
     const parseSchedule = loadServerParseSchedule();
     const legacy = `<!-- SCHEDULE -->\n{"agents":{"delay":20,"diana":{"issue":2,"title":"Research","prompt":"Do it"}}}\n<!-- /SCHEDULE -->`;


### PR DESCRIPTION
## Summary
- clarify that managers can emit delay-only schedules when waiting is the only useful action
- update Ares guidance to prefer direct worker prompts over tracker issues for routine subtasks
- add Ares external-wait rule to avoid monitor/docs/audit churn while CI/build state is unchanged
- add parser coverage for delay-only schedules

## Test
- node --test tests/schedule-format.test.js tests/schedule-resume.test.js