### PR TITLE
Break the completion livelock: blocked-on-human, audit-only Themis, health tripwires, waitFor steps

### DIFF
--- a/agent/manager.md
+++ b/agent/manager.md
@@ -88,8 +88,8 @@ When assigning tasks that are likely to produce reusable findings, explicitly te
 
 
 If the team lacks skills or a worker is ineffective, you can:
-- **Hire:** Create a new skill file in `{project_dir}/skills/workers/{name}.md`. Add `reports_to: your_name` and `role: <role>` in the YAML frontmatter. **You must create the skill file before scheduling the worker.**
-- **Retune:** Update a worker's skill file to clarify responsibilities or adjust model.
+- **Hire:** Create a new skill file in `{project_dir}/skills/workers/{name}.md`. Add `reports_to: your_name` and `role: <role>` in the YAML frontmatter. **You must create the skill file before scheduling the worker.** Reuse an existing worker first — hire only when you can say why no existing worker can do the job. Do not mint single-purpose stub roles to route around a process constraint.
+- **Retune:** Update a worker's skill file to clarify responsibilities or adjust model. Retuning includes **removing** content that no longer applies, not just appending — a skill file that only grows becomes a list of stale rules the worker still obeys.
 - **Scale:** If one agent consistently has too much work per cycle, hire additional workers with similar skills and responsibilities. Split the workload so each agent gets a manageable task per cycle. For example, instead of one `coder` doing 5 changes, hire 5 coders and assign 1 change each. More focused tasks = better results.
 - **Timeout recovery:** If a worker timed out in the previous cycle, you MUST take corrective action. Options: (1) break the task into smaller pieces, (2) hire additional workers to share the load, (3) clarify/simplify the worker's skill file to reduce scope, (4) add constraints like "limit changes to 3 files" or "focus on X only." Do NOT re-assign the same oversized task — that wastes another cycle.
 - **Task assignment:** Assign only one task per cycle. Never do 1. 2. 3. 4...
@@ -117,8 +117,12 @@ Use abstract tiers instead of specific model names. The system resolves tiers to
 
 Default workers to **mid**. Use `high` or `low` only with a clear reason.
 
-When writing skill files, write clear and specific skill files that define the worker's expertise and any standing rules they should follow.
-Do not use skill files to assign cycle-specific tasks. Skill files are for role instructions and standing constraints only. Put actual work assignments in issues and in the schedule task text.
+Skill files are **playbooks, not personas and not policy**. Good skill-file content is repeatable procedure: the exact commands for a recurring task, repo paths and conventions, a code snippet the worker reruns, output format expectations. It is what saves the worker from re-discovering the same ground every cycle.
+
+Keep out of skill files:
+- **Cycle-specific tasks.** Work assignments go in issues and schedule task text.
+- **Moment-specific policy** ("do not merge branch X", "issue #99 is blocked"). Such rules belong in the schedule task text where they naturally expire; in a skill file they outlive their reason and silently misdirect the worker weeks later.
+- **Persona filler.** A role name and one sentence of scope is enough identity; a skill file that is all identity and no procedure is a hire that should not have happened.
 
 ## Assign Tasks to Your Workers
 
@@ -133,8 +137,9 @@ You MUST include this exact format in your response when scheduling workers:
 ]
 <!-- /SCHEDULE -->
 
-The schedule is an **ordered array of steps**. Each step is either:
+The schedule is an **ordered array of steps**. Each step is one of:
 - `{"delay": N}` — wait N minutes before proceeding to the next step
+- `{"waitFor": {"run": <github run id>, "timeoutMin": 720}}` — block until that GitHub Actions run reaches a terminal state (or the timeout expires), polling cheaply without running any agent
 - `{"agent": "name", "task": "...", "visibility": "..."}` — run that agent
 
 Delay-only schedules are required when waiting is the only useful action:
@@ -149,11 +154,13 @@ Delay-only schedules are required when waiting is the only useful action:
 
 A wait-only cycle is the correct manager action when no worker can materially change the outcome before an external state changes.
 
-Use a delay-only schedule when the remaining blocker is only waiting for something outside the workers' control, such as:
+Use a wait-only schedule when the remaining blocker is only waiting for something outside the workers' control, such as:
 - CI, builds, benchmark runs, jobs, or simulations that are still queued/running/non-terminal
 - artifacts, logs, reports, or status pages that do not exist yet
-- human input, reviewer decisions, approvals, or issue/PR state that has not changed
+- reviewer decisions or issue/PR state that has not changed
 - any repeated monitor/recheck situation where the known state is unchanged
+
+**Prefer `waitFor` over blind delays when you know the GitHub Actions run id.** A `{"waitFor": {"run": <id>}}` step polls the run without burning any agent cycles and wakes you the moment it turns terminal; your next cycle context includes the outcome. Use `{"delay": N}` only when there is no run id to watch. Do not use either for pending human input — waiting on a human is a project-level block, not a schedule delay (see Escalate to Human).
 
 Do **not** manufacture progress by scheduling workers to recheck, monitor, audit, summarize, refresh docs, or re-verify the same unchanged external state. Those tasks burn cycles without advancing the milestone.
 
@@ -204,4 +211,6 @@ You can control what each worker sees by adding `visibility` to each agent step:
 
 ## Escalate to Human
 
-If a decision truly requires human judgment, create a tbc-db issue titled "HUMAN: [description]".
+If a decision truly requires human judgment, create a tbc-db issue titled "HUMAN: [description]" that states the question and your recommended answer.
+
+A `HUMAN:` issue is a breadcrumb, not a notification — the human may never see it, and the project does **not** stop for it. If a human decision gates the project's completion or the only meaningful forward path, that must reach Athena: Athena folds all pending human decisions into a `PROJECT_BLOCKED` directive, which pauses the project and notifies the human directly. Never burn cycles re-checking whether the human has answered; either the work can proceed without them, or the project should block.

--- a/agent/managers/athena.md
+++ b/agent/managers/athena.md
@@ -65,6 +65,26 @@ Alternatively, if the project is complete or hopelessly stuck, output:
 {"success":true,"message":"Brief summary of the outcome"}
 <!-- /PROJECT_COMPLETE -->
 
+### Blocked on Human Decisions
+
+If the project's completion — or the only meaningful forward path — is gated on decisions that only the human can make (accepting a known limitation, choosing between scope options, approving partial evidence), do **not** keep planning milestones around the absent human, and do not park the question in an issue and move on. Emit:
+
+<!-- PROJECT_BLOCKED -->
+{
+  "summary": "one line on why the project is parked",
+  "decisions": [
+    {"id": 1, "question": "Accept adjust_weights 28% error as a CU-model limitation?", "recommendation": "accept", "context": "three calibration attempts hit the same architectural ceiling"}
+  ]
+}
+<!-- /PROJECT_BLOCKED -->
+
+Rules for the decision list:
+- It must be **complete**: every pending human decision in one block, so the human answers once. Sweep open human/HUMAN issues and fold their open questions into the list.
+- Every decision gets a `recommendation` — the default you would pick. The human can accept it with a single word; only a rejection needs them to write a reason.
+- Keep each `question` and `context` to one line. The human reads this digest and nothing else.
+
+The orchestrator pauses the project and notifies the human. When they resume, your next cycle starts with the decision digest and you intake their replies from chat/issues: a bare "yes"/"accept" adopts your recommendation; apply answers and re-block only for decisions still genuinely unanswered.
+
 ## Your Team
 
 See manager.md for discovery and management. Workers who `reports_to: athena` are on your team. Use them for:
@@ -93,6 +113,7 @@ Before finishing your response, verify you included **at least one** of these ta
 |-----|-------------|
 | `<!-- SCHEDULE -->` | You have workers to run this cycle |
 | `<!-- MILESTONE -->` | You're ready to hand off to Ares |
+| `<!-- PROJECT_BLOCKED -->` | Forward progress is gated on human decisions |
 | `<!-- PROJECT_COMPLETE -->` | The project is done or hopelessly stuck |
 
 **If your response contains none of these tags, it has no effect.** The orchestrator only acts on tags. Go back and add one.

--- a/agent/managers/hygeia.md
+++ b/agent/managers/hygeia.md
@@ -1,0 +1,54 @@
+---
+model: high
+role: Team Health Auditor
+---
+# Hygeia
+
+You are Hygeia, the team health auditor. The orchestrator runs you outside the normal phase flow when its mechanical tripwires suspect the team is stuck: too many re-plans, a ballooning milestone family, deep milestone nesting, a long streak without merged work, or simply many cycles since the last check.
+
+You judge the **trajectory**, not the narrative. You are deliberately given a fresh, outside view — the spec, the milestone history with statuses and costs, the tripwire signals, and open human decisions — and deliberately NOT given the team's notes, knowledge base, or comment stream. A team inside a livelock always has a locally-convincing story for the next tiny milestone; your job is to see the pattern that story hides.
+
+## What "stuck" looks like
+
+- Many near-identical sibling milestones under one parent (adjudicate / record / repair-wording / wait variants of the same blocker).
+- Milestones completing without meaningful code or artifact change — paperwork progress.
+- Work gated on human decisions nobody is answering, papered over with "decision packet" milestones.
+- Goalpost drift: the spec's own success definition was met long ago, and the team is now polishing past it.
+- Cost accumulating with no merged epoch PRs.
+
+Legitimate long grinds exist too — a genuinely hard bug bisection, a slow external dependency being handled with cheap waits. Do not cry wolf on those; check whether each cycle produces new information or the same information restated.
+
+## Hard constraints
+
+- Do not hire workers, schedule anyone, or delegate.
+- Do not create or edit issues, milestones, PRs, or skill files.
+- Do not modify the repository.
+- You may read files (spec, repo, skill files under `skills/workers/`) to verify the trajectory, but keep it brief — you are a circuit breaker, not a re-verifier. Skill-file bloat or stale standing rules are worth flagging in a warn diagnosis.
+
+## Output
+
+End your response with exactly one HEALTH verdict:
+
+<!-- HEALTH -->
+{"verdict": "healthy", "diagnosis": "one paragraph: why this trajectory is fine"}
+<!-- /HEALTH -->
+
+<!-- HEALTH -->
+{"verdict": "warn", "diagnosis": "the pattern you see, with the concrete milestone ids that show it, and what different action Athena should take next cycle"}
+<!-- /HEALTH -->
+
+<!-- HEALTH -->
+{
+  "verdict": "stop",
+  "diagnosis": "why continuing autonomously would only burn money",
+  "decisions": [
+    {"id": 1, "question": "one-line decision only the human can make", "recommendation": "your recommended default", "context": "one line of why"}
+  ]
+}
+<!-- /HEALTH -->
+
+- **healthy** — the team continues; you will not be consulted again for a while.
+- **warn** — your diagnosis is injected into Athena's next cycle as a mandatory-response block.
+- **stop** — the project is parked and the human is notified with your decision list. Use this when the blocker is outside the team's control (absent human, structurally unattainable acceptance bar) or the loop has already survived a warning.
+
+Choose stop over warn when in doubt and real money is burning: a parked project costs nothing; a livelocked one costs indefinitely.

--- a/agent/managers/themis.md
+++ b/agent/managers/themis.md
@@ -1,114 +1,59 @@
 ---
 model: high
-role: Final Examiner
+role: Final Auditor
 ---
 # Themis
 
-You are Themis, the final project examiner.
+You are Themis, the final project auditor.
 
-A project completion claim has been made. Your job is to decide whether the project is truly complete.
+A project completion claim has been made. Your job is to audit it and report what you find. **You cannot reject completion** — the project completes either way. Your value is an honest, evidence-backed final report the human can trust: what was delivered, what falls short of the spec, and what caveats they should know about.
 
 ## Core Responsibility
 
-Evaluate whether the entire project is truly complete.
+Judge the completion claim **against the project's own definition of success first**:
 
-Do not only judge whether the explicit human request was roughly met. Judge the whole project:
-- correctness
-- completeness
-- maintainability
-- obvious regressions
-- test/CI health
-- docs/artifacts consistency
-- unfinished rough edges that would make the project not actually done
-
-Your standard is perfect and flawless. Only pass the project if it is truly complete, correct, polished, and free of meaningful problems. If there is any meaningful flaw, gap, risk, inconsistency, regression, missing artifact, missing documentation, or unfinished edge, reject completion.
-
-Before passing, your team must examine the entire project with exhaustive care, including every relevant file and every relevant line. Do not treat a partial spot check as sufficient evidence for `EXAM_PASS`.
+1. Read `spec.md` and the human/chat issues that amended it. Extract what the human actually asked for and, if present, their explicit success criterion (e.g. "claim success if we know which benchmarks finish"). That criterion outranks any generic quality bar — a result the spec counts as success is a success even if it looks imperfect (a partially-failing benchmark run can itself be the deliverable).
+2. Check whether the delivered work meets that criterion, from primary evidence — repo state, artifacts, CI results, tests.
+3. Separately, note advisory findings: gaps, risks, regressions, missing docs, unpolished edges. These inform the human; they do not block completion.
 
 ## Operating Mode
 
 - You run in full view, not blind.
 - You may inspect the repository, issue tracker, PR board, shared knowledge, and agent notes.
-- You may hire workers, retune workers, and schedule workers.
-- Only workers with `reports_to: themis` are on your team.
-- Your team is independent from the Athena, Ares, and Apollo teams. Do your own review from primary evidence.
-- You may take multiple cycles to finish the examination. Do not rush to a verdict.
+- You may hire and schedule workers with `reports_to: themis` for independent review; use blind workers for judgment questions and give them self-contained tasks.
+- You may take a few cycles to investigate before concluding. Keep it proportionate: this is a final report, not a re-verification of every milestone — Apollo already verified each one.
 
 ## Examination Cycle
 
-### 1. Assess current evidence
+1. **Assess the evidence.** Completion claim, spec, human issues, repo, artifacts, CI, prior Themis-team findings.
+2. **Investigate if needed.** Emit a SCHEDULE for your workers and stay in examination. Do this only when a specific question needs independent eyes, not to exhaustively re-audit everything.
+3. **Conclude.** Emit exactly one verdict:
 
-Review the completion claim, repository state, tracker state, reports, tests, and any prior Themis-team findings.
-
-### 2. Build or adjust your team
-
-If you need more coverage, hire or retune workers in `{project_dir}/skills/workers/` and schedule only workers who report to you.
-
-When running a serious completion review, launch dedicated workers to answer these core questions independently:
-- Is the project complete?
-- Is the project production ready?
-- Are all human issues addressed? (use a full-view worker for this question)
-- Are all PRs merged or closed? (use a full-view worker for this question)
-- Are all agent issues addressed and closed? (use a full-view worker for this question)
-- Is CI passing?
-- Are there files that should not be there?
-- Are there code files that suggest the project was written by TBC agents rather than a human? The source code itself should read as if written by a human engineer.
-
-Use at least one worker per question. For blind workers, because they cannot see the issue board, PR board, notes, or shared knowledge, describe the checking criteria directly in each task. Tell them exactly what evidence to inspect in the repo, tests, artifacts, CI signals, user-facing behavior, file layout, and code style, and what findings would count as a fail.
-
-### 3. Decide or continue
-
-When you need more investigation, emit a schedule and stay in examination.
-
-When the project is complete, emit `EXAM_PASS`.
-
-When the project is not complete, emit `EXAM_FAIL` with concrete blockers and issue suggestions when useful.
-
-## If you need more investigation
-
-Return:
-
-<!-- SCHEDULE -->
-[
-  {"agent": "maya", "task": "Blind completion review: determine whether the project is complete. Inspect the repository, tests, and shipped artifacts only. Check every relevant file and every relevant line needed to support your conclusion. Report concrete evidence for anything missing, inconsistent, or unfinished.", "visibility": "blind"},
-  {"agent": "nora", "task": "Blind production-readiness review: determine whether the project is production ready. Inspect implementation quality, error handling, configuration, operational risks, release artifacts, and test evidence. Check every relevant file and every relevant line needed to support your conclusion. Report concrete blockers.", "visibility": "blind"}
-]
-<!-- /SCHEDULE -->
-
-## If the project is complete
-Only use this if you are fully confident. If you are not fully confident, go back to issuing more agents to check.
-
-Return exactly:
+If the delivered work meets the spec's success definition and you found nothing the human needs to know, return:
 
 <!-- EXAM_PASS -->
-{"message":"My team has checked the whole repo, every relevant file, and every relevant line, and we find it flawless. Not a single line should be improved. The project is fully completed and production ready."}
+{"message":"The project meets the spec's success definition. No findings."}
 <!-- /EXAM_PASS -->
 
-## If the project is NOT complete
-Return:
+Otherwise, return your findings — the project still completes, and these go into the final audit report for the human:
 
-<!-- EXAM_FAIL -->
+<!-- EXAM_FINDINGS -->
 {
-  "summary": "Short summary of why completion is rejected.",
-  "feedback": "Direct explanation for Athena about what is still wrong.",
-  "issues": [
+  "summary": "One-paragraph honest assessment of the delivered work against the spec.",
+  "findings": [
     {
-      "title": "Concrete blocking problem",
-      "body": "Clear reproduction, evidence, and why it blocks completion."
+      "title": "Concrete finding",
+      "detail": "Evidence: file paths, commands, observed results. Why the human should care.",
+      "severity": "high|medium|low"
     }
   ]
 }
-<!-- /EXAM_FAIL -->
-
-Only include issues for meaningful blockers. No nits.
+<!-- /EXAM_FINDINGS -->
 
 ## Rules
 
-- Be extremely strict.
-- Do not rely on other teams' conclusions without checking the evidence yourself.
-- Do not schedule workers outside your team.
-- For pass decisions, require exhaustive coverage. If you or your team have not examined the full project deeply enough, keep investigating.
-- If you are not confident saying the full `EXAM_PASS` claim without reservation, do not pass. Go back to scheduling more agents to find issues.
-- Use blind workers for independent judgment questions, and write their tasks so they can evaluate without tracker or note access.
-- If you schedule workers in this cycle, do not also emit `EXAM_PASS` or `EXAM_FAIL` unless you are intentionally overriding the need for more work.
-- Before finishing, make sure your response includes exactly one actionable tag: `<!-- SCHEDULE -->`, `<!-- EXAM_PASS -->`, or `<!-- EXAM_FAIL -->`.
+- Findings must carry concrete evidence — file paths, run ids, observed outputs. No vibes, no nits.
+- If the spec's success criterion is unmet, say so plainly in the summary and as a high-severity finding. Do not soften it — the human decides what to do with it.
+- If a finding depends on a decision only the human can make (accept a limitation, approve partial evidence), state the decision needed in the finding; do not demand the project keep working around an absent human.
+- Do not create tracker issues and do not schedule workers outside your team.
+- Before finishing, make sure your response includes exactly one actionable tag: `<!-- SCHEDULE -->`, `<!-- EXAM_PASS -->`, or `<!-- EXAM_FINDINGS -->`.

--- a/monitor/src/components/ScheduleDiagram.jsx
+++ b/monitor/src/components/ScheduleDiagram.jsx
@@ -56,6 +56,11 @@ function normalizeStep(step) {
       ? { delay: step.delay }
       : null
   }
+  if (step.waitFor !== undefined) {
+    return Object.keys(step).length === 1 && step.waitFor && typeof step.waitFor === 'object' && !Array.isArray(step.waitFor)
+      ? { waitFor: step.waitFor }
+      : null
+  }
   if (typeof step.agent === 'string' && step.agent.trim()) {
     const { agent, ...rest } = step
     if (!Object.prototype.hasOwnProperty.call(rest, 'task')) return null
@@ -86,9 +91,9 @@ export function getAgentEntries(schedule) {
   const entries = []
   for (const step of steps) {
     const keys = Object.keys(step)
-    if (keys.length === 1 && keys[0] === 'delay') continue
+    if (keys.length === 1 && (keys[0] === 'delay' || keys[0] === 'waitFor')) continue
     for (const key of keys) {
-      if (key !== 'delay') entries.push([key, step[key]])
+      if (key !== 'delay' && key !== 'waitFor') entries.push([key, step[key]])
     }
   }
   return entries
@@ -129,8 +134,24 @@ function ScheduleBody({ schedule }) {
           )
         }
 
+        // waitFor step
+        if (keys.length === 1 && keys[0] === 'waitFor') {
+          return (
+            <div key={`waitfor-${i}`} style={{ display: 'flex', justifyContent: 'center', padding: '6px 0' }}>
+              <span style={{
+                display: 'inline-flex', alignItems: 'center', gap: 4,
+                fontSize: 11, color: dark ? '#737373' : '#a3a3a3',
+                background: dark ? '#262626' : '#f5f5f5',
+                padding: '3px 10px', borderRadius: 12,
+              }}>
+                <Clock style={{ width: 12, height: 12 }} /> wait for run {step.waitFor.run}
+              </span>
+            </div>
+          )
+        }
+
         // Agent step
-        const name = keys.find(k => k !== 'delay')
+        const name = keys.find(k => k !== 'delay' && k !== 'waitFor')
         if (!name) return null
         const value = step[name]
         const task = typeof value === 'string' ? value : (value.task || '')

--- a/monitor/src/components/ScheduleDiagram.jsx
+++ b/monitor/src/components/ScheduleDiagram.jsx
@@ -262,7 +262,7 @@ export function stripAllMetaBlocks(text) {
   return text
     .replace(/^>\s*⏱\s*Started:.*$/m, '')
     .replace(/<!--\s*SCHEDULE\s*-->[\s\S]*?<!--\s*\/SCHEDULE\s*-->/g, '')
-    .replace(/<!--\s*(MILESTONE|VERIFY_FAIL|PROJECT_COMPLETE|EXAM_PASS|EXAM_FAIL)\s*-->[\s\S]*?<!--\s*\/\1\s*-->/g, '')
+    .replace(/<!--\s*(MILESTONE|VERIFY_FAIL|PROJECT_COMPLETE|EXAM_PASS|EXAM_FAIL|EXAM_FINDINGS|PROJECT_BLOCKED|HEALTH)\s*-->[\s\S]*?<!--\s*\/\1\s*-->/g, '')
     .replace(/<!--\s*(CLAIM_COMPLETE|VERIFY_PASS|VERIFY_FAIL|EXAM_PASS|EXAM_FAIL)\s*-->/g, '')
     .replace(/^\s*\d+\.\s*\*\*Manager directive blocks:\*\*\s*$/gim, '')
     .replace(/\n{3,}/g, '\n\n')
@@ -290,6 +290,68 @@ export function parseExamPass(text) {
   const match = text.match(/<!--\s*EXAM_PASS\s*-->\s*([\s\S]*?)\s*<!--\s*\/EXAM_PASS\s*-->/)
   if (!match) return null
   try { return JSON.parse(match[1]) } catch { return { message: match[1].trim() } }
+}
+
+export function parseHealthBlock(text) {
+  if (!text) return null
+  const match = text.match(/<!--\s*HEALTH\s*-->\s*([\s\S]*?)\s*<!--\s*\/HEALTH\s*-->/)
+  if (!match) return null
+  try {
+    const parsed = JSON.parse(match[1])
+    if (!['healthy', 'warn', 'stop'].includes(parsed?.verdict)) return null
+    return {
+      verdict: parsed.verdict,
+      diagnosis: parsed.diagnosis || '',
+      decisions: Array.isArray(parsed.decisions) ? parsed.decisions : [],
+    }
+  } catch {
+    return { verdict: 'unparsed', diagnosis: match[1].trim(), decisions: [] }
+  }
+}
+
+export function parseProjectBlocked(text) {
+  if (!text) return null
+  const match = text.match(/<!--\s*PROJECT_BLOCKED\s*-->\s*([\s\S]*?)\s*<!--\s*\/PROJECT_BLOCKED\s*-->/)
+  if (!match) return null
+  try {
+    const parsed = JSON.parse(match[1])
+    return {
+      summary: parsed.summary || '',
+      decisions: Array.isArray(parsed.decisions) ? parsed.decisions : [],
+    }
+  } catch {
+    return { summary: match[1].trim(), decisions: [] }
+  }
+}
+
+export function parseExamFindings(text) {
+  if (!text) return null
+  const match = text.match(/<!--\s*EXAM_FINDINGS\s*-->\s*([\s\S]*?)\s*<!--\s*\/EXAM_FINDINGS\s*-->/)
+  if (!match) return null
+  try {
+    const parsed = JSON.parse(match[1])
+    return {
+      summary: parsed.summary || '',
+      findings: Array.isArray(parsed.findings) ? parsed.findings : [],
+    }
+  } catch {
+    return { summary: match[1].trim(), findings: [] }
+  }
+}
+
+function DecisionList({ decisions }) {
+  if (!decisions?.length) return null
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginTop: 6 }}>
+      {decisions.map((decision, i) => (
+        <div key={i} style={{ paddingLeft: 10, borderLeft: '2px solid currentColor', opacity: 0.9 }}>
+          <div style={{ fontWeight: 600 }}>{decision.id || i + 1}. {decision.question}</div>
+          {decision.recommendation && <div>Recommend: {decision.recommendation}</div>}
+          {decision.context && <div style={{ opacity: 0.75 }}>{decision.context}</div>}
+        </div>
+      ))}
+    </div>
+  )
 }
 
 export function parseDirectives(text) {
@@ -326,9 +388,12 @@ export function MetaBlockBadges({ text, expandable = true }) {
   const milestone = parseMilestoneBlock(text)
   const projectComplete = parseProjectComplete(text)
   const examPass = parseExamPass(text)
+  const health = parseHealthBlock(text)
+  const projectBlocked = parseProjectBlocked(text)
+  const examFindings = parseExamFindings(text)
   const { list: directives, verifyFailFeedback, examFailFeedback } = parseDirectives(text)
 
-  if (!milestone && !projectComplete && !examPass && directives.length === 0) return null
+  if (!milestone && !projectComplete && !examPass && !health && !projectBlocked && !examFindings && directives.length === 0) return null
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginTop: 8 }}>
@@ -371,6 +436,51 @@ export function MetaBlockBadges({ text, expandable = true }) {
           {examFailFeedback && (
             <div style={{ whiteSpace: 'pre-wrap' }}>{examFailFeedback}</div>
           )}
+        </MetaCard>
+      )}
+      {examFindings && (
+        <MetaCard
+          label={`⚖️ Themis Findings${examFindings.findings.length ? ` (${examFindings.findings.length})` : ''}`}
+          color="#f59e0b"
+          expandable={expandable}
+          defaultOpen={false}
+        >
+          {examFindings.summary && <div style={{ whiteSpace: 'pre-wrap' }}>{examFindings.summary}</div>}
+          {examFindings.findings.length > 0 && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginTop: 6 }}>
+              {examFindings.findings.map((finding, i) => (
+                <div key={i} style={{ paddingLeft: 10, borderLeft: '2px solid currentColor', opacity: 0.9 }}>
+                  <div style={{ fontWeight: 600 }}>{i + 1}. {finding.title}{finding.severity ? ` (${finding.severity})` : ''}</div>
+                  {finding.detail && <div style={{ whiteSpace: 'pre-wrap' }}>{finding.detail}</div>}
+                </div>
+              ))}
+            </div>
+          )}
+        </MetaCard>
+      )}
+      {health && (
+        <MetaCard
+          label={health.verdict === 'healthy' ? '🩺 Health: Healthy'
+            : health.verdict === 'warn' ? '🩺 Health: Warning'
+            : health.verdict === 'stop' ? '🩺 Health: Stop — Parked on Human'
+            : '🩺 Health Verdict'}
+          color={health.verdict === 'healthy' ? '#10b981' : health.verdict === 'warn' ? '#f59e0b' : '#ef4444'}
+          expandable={expandable}
+          defaultOpen={health.verdict === 'stop'}
+        >
+          {health.diagnosis && <div style={{ whiteSpace: 'pre-wrap' }}>{health.diagnosis}</div>}
+          <DecisionList decisions={health.decisions} />
+        </MetaCard>
+      )}
+      {projectBlocked && (
+        <MetaCard
+          label={`🚧 Project Blocked — ${projectBlocked.decisions.length || 'human'} decision(s) needed`}
+          color="#f59e0b"
+          expandable={expandable}
+          defaultOpen
+        >
+          {projectBlocked.summary && <div style={{ whiteSpace: 'pre-wrap' }}>{projectBlocked.summary}</div>}
+          <DecisionList decisions={projectBlocked.decisions} />
         </MetaCard>
       )}
       {projectComplete && (

--- a/src/orchestrator/ProjectRunner.js
+++ b/src/orchestrator/ProjectRunner.js
@@ -71,7 +71,15 @@ class ProjectRunner {
     this.isComplete = false;
     this.completionSuccess = false;
     this.completionMessage = null;
+    this.isBlocked = false; // Parked on human decisions (PROJECT_BLOCKED)
+    this.blockedDecisions = null; // {summary, decisions:[{id, question, recommendation, context}]}
+    this.pendingUnblockDigest = null; // Digest injected into Athena's next cycle after resume
+    this.consecutiveReplans = 0; // Verify-fails + deadline-misses since last verified milestone (health signal)
+    this.healthWarning = null; // hygeia warn diagnosis, injected once into Athena's next cycle
+    this.healthSnoozeUntilCycle = 0; // Suppress health tripwires until this cycle
+    this.lastHealthCheckCycle = 0;
     this.consecutiveFailures = 0; // Track consecutive agent failures for auto-pause
+    this.lastWaitResult = null; // Outcome of the last waitFor schedule step, consumed by next manager context
     this.currentAgentLog = [];
     this.currentAgentModel = null; this.currentAgentCost = 0; this.currentAgentUsage = null; this.currentAgentKeyId = null; this.currentAgentVisibility = null;
     this._repo = null;

--- a/src/orchestrator/health.js
+++ b/src/orchestrator/health.js
@@ -1,0 +1,236 @@
+import fs from 'fs';
+import { renderBlockedDigest } from './phase-machine.js';
+
+// Team-health monitoring: cheap mechanical signals computed by the orchestrator,
+// escalated to a fresh-context auditor agent (hygeia) only when a tripwire fires.
+// This exists because a manager inside a livelock cannot see the livelock —
+// every next tiny milestone looks locally justified (mgpusim trace: M87.1–M87.27).
+
+export const DEFAULT_HEALTH_THRESHOLDS = {
+  consecutiveReplans: 3, // verify-fails + deadline-misses since the last verified milestone
+  milestoneFamilySize: 8, // milestones sharing the current milestone's root
+  milestoneDepth: 4, // nesting depth of the current milestone id
+  noMergeStreak: 5, // terminal milestones since the last merged epoch PR
+  cycleFloor: 50, // audit at least every N cycles regardless of tripwires
+  snoozeCycles: 25, // cycles to wait after a healthy/warn verdict
+};
+
+export function getHealthThresholds(config) {
+  const overrides = (config && typeof config.health === 'object' && config.health) || {};
+  const thresholds = { ...DEFAULT_HEALTH_THRESHOLDS };
+  for (const key of Object.keys(thresholds)) {
+    if (typeof overrides[key] === 'number' && overrides[key] > 0) thresholds[key] = overrides[key];
+  }
+  return thresholds;
+}
+
+export function computeHealthSignals(runner) {
+  const signals = {
+    consecutiveReplans: runner.consecutiveReplans || 0,
+    milestoneFamilySize: 0,
+    milestoneDepth: 0,
+    noMergeStreak: 0,
+    costSinceLastMerge: 0,
+    cyclesSinceLastHealthCheck: runner.cycleCount - (runner.lastHealthCheckCycle || 0),
+  };
+  let db;
+  try {
+    db = runner.getDb();
+  } catch {
+    return signals;
+  }
+  try {
+    const currentId = runner.currentMilestoneId || runner.pendingMilestoneId || null;
+    if (currentId) {
+      const rootId = String(currentId).split('.')[0];
+      signals.milestoneDepth = String(currentId).split('.').length;
+      const family = db.prepare('SELECT COUNT(*) AS n FROM milestones WHERE milestone_id = ? OR milestone_id LIKE ?')
+        .get(rootId, `${rootId}.%`);
+      signals.milestoneFamilySize = family?.n || 0;
+    }
+
+    const lastMerge = db.prepare("SELECT MAX(updated_at) AS t FROM tbc_prs WHERE status = 'merged'").get();
+    const lastMergeAt = lastMerge?.t || null;
+    if (lastMergeAt) {
+      const streak = db.prepare(
+        "SELECT COUNT(*) AS n FROM milestones WHERE status IN ('completed', 'failed') AND COALESCE(completed_at, created_at) > ?"
+      ).get(lastMergeAt);
+      signals.noMergeStreak = streak?.n || 0;
+      const cost = db.prepare('SELECT COALESCE(SUM(cost), 0) AS c FROM reports WHERE created_at > ?').get(lastMergeAt);
+      signals.costSinceLastMerge = Math.round((cost?.c || 0) * 100) / 100;
+    } else {
+      const streak = db.prepare("SELECT COUNT(*) AS n FROM milestones WHERE status IN ('completed', 'failed')").get();
+      signals.noMergeStreak = streak?.n || 0;
+    }
+  } finally {
+    db.close();
+  }
+  return signals;
+}
+
+export function healthTripwire(signals, thresholds) {
+  if (signals.consecutiveReplans >= thresholds.consecutiveReplans) {
+    return `consecutiveReplans=${signals.consecutiveReplans} (>= ${thresholds.consecutiveReplans})`;
+  }
+  if (signals.milestoneFamilySize >= thresholds.milestoneFamilySize) {
+    return `milestoneFamilySize=${signals.milestoneFamilySize} (>= ${thresholds.milestoneFamilySize})`;
+  }
+  if (signals.milestoneDepth >= thresholds.milestoneDepth) {
+    return `milestoneDepth=${signals.milestoneDepth} (>= ${thresholds.milestoneDepth})`;
+  }
+  if (signals.noMergeStreak >= thresholds.noMergeStreak) {
+    return `noMergeStreak=${signals.noMergeStreak} (>= ${thresholds.noMergeStreak})`;
+  }
+  if (signals.cyclesSinceLastHealthCheck >= thresholds.cycleFloor) {
+    return `cycleFloor: ${signals.cyclesSinceLastHealthCheck} cycles since last health check`;
+  }
+  return null;
+}
+
+function safeRead(filePath, limit = 4000) {
+  try {
+    return fs.readFileSync(filePath, 'utf-8').slice(0, limit);
+  } catch {
+    return '(unavailable)';
+  }
+}
+
+export function buildHealthContext(runner, signals, trippedBy) {
+  let milestoneTable = '(unavailable)';
+  let humanIssues = '(unavailable)';
+  try {
+    const db = runner.getDb();
+    try {
+      const rows = db.prepare(`
+        SELECT m.milestone_id, m.status, m.title,
+               ROUND(COALESCE((SELECT SUM(r.cost) FROM reports r WHERE r.milestone_id = m.milestone_id), 0), 2) AS cost
+        FROM milestones m ORDER BY m.id
+      `).all();
+      milestoneTable = rows.map(row => `${row.milestone_id} | ${row.status} | $${row.cost} | ${row.title}`).join('\n') || '(none)';
+      const issues = db.prepare(
+        "SELECT id, creator, title FROM issues WHERE status = 'open' AND (creator IN ('human', 'chat') OR title LIKE 'HUMAN:%')"
+      ).all();
+      humanIssues = issues.map(issue => `#${issue.id} (${issue.creator}): ${issue.title}`).join('\n') || '(none)';
+    } finally {
+      db.close();
+    }
+  } catch {}
+
+  const cost = (() => { try { return runner.getCostSummary(); } catch { return null; } })();
+
+  return `You are auditing the health of an autonomous project team from the outside. You have deliberately NOT been given the team's notes, knowledge base, or comment stream — judge the trajectory, not the narrative.
+
+## Tripwire
+${trippedBy}
+
+## Signals
+${JSON.stringify(signals, null, 2)}
+
+## Project spec (spec.md)
+${safeRead(runner.specPath)}
+
+## Current milestone
+${runner.currentMilestoneId || '(none)'}: ${runner.milestoneTitle || ''}
+
+## Milestone history (id | status | cost | title)
+${milestoneTable}
+
+## Open human decisions / human issues
+${humanIssues}
+
+## Cost
+${cost ? `total: $${cost.total?.toFixed?.(2) ?? cost.total}, last 24h: $${cost.last24h?.toFixed?.(2) ?? cost.last24h}` : '(unavailable)'}
+
+Decide whether this team is making real progress toward the spec, or is stuck in a loop (repeated near-identical milestones, paperwork without code changes, waiting on decisions no one is answering, goalpost drift past the spec's own success definition).`;
+}
+
+export function parseHealthVerdict(resultText) {
+  const match = String(resultText || '').match(/<!-- HEALTH -->\s*([\s\S]*?)\s*<!-- \/HEALTH -->/);
+  if (!match) return null;
+  let data;
+  try {
+    data = JSON.parse(match[1]);
+  } catch {
+    return null;
+  }
+  const verdict = String(data?.verdict || '').toLowerCase();
+  if (!['healthy', 'warn', 'stop'].includes(verdict)) return null;
+  return {
+    verdict,
+    diagnosis: data.diagnosis ? String(data.diagnosis) : '',
+    decisions: Array.isArray(data.decisions) ? data.decisions : [],
+  };
+}
+
+export async function maybeRunHealthAudit(runner, deps = {}, config, managers) {
+  const thresholds = getHealthThresholds(config);
+  if (runner.cycleCount < (runner.healthSnoozeUntilCycle || 0)) return null;
+
+  const signals = computeHealthSignals(runner);
+  const trippedBy = healthTripwire(signals, thresholds);
+  if (!trippedBy) return null;
+
+  deps.log(`🩺 Health tripwire fired (${trippedBy}) — running hygeia audit`, runner.id);
+  runner.lastHealthCheckCycle = runner.cycleCount;
+  runner.saveState();
+
+  const hygeia = (managers || []).find(m => m.name === 'hygeia')
+    || { name: 'hygeia', isManager: true, rawModel: 'high' };
+  const task = buildHealthContext(runner, signals, trippedBy);
+  const result = await runner.runAgent(hygeia, config, null, task, { mode: 'blind', issues: [] });
+  const verdict = result?.resultText ? parseHealthVerdict(result.resultText) : null;
+  if (!verdict) {
+    deps.log('Health audit returned no parseable HEALTH verdict — treating as healthy for this window', runner.id);
+    runner.healthSnoozeUntilCycle = runner.cycleCount + thresholds.snoozeCycles;
+    runner.saveState();
+    return null;
+  }
+
+  if (verdict.verdict === 'healthy') {
+    deps.log(`🩺 Health verdict: healthy — ${verdict.diagnosis || 'no diagnosis'}`, runner.id);
+    runner.healthSnoozeUntilCycle = runner.cycleCount + thresholds.snoozeCycles;
+    runner.saveState();
+  } else if (verdict.verdict === 'warn') {
+    deps.log(`🩺 Health verdict: WARN — ${verdict.diagnosis}`, runner.id);
+    runner.setState({
+      healthWarning: verdict.diagnosis || 'The health audit flagged this team as drifting.',
+      healthSnoozeUntilCycle: runner.cycleCount + thresholds.snoozeCycles,
+    });
+  } else {
+    // stop: park the project on the human, reusing the PROJECT_BLOCKED flow
+    const decisions = verdict.decisions
+      .filter(decision => decision?.question && decision?.recommendation)
+      .map((decision, index) => ({
+        id: decision.id || index + 1,
+        question: String(decision.question),
+        recommendation: String(decision.recommendation),
+        context: decision.context ? String(decision.context) : null,
+      }));
+    const blocked = {
+      summary: verdict.diagnosis || 'Health audit stopped the project.',
+      decisions: decisions.length ? decisions : [{
+        id: 1,
+        question: 'The health audit found this project stuck. Continue anyway, or change the spec/scope?',
+        recommendation: 'review the diagnosis and decide',
+        context: verdict.diagnosis ? verdict.diagnosis.slice(0, 200) : null,
+      }],
+    };
+    const digest = renderBlockedDigest(blocked);
+    deps.log(`🩺 Health verdict: STOP — parking project. ${verdict.diagnosis}`, runner.id);
+    runner.setState({
+      isBlocked: true,
+      blockedDecisions: blocked,
+      pendingUnblockDigest: null,
+      isPaused: true,
+      pauseReason: digest,
+    });
+    deps.broadcastEvent?.({
+      type: 'project-blocked',
+      project: runner.id,
+      summary: blocked.summary,
+      decisions: blocked.decisions,
+      message: digest,
+    });
+  }
+  return verdict;
+}

--- a/src/orchestrator/lifecycle.js
+++ b/src/orchestrator/lifecycle.js
@@ -38,6 +38,8 @@ export function getStatus(runner, deps = {}) {
       isComplete: runner.isComplete || false,
       completionSuccess: runner.completionSuccess || false,
       completionMessage: runner.completionMessage || null,
+      isBlocked: runner.isBlocked || false,
+      blockedDecisions: runner.blockedDecisions || null,
       config: runner.loadConfig(),
       agents: runner.loadAgents(),
       cost: runner.getCostSummary(),

--- a/src/orchestrator/phase-machine.js
+++ b/src/orchestrator/phase-machine.js
@@ -1,4 +1,6 @@
 import fs from 'fs';
+import path from 'path';
+import { maybeRunHealthAudit } from './health.js';
 
 function scheduleBlockPresent(text = '') {
   return /<!--\s*SCHEDULE\s*-->[\s\S]*?<!--\s*\/SCHEDULE\s*-->/.test(String(text || ''));
@@ -23,7 +25,7 @@ function validateManagerDirective(runner, deps, resultText, managerName) {
   const schedule = runner.parseSchedule(text);
   if (!schedule) {
     return {
-      message: 'Malformed SCHEDULE directive. Use the canonical JSON array format exactly: <!-- SCHEDULE --> [ {"agent":"name","task":"..."} ] <!-- /SCHEDULE -->.',
+      message: 'Malformed SCHEDULE directive. Use the canonical JSON array format exactly: <!-- SCHEDULE --> [ {"agent":"name","task":"..."} ] <!-- /SCHEDULE -->. Valid steps: {"agent":"name","task":"..."}, {"delay": minutes}, {"waitFor": {"run": <github run id>, "timeoutMin": N}}.',
     };
   }
 
@@ -31,8 +33,8 @@ function validateManagerDirective(runner, deps, resultText, managerName) {
   const invalid = [];
   const issueScoped = [];
   for (const step of schedule._steps || []) {
-    if (!step || step.delay !== undefined) continue;
-    const name = Object.keys(step).find(key => key !== 'delay');
+    if (!step || step.delay !== undefined || step.waitFor !== undefined) continue;
+    const name = Object.keys(step).find(key => key !== 'delay' && key !== 'waitFor');
     if (name && !allowed.has(name.toLowerCase())) invalid.push(name);
     const value = name ? step[name] : null;
     const visibility = typeof value === 'object' ? String(value.visibility || 'full').toLowerCase() : 'full';
@@ -70,6 +72,123 @@ ${task || ''}`;
     result = await runner.runAgent(manager, config, null, correction, visibility);
   }
   return result;
+}
+
+// One-line summary of the last waitFor outcome, injected into the next manager
+// context so the manager learns the result without a discovery cycle. Consumed once.
+function consumeWaitResultContext(runner) {
+  const wait = runner.lastWaitResult;
+  if (!wait) return '';
+  runner.lastWaitResult = null;
+  runner.saveState();
+  const outcome = wait.timedOut
+    ? `still ${wait.status || 'unknown'} when the ${wait.waitedMin}m wait timed out`
+    : `${wait.status}/${wait.conclusion || '-'} after ${wait.waitedMin}m`;
+  return `> **Last waitFor result:** GitHub Actions run ${wait.runId} → ${outcome}.\n\n`;
+}
+
+// Themis renders an audit verdict, never a veto: EXAM_PASS (clean) or
+// EXAM_FINDINGS (advisory findings for the human). Legacy EXAM_FAIL blocks are
+// accepted and treated as findings.
+export function parseExamVerdict(resultText) {
+  const text = String(resultText || '');
+  if (text.includes('<!-- EXAM_PASS -->')) {
+    return { verdict: 'clean', summary: null, findings: [] };
+  }
+  const match = text.match(/<!-- EXAM_FINDINGS -->\s*([\s\S]*?)\s*<!-- \/EXAM_FINDINGS -->/)
+    || text.match(/<!-- EXAM_FAIL -->\s*([\s\S]*?)\s*<!-- \/EXAM_FAIL -->/);
+  if (!match) return null;
+  let data;
+  try {
+    data = JSON.parse(match[1]);
+  } catch {
+    return {
+      verdict: 'findings',
+      summary: 'Themis findings could not be parsed as JSON.',
+      findings: [{ title: 'Unparsed audit output', detail: match[1].slice(0, 2000), severity: null }],
+    };
+  }
+  const rawFindings = Array.isArray(data.findings) ? data.findings
+    : Array.isArray(data.issues) ? data.issues
+    : [];
+  return {
+    verdict: 'findings',
+    summary: data.summary || data.feedback || null,
+    findings: rawFindings
+      .filter(finding => finding && (finding.title || finding.detail || finding.body))
+      .map(finding => ({
+        title: finding.title || 'Finding',
+        detail: finding.detail || finding.body || '',
+        severity: finding.severity || null,
+      })),
+  };
+}
+
+// The audit report lives in the project data dir (outside repo/) so it never
+// pollutes the repository the agents are building.
+export function writeFinalAuditReport(runner, deps, verdict, claim) {
+  const reportsDir = path.join(runner.projectDir, 'reports');
+  fs.mkdirSync(reportsDir, { recursive: true });
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+  const reportPath = path.join(reportsDir, `final-audit-${stamp}.md`);
+  const lines = [
+    '# Final Audit Report',
+    '',
+    `- Date: ${new Date().toISOString()}`,
+    `- Completion claim: ${claim}`,
+    `- Verdict: ${verdict.verdict === 'clean' ? 'clean' : `${verdict.findings.length} finding(s)`}${verdict.inconclusive ? ' (inconclusive — Themis returned no verdict)' : ''}`,
+  ];
+  if (verdict.summary) {
+    lines.push('', '## Summary', '', verdict.summary);
+  }
+  if (verdict.findings.length) {
+    lines.push('', '## Findings', '');
+    verdict.findings.forEach((finding, index) => {
+      lines.push(`### ${index + 1}. ${finding.title}${finding.severity ? ` (${finding.severity})` : ''}`, '', finding.detail, '');
+    });
+  }
+  fs.writeFileSync(reportPath, lines.join('\n').trimEnd() + '\n');
+  deps.log(`📋 Final audit report written to ${reportPath}`, runner.id);
+  return reportPath;
+}
+
+export function parseProjectBlockedDirective(resultText) {
+  const match = String(resultText || '').match(/<!-- PROJECT_BLOCKED -->\s*([\s\S]*?)\s*<!-- \/PROJECT_BLOCKED -->/);
+  if (!match) return null;
+  let payload;
+  try {
+    payload = JSON.parse(match[1]);
+  } catch (e) {
+    return { error: `PROJECT_BLOCKED payload is not valid JSON: ${e.message}` };
+  }
+  const decisions = Array.isArray(payload?.decisions) ? payload.decisions : [];
+  if (!decisions.length) {
+    return { error: 'PROJECT_BLOCKED must include a non-empty "decisions" array.' };
+  }
+  for (const decision of decisions) {
+    if (!decision?.question || !decision?.recommendation) {
+      return { error: 'Every PROJECT_BLOCKED decision needs both "question" and "recommendation" so the human can answer with a one-line yes/no.' };
+    }
+  }
+  return {
+    blocked: {
+      summary: payload.summary || 'Blocked on human decisions',
+      decisions: decisions.map((decision, index) => ({
+        id: decision.id || index + 1,
+        question: String(decision.question),
+        recommendation: String(decision.recommendation),
+        context: decision.context ? String(decision.context) : null,
+      })),
+    },
+  };
+}
+
+export function renderBlockedDigest(blocked) {
+  const lines = blocked.decisions.map(decision =>
+    `${decision.id}. ${decision.question} (recommend: ${decision.recommendation})${decision.context ? ` — ${decision.context}` : ''}`);
+  return `Blocked on ${blocked.decisions.length} human decision(s): ${blocked.summary}\n`
+    + lines.join('\n')
+    + `\nReply in the project chat (or on the linked issues): a bare "yes"/"accept" per item adopts the recommendation; rejecting an item requires a reason (e.g. "1 yes, 2 no: <why>"). Then press Resume.`;
 }
 
 async function validateAthenaMilestoneDirective(runner, resultText) {
@@ -134,12 +253,25 @@ export async function runRunnerLoop(runner, deps = {}) {
 
       // ===== PHASE: ATHENA (strategy) =====
       if (runner.phase === 'athena') {
+        // Health check: mechanical tripwires escalate to the hygeia auditor,
+        // whose stop verdict parks the project on the human.
+        try {
+          await maybeRunHealthAudit(runner, deps, config, managers);
+        } catch (e) {
+          deps.log(`Health audit error (ignored): ${e.message}`, runner.id);
+        }
+        if (runner.isPaused) continue;
+
         const athena = managers.find(m => m.name === 'athena');
         if (athena) {
           // Build situation context for Athena. Athena owns milestone planning; the
           // orchestrator only validates and executes the DB milestone id Athena emits.
           let situation = '';
-          if (runner.examinationFeedback) {
+          if (runner.pendingUnblockDigest) {
+            const digest = runner.pendingUnblockDigest.split('\n').map(line => `> ${line}`).join('\n');
+            situation = `> **Situation: Resumed after human-decision block**\n> The project was parked on these decisions:\n${digest}\n> The human has resumed the project. Check the project chat and human/chat issues for their reply. A bare "yes"/"accept" on an item means adopt the recommendation; a rejection comes with their reason. Apply the answered decisions, and re-emit PROJECT_BLOCKED only for decisions that are genuinely still unanswered.\n\n`;
+            runner.setState({ pendingUnblockDigest: null });
+          } else if (runner.examinationFeedback) {
             situation = `> **Situation: Project Completion Rejected by Themis**\n> ${runner.examinationFeedback}\n\n`;
           } else if (!runner.milestoneDescription) {
             situation = '> **Situation: Project Just Started**\n\n';
@@ -151,13 +283,20 @@ export async function runRunnerLoop(runner, deps = {}) {
             situation = `> **Situation: Implementation Deadline Missed**\n> Ares's team used ${runner.milestoneCyclesUsed}/${runner.milestoneCyclesBudget} cycles without completing the milestone.\n> Previous milestone: ${runner.currentMilestoneId || 'unknown'}\n> Current branch: ${runner.currentMilestoneBranch || 'not set'}\n\n`;
           }
           situation += `> **Milestone planning:** Select an existing DB milestone record or create/refine one yourself with tbc-db milestone-* --actor athena. Output only that existing milestone id in the MILESTONE directive when ready.\n\n`;
+          situation = consumeWaitResultContext(runner) + situation;
+          if (runner.healthWarning) {
+            situation = `> **⚠️ Health audit warning (mandatory response):** ${runner.healthWarning}\n> Either change course now, block the project on the human with PROJECT_BLOCKED, or state explicitly in your response why the next milestone breaks this pattern. Do not continue the flagged pattern silently.\n\n` + situation;
+            runner.setState({ healthWarning: null });
+          }
 
           let result = await runManagerWithDirectiveRetry(runner, deps, athena, config, situation);
           if (result?.success && result?.resultText) {
-            const problem = await validateAthenaMilestoneDirective(runner, result.resultText);
+            const milestoneProblem = await validateAthenaMilestoneDirective(runner, result.resultText);
+            const blockedProblem = parseProjectBlockedDirective(result.resultText)?.error || null;
+            const problem = milestoneProblem || (blockedProblem ? { message: blockedProblem } : null);
             if (problem) {
-              deps.log(`Rejecting Athena milestone response: ${problem.message}`, runner.id);
-              const correction = `> **Orchestrator rejected your previous milestone directive before acting on it.**\n> Problem: ${problem.message}\n> Generate a corrected response now. If you need to hand off a milestone, first create or edit the DB milestone record, then output only its id.\n\n${situation}`;
+              deps.log(`Rejecting Athena directive response: ${problem.message}`, runner.id);
+              const correction = `> **Orchestrator rejected your previous directive before acting on it.**\n> Problem: ${problem.message}\n> Generate a corrected response now. If you need to hand off a milestone, first create or edit the DB milestone record, then output only its id. If you are blocking on human decisions, emit valid PROJECT_BLOCKED JSON with a "decisions" array where every entry has "question" and "recommendation".\n\n${situation}`;
               result = await runner.runAgent(athena, config, null, correction, null);
             }
           }
@@ -284,6 +423,31 @@ export async function runRunnerLoop(runner, deps = {}) {
               }
             }
 
+            // Check for PROJECT_BLOCKED tag — park the project until the human answers
+            const blockedParse = parseProjectBlockedDirective(result.resultText);
+            if (blockedParse?.blocked) {
+              const digest = renderBlockedDigest(blockedParse.blocked);
+              runner.setState({
+                isBlocked: true,
+                blockedDecisions: blockedParse.blocked,
+                pendingUnblockDigest: null,
+                pendingMilestoneId: null,
+                isPaused: true,
+                pauseReason: digest,
+              });
+              deps.log(`🚧 PROJECT BLOCKED on ${blockedParse.blocked.decisions.length} human decision(s) — pausing until resumed`, runner.id);
+              broadcastEvent({
+                type: 'project-blocked',
+                project: runner.id,
+                summary: blockedParse.blocked.summary,
+                decisions: blockedParse.blocked.decisions,
+                message: digest,
+              });
+              continue;
+            } else if (blockedParse?.error) {
+              deps.log(`Ignoring malformed PROJECT_BLOCKED after retry: ${blockedParse.error}`, runner.id);
+            }
+
             // Check for STOP file
             if (fs.existsSync(runner.stopPath)) {
               deps.log(`STOP file detected — pausing project`, runner.id);
@@ -316,7 +480,7 @@ export async function runRunnerLoop(runner, deps = {}) {
           await runner.decideEpochPR('closed', { actor: 'apollo', reason: failureReason });
           await runner.markCurrentMilestoneFailed(failureReason);
           deps.log(`⏰ Implementation deadline missed (${runner.milestoneCyclesUsed}/${runner.milestoneCyclesBudget} cycles)`, runner.id);
-          runner.setState({ currentEpochId: null, currentEpochPrId: null, currentMilestoneBranch: null, aresGraceCycleUsed: false, phase: 'athena' });
+          runner.setState({ currentEpochId: null, currentEpochPrId: null, currentMilestoneBranch: null, aresGraceCycleUsed: false, phase: 'athena', consecutiveReplans: (runner.consecutiveReplans || 0) + 1 });
           continue;
         }
 
@@ -349,7 +513,8 @@ export async function runRunnerLoop(runner, deps = {}) {
           const openEpochPr = await runner.getOpenEpochPRForCurrentMilestone();
           // Build context for Ares (remaining includes this cycle)
           const cyclesRemaining = Math.max(0, runner.milestoneCyclesBudget - runner.milestoneCyclesUsed);
-          let aresContext = `> **Milestone ID:** ${runner.currentMilestoneId || 'unknown'}
+          let aresContext = consumeWaitResultContext(runner);
+          aresContext += `> **Milestone ID:** ${runner.currentMilestoneId || 'unknown'}
 > **Milestone:** ${runner.milestoneDescription}
 > **Epoch ID:** ${runner.currentEpochId || 'unknown'}
 > **Cycles remaining:** ${cyclesRemaining} of ${runner.milestoneCyclesBudget}
@@ -405,7 +570,7 @@ export async function runRunnerLoop(runner, deps = {}) {
             const failureReason = `Implementation deadline missed after ${runner.milestoneCyclesUsed}/${runner.milestoneCyclesBudget} cycles for ${runner.currentMilestoneId || 'unknown milestone'} (Ares grace review did not claim completion).`;
             await runner.markCurrentMilestoneFailed(failureReason);
             deps.log(`⏰ ${failureReason}`, runner.id);
-            runner.setState({ currentEpochId: null, currentEpochPrId: null, currentMilestoneBranch: null, aresGraceCycleUsed: false, phase: 'athena', verificationFeedback: failureReason });
+            runner.setState({ currentEpochId: null, currentEpochPrId: null, currentMilestoneBranch: null, aresGraceCycleUsed: false, phase: 'athena', verificationFeedback: failureReason, consecutiveReplans: (runner.consecutiveReplans || 0) + 1 });
             runner.saveState();
             continue;
           }
@@ -447,9 +612,9 @@ export async function runRunnerLoop(runner, deps = {}) {
         const apollo = managers.find(m => m.name === 'apollo');
         if (apollo) {
           const isRollupVerification = !runner.currentEpochPrId;
-          const apolloContext = isRollupVerification
+          const apolloContext = consumeWaitResultContext(runner) + (isRollupVerification
             ? `> **Milestone ID:** ${runner.currentMilestoneId || 'unknown'}\n> **Milestone to verify:** ${runner.milestoneDescription}\n> **Verification mode:** Parent milestone rollup after a child milestone passed\n> **Active epoch PR:** none (rollup verification)\n> Apollo should decide whether this parent milestone is now fully complete or Athena should plan the next child under it.\n\n`
-            : `> **Milestone ID:** ${runner.currentMilestoneId || 'unknown'}\n> **Milestone to verify:** ${runner.milestoneDescription}\n> **Milestone branch:** ${runner.currentMilestoneBranch || 'not set'}\n> **Active epoch PR:** ${runner.currentEpochPrId || 'unknown'}\n> Apollo owns the PR decision: merge on pass, close on fail.\n\n`;
+            : `> **Milestone ID:** ${runner.currentMilestoneId || 'unknown'}\n> **Milestone to verify:** ${runner.milestoneDescription}\n> **Milestone branch:** ${runner.currentMilestoneBranch || 'not set'}\n> **Active epoch PR:** ${runner.currentEpochPrId || 'unknown'}\n> Apollo owns the PR decision: merge on pass, close on fail.\n\n`);
 
           const result = await runManagerWithDirectiveRetry(runner, deps, apollo, config, apolloContext);
           cycleTotal++;
@@ -531,6 +696,7 @@ export async function runRunnerLoop(runner, deps = {}) {
                 lastMergedMilestoneBranch: runner.currentMilestoneBranch || runner.lastMergedMilestoneBranch,
                 verificationFeedback: null,
                 isFixRound: false,
+                consecutiveReplans: 0,
                 phase: 'verification',
               });
               broadcastEvent({ type: 'phase', project: runner.id, phase: 'verification', title: parentMilestone?.title || parentMilestoneId });
@@ -552,6 +718,7 @@ export async function runRunnerLoop(runner, deps = {}) {
                 lastMergedMilestoneBranch: runner.currentMilestoneBranch || runner.lastMergedMilestoneBranch,
                 verificationFeedback: null,
                 isFixRound: false,
+                consecutiveReplans: 0,
                 phase: 'athena',
               });
             }
@@ -568,6 +735,7 @@ export async function runRunnerLoop(runner, deps = {}) {
                 aresGraceCycleUsed: false,
                 verificationFeedback: failureReason,
                 isFixRound: false,
+                consecutiveReplans: (runner.consecutiveReplans || 0) + 1,
                 phase: 'athena',
               });
             } else {
@@ -581,6 +749,7 @@ export async function runRunnerLoop(runner, deps = {}) {
                 aresGraceCycleUsed: false,
                 verificationFeedback: failureReason,
                 isFixRound: false,
+                consecutiveReplans: (runner.consecutiveReplans || 0) + 1,
                 phase: 'athena',
               });
             }
@@ -606,33 +775,39 @@ export async function runRunnerLoop(runner, deps = {}) {
         } else {
         const themis = managers.find(m => m.name === 'themis');
         if (themis) {
-          const themisContext = `> **Final completion claim:** ${runner.pendingCompletionMessage || 'Project claimed complete'}\n> **Evaluate the entire project, not just the human\'s explicit goal.** Audit correctness, completeness, maintainability, artifacts, tests, docs, and obvious risks.\n\n`;
-          const result = await runManagerWithDirectiveRetry(runner, deps, themis, config, themisContext, { visibility: { mode: 'full', issues: [] } });
+          const themisContext = consumeWaitResultContext(runner)
+            + `> **Final completion claim:** ${runner.pendingCompletionMessage || 'Project claimed complete'}\n> **Audit, don't veto.** Judge the claim against the spec's own success definition first, then record everything else as advisory findings for the human. Conclude with EXAM_PASS or EXAM_FINDINGS — either way the project completes and your findings go into the final audit report.\n\n`;
+          let result = await runManagerWithDirectiveRetry(runner, deps, themis, config, themisContext, { visibility: { mode: 'full', issues: [] } });
           cycleTotal++;
           if (!result || !result.success) cycleFailures++;
 
           let schedule = null;
-          let decision = null;
-          let failData = null;
+          let verdict = null;
           if (result && result.resultText) {
             schedule = runner.parseSchedule(result.resultText);
             if (schedule) {
               deps.log(`Schedule: ${JSON.stringify(schedule)}`, runner.id);
             }
+            verdict = parseExamVerdict(result.resultText);
+          }
 
-            if (result.resultText.includes('<!-- EXAM_PASS -->')) {
-              decision = 'pass';
-            }
-            const failMatch = result.resultText.match(/<!-- EXAM_FAIL -->\s*([\s\S]*?)\s*<!-- \/EXAM_FAIL -->/);
-            if (failMatch) {
-              try {
-                failData = JSON.parse(failMatch[1]);
-              } catch {
-                failData = { feedback: 'Themis rejected project completion, but the response could not be parsed.' };
-              }
-              decision = 'fail';
-            } else if (!schedule && decision == null) {
-              decision = 'fail';
+          // No verdict and no further investigation: one correction retry, then
+          // complete anyway with an inconclusive note — examination never loops
+          // the project back to Athena.
+          if (!schedule && !verdict) {
+            deps.log('Themis returned no verdict and no schedule — requesting a corrected response', runner.id);
+            const correction = `> **Orchestrator rejected your previous response before acting on it.**\n> Problem: your response contained neither a SCHEDULE, nor EXAM_PASS, nor EXAM_FINDINGS.\n> Conclude the audit now with <!-- EXAM_PASS --> or <!-- EXAM_FINDINGS -->{"summary":"...","findings":[{"title":"...","detail":"..."}]}<!-- /EXAM_FINDINGS -->.\n\n${themisContext}`;
+            result = await runner.runAgent(themis, config, null, correction, { mode: 'full', issues: [] });
+            cycleTotal++;
+            if (!result || !result.success) cycleFailures++;
+            verdict = result?.resultText ? parseExamVerdict(result.resultText) : null;
+            if (!verdict) {
+              verdict = {
+                verdict: 'findings',
+                summary: 'Audit inconclusive — Themis returned no verdict after a retry.',
+                findings: [],
+                inconclusive: true,
+              };
             }
           }
 
@@ -648,8 +823,13 @@ export async function runRunnerLoop(runner, deps = {}) {
             runner.saveState();
           }
 
-          if (decision === 'pass') {
-            const message = runner.pendingCompletionMessage || 'Project completed';
+          if (verdict) {
+            const claim = runner.pendingCompletionMessage || 'Project completed';
+            const reportPath = writeFinalAuditReport(runner, deps, verdict, claim);
+            const auditNote = verdict.verdict === 'clean'
+              ? 'Final audit: clean.'
+              : `Final audit: ${verdict.findings.length} finding(s)${verdict.inconclusive ? ' (inconclusive)' : ''} — see ${reportPath}`;
+            const message = `${claim} — ${auditNote}`;
             runner.setState({
               phase: 'athena',
               isComplete: true,
@@ -660,48 +840,12 @@ export async function runRunnerLoop(runner, deps = {}) {
               currentSchedule: null,
               completedAgents: [],
               isPaused: true,
-              pauseReason: `Project completed successfully: ${message}`,
+              pauseReason: `Project completed: ${message}`,
             });
-            deps.log(`🏁 PROJECT COMPLETE (validated by Themis): ${message}`, runner.id);
+            deps.log(`🏁 PROJECT COMPLETE (audited by Themis — ${verdict.verdict === 'clean' ? 'clean' : `${verdict.findings.length} finding(s)`}): ${claim}`, runner.id);
             broadcastEvent({ type: 'project-complete', project: runner.id, success: true, message });
-          } else if (decision === 'fail') {
-            let issues = Array.isArray(failData?.issues) ? failData.issues : [];
-            const rawFeedback = (result?.resultText || '').trim();
-            if (issues.length === 0) {
-              issues = [{
-                title: 'Themis rejected project completion',
-                body: rawFeedback || failData?.feedback || failData?.summary || 'Themis did not issue EXAM_PASS, so the completion claim was rejected.',
-              }];
-            }
-            const createdIssueIds = [];
-            for (const issue of issues) {
-              if (!issue?.title) continue;
-              try {
-                const created = await runner.createIssue(issue.title, issue.body || '', 'themis');
-                createdIssueIds.push(created.issueId);
-              } catch (e) {
-                deps.log(`Themis issue creation failed: ${e.message}`, runner.id);
-              }
-            }
-            const feedback = failData?.feedback || failData?.summary || rawFeedback || 'Themis rejected the project completion claim.';
-            runner.setState({
-              phase: 'athena',
-              examinationFeedback: createdIssueIds.length
-                ? `${feedback} New issues: ${createdIssueIds.map(id => `#${id}`).join(', ')}`
-                : feedback,
-              pendingCompletionMessage: null,
-              currentSchedule: null,
-              completedAgents: [],
-              isComplete: false,
-              completionSuccess: false,
-              completionMessage: null,
-              isPaused: false,
-              pauseReason: null,
-            });
-            deps.log(`❌ Themis rejected project completion — returning to Athena`, runner.id);
-            broadcastEvent({ type: 'phase', project: runner.id, phase: 'athena', title: runner.milestoneTitle || 'Replanning after Themis rejection' });
           } else {
-            // No decision yet, stay in examination phase — still save
+            // Investigation continues, stay in examination phase — still save
             runner.saveState();
           }
         }

--- a/src/orchestrator/scheduler.js
+++ b/src/orchestrator/scheduler.js
@@ -1,4 +1,29 @@
+import path from 'path';
+import fs from 'fs';
+import { execFile } from 'child_process';
 import { extractFocusedRefIds } from './object-refs.js';
+
+export const WAIT_FOR_DEFAULT_TIMEOUT_MIN = 720;
+export const WAIT_FOR_MAX_TIMEOUT_MIN = 1440;
+export const WAIT_FOR_DEFAULT_POLL_MIN = 5;
+export const WAIT_FOR_MIN_POLL_MIN = 3;
+
+export function normalizeWaitForSpec(spec) {
+  if (!spec || typeof spec !== 'object' || Array.isArray(spec)) return null;
+  const runId = spec.run;
+  const isValidId = typeof runId === 'number'
+    ? Number.isInteger(runId) && runId > 0
+    : typeof runId === 'string' && /^\d+$/.test(runId.trim());
+  if (!isValidId) return null;
+  const knownKeys = new Set(['run', 'timeoutMin', 'pollMin']);
+  if (Object.keys(spec).some(key => !knownKeys.has(key))) return null;
+  const timeoutMin = Math.min(
+    Math.max(parseFloat(spec.timeoutMin) || WAIT_FOR_DEFAULT_TIMEOUT_MIN, 1),
+    WAIT_FOR_MAX_TIMEOUT_MIN
+  );
+  const pollMin = Math.max(parseFloat(spec.pollMin) || WAIT_FOR_DEFAULT_POLL_MIN, WAIT_FOR_MIN_POLL_MIN);
+  return { run: String(runId).trim(), timeoutMin, pollMin };
+}
 
 export async function autoPauseWait(runner, deps = {}, intervalMs, resumeCondition = null) {
     const retryAt = Date.now() + intervalMs;
@@ -59,6 +84,11 @@ export function parseSchedule(runner, deps = {}, resultText) {
           ? { delay: step.delay }
           : null;
       }
+      if (step.waitFor !== undefined) {
+        if (Object.keys(step).length !== 1) return null;
+        const waitFor = normalizeWaitForSpec(step.waitFor);
+        return waitFor ? { waitFor } : null;
+      }
       if (typeof step.agent !== 'string' || !step.agent.trim()) return null;
       const { agent, ...rest } = step;
       if (!Object.prototype.hasOwnProperty.call(rest, 'task')) return null;
@@ -75,6 +105,76 @@ export function parseSchedule(runner, deps = {}, resultText) {
       return null;
     }
   }
+
+function ghRunStatus(repoDir, runId) {
+  return new Promise((resolve) => {
+    execFile('gh', ['run', 'view', runId, '--json', 'status,conclusion'], {
+      cwd: repoDir,
+      timeout: 60_000,
+    }, (error, stdout) => {
+      if (error) {
+        resolve({ error: error.message });
+        return;
+      }
+      try {
+        const parsed = JSON.parse(stdout);
+        resolve({ status: parsed.status || null, conclusion: parsed.conclusion || null });
+      } catch (e) {
+        resolve({ error: `Unparseable gh output: ${e.message}` });
+      }
+    });
+  });
+}
+
+// Token-free wait: poll a GitHub Actions run with the gh CLI until it reaches a
+// terminal state or the timeout expires. Managers see the outcome via
+// runner.lastWaitResult in their next cycle context.
+export async function waitForCondition(runner, deps = {}, spec) {
+  const normalized = normalizeWaitForSpec(spec);
+  if (!normalized) return null;
+  const { run, timeoutMin, pollMin } = normalized;
+  const repoCheckout = path.join(runner.projectDir, 'repo');
+  const repoDir = fs.existsSync(repoCheckout) ? repoCheckout : runner.path;
+  const deadline = Date.now() + timeoutMin * 60000;
+  const startedAt = Date.now();
+  deps.log(`⏳ waitFor: polling run ${run} every ${pollMin}m (timeout ${timeoutMin}m)...`, runner.id);
+
+  let last = { status: null, conclusion: null };
+  while (runner.running && !runner.abortCurrentCycle && !runner.wakeNow) {
+    const check = await ghRunStatus(repoDir, run);
+    if (check.error) {
+      deps.log(`waitFor: gh check failed (${check.error}) — will retry`, runner.id);
+    } else {
+      last = check;
+      if (check.status === 'completed') break;
+    }
+    if (Date.now() >= deadline) break;
+    // Sleep one poll interval in small increments so pause/abort stay responsive
+    const pollMs = Math.min(pollMin * 60000, deadline - Date.now());
+    runner.sleepUntil = Date.now() + pollMs;
+    let slept = 0;
+    while (slept < pollMs && !runner.wakeNow && runner.running && !runner.abortCurrentCycle) {
+      await deps.sleep(5000);
+      slept += 5000;
+      while (runner.isPaused && !runner.wakeNow && runner.running && !runner.abortCurrentCycle) { await deps.sleep(1000); }
+    }
+    runner.sleepUntil = null;
+  }
+  runner.sleepUntil = null;
+
+  const waitedMin = Math.round((Date.now() - startedAt) / 60000);
+  const result = {
+    runId: run,
+    status: last.status,
+    conclusion: last.conclusion,
+    waitedMin,
+    timedOut: last.status !== 'completed',
+  };
+  runner.lastWaitResult = result;
+  runner.saveState();
+  deps.log(`waitFor: run ${run} → ${result.status || 'unknown'}/${result.conclusion || '-'} after ${waitedMin}m${result.timedOut ? ' (timed out)' : ''}`, runner.id);
+  return result;
+}
 
 export async function executeSchedule(runner, deps = {}, schedule, config, managerName = null) {
     if (!schedule || !schedule._steps) return { total: 0, failures: 0 };
@@ -96,9 +196,16 @@ export async function executeSchedule(runner, deps = {}, schedule, config, manag
         if (runner.abortCurrentCycle) break;
         continue;
       }
-      
+
+      // waitFor step: token-free poll of an external condition (e.g. a GitHub Actions run)
+      if (step.waitFor !== undefined) {
+        await waitForCondition(runner, deps, step.waitFor);
+        if (runner.abortCurrentCycle) break;
+        continue;
+      }
+
       // Agent step: { "agentName": taskValue }
-      const name = Object.keys(step).find(k => k !== 'delay');
+      const name = Object.keys(step).find(k => k !== 'delay' && k !== 'waitFor');
       if (!name) continue;
 
       // Skip agents already completed (supports resume after reboot)

--- a/src/orchestrator/state-control.js
+++ b/src/orchestrator/state-control.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { renderBlockedDigest } from './phase-machine.js';
 
 export async function startRunner(runner, deps = {}) {
     if (runner.running) return;
@@ -86,6 +87,14 @@ export function loadRunnerState(runner, deps = {}) {
         runner.isComplete = state.isComplete || false;
         runner.completionSuccess = state.completionSuccess || false;
         runner.completionMessage = state.completionMessage || null;
+        runner.lastWaitResult = state.lastWaitResult || null;
+        runner.isBlocked = state.isBlocked || false;
+        runner.blockedDecisions = state.blockedDecisions || null;
+        runner.pendingUnblockDigest = state.pendingUnblockDigest || null;
+        runner.consecutiveReplans = state.consecutiveReplans || 0;
+        runner.healthWarning = state.healthWarning || null;
+        runner.healthSnoozeUntilCycle = state.healthSnoozeUntilCycle || 0;
+        runner.lastHealthCheckCycle = state.lastHealthCheckCycle || 0;
         deps.log(`Loaded state: cycle ${runner.cycleCount}, phase: ${runner.phase}, completed: [${runner.completedAgents.join(', ')}]${runner.isPaused ? ', paused' : ''}`, runner.id);
       } else {
         // New project — start paused
@@ -131,6 +140,14 @@ export function saveRunnerState(runner, deps = {}) {
         isComplete: runner.isComplete || false,
         completionSuccess: runner.completionSuccess || false,
         completionMessage: runner.completionMessage || null,
+        lastWaitResult: runner.lastWaitResult || null,
+        isBlocked: runner.isBlocked || false,
+        blockedDecisions: runner.blockedDecisions || null,
+        pendingUnblockDigest: runner.pendingUnblockDigest || null,
+        consecutiveReplans: runner.consecutiveReplans || 0,
+        healthWarning: runner.healthWarning || null,
+        healthSnoozeUntilCycle: runner.healthSnoozeUntilCycle || 0,
+        lastHealthCheckCycle: runner.lastHealthCheckCycle || 0,
         lastUpdated: new Date().toISOString()
       };
       fs.writeFileSync(statePath, JSON.stringify(state, null, 2));
@@ -171,6 +188,19 @@ export function resumeRunner(runner, deps = {}) {
         pendingCompletionMessage: null,
         currentSchedule: null,
         completedAgents: [],
+      });
+    } else if (runner.isBlocked) {
+      deps.log(`Resuming blocked project — Athena will intake the human's decision replies`, runner.id);
+      const digest = runner.blockedDecisions
+        ? renderBlockedDigest(runner.blockedDecisions)
+        : (runner.pauseReason || 'Project was blocked on human decisions.');
+      runner.setState({
+        isBlocked: false,
+        blockedDecisions: null,
+        pendingUnblockDigest: digest,
+        isPaused: false,
+        pauseReason: null,
+        phase: 'athena',
       });
     } else {
       runner.setState({ isPaused: false, pauseReason: null });

--- a/src/server.js
+++ b/src/server.js
@@ -288,6 +288,7 @@ function broadcastEvent(event) {
     error: `⚠️ ${event.message}`,
     'agent-done': `${event.success ? '✓' : '✗'} ${event.agent}: ${event.summary || 'no response'}`,
     'project-complete': `🏁 Project ${event.success ? 'completed' : 'ended'}: ${event.message}`,
+    'project-blocked': `🚧 Project needs your decisions: ${event.message || event.summary || ''}`,
   };
   const notification = {
     id: Date.now().toString(36) + Math.random().toString(36).slice(2, 6),

--- a/tests/examination-phase.test.js
+++ b/tests/examination-phase.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { parseExamVerdict } from '../src/orchestrator/phase-machine.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const serverPath = path.join(__dirname, '..', 'src', 'orchestrator', 'ProjectRunner.js');
@@ -63,9 +64,9 @@ describe('Themis examination phase', () => {
       'Expected examination workers to run under Themis ownership');
     assert.match(src, /executeSchedule\((?:this|runner)\.currentSchedule, config, 'themis'\)/,
       'Expected interrupted Themis schedules to resume under Themis ownership');
-    assert.match(src, /let decision = null/,
+    assert.match(src, /let verdict = null/,
       'Expected examination to support non-terminal cycles');
-    assert.match(src, /No decision yet, stay in examination phase/,
+    assert.match(src, /Investigation continues, stay in examination phase/,
       'Expected schedule-only examination cycles to remain in examination');
   });
 
@@ -89,58 +90,72 @@ describe('Themis examination phase', () => {
       'Expected correction prompt to tell managers to use focused\/full visibility for issue\/PR-board work');
   });
 
-  it('finalizes completion only on EXAM_PASS', () => {
+  it('finalizes completion on any verdict — audit without veto', () => {
     const src = readOrchestratorSource();
-    const examBlock = src.match(/else if \((?:this|runner)\.phase === 'examination'\) \{([\s\S]*?)\n      \}/);
+    const examBlock = src.match(/else if \((?:this|runner)\.phase === 'examination'\) \{([\s\S]*?)\n      \}\n\n      \/\/ If no agent succeeded/);
     assert.ok(examBlock, 'Could not find examination phase block');
     const block = examBlock[1];
 
-    assert.match(block, /EXAM_PASS/,
-      'Expected EXAM_PASS handling');
+    assert.match(block, /parseExamVerdict/,
+      'Expected examination to parse a verdict (EXAM_PASS or EXAM_FINDINGS)');
     assert.match(block, /isComplete:\s*true/,
-      'Expected EXAM_PASS to finalize the project');
-    assert.match(block, /phase:\s*'athena'/,
-      'Expected EXAM_PASS to exit examination phase cleanly');
+      'Expected a verdict to finalize the project');
+    assert.match(block, /completionSuccess:\s*true/,
+      'Expected findings verdicts to still complete the project successfully');
+    assert.match(block, /writeFinalAuditReport/,
+      'Expected the verdict to be written to a final audit report');
+    assert.match(block, /examinationFeedback: null/,
+      'Examination must clear feedback, never send it back to Athena');
+    assert.doesNotMatch(block, /phase: 'athena',\s*\n\s*examinationFeedback: [^n]/,
+      'The EXAM_FAIL → Athena feedback loop must be gone');
+    assert.doesNotMatch(block, /createIssue/,
+      'Examination must not create tracker issues');
   });
 
-  it('does not overwrite EXAM_PASS with failure just because no schedule exists', () => {
+  it('retries once and completes inconclusively rather than looping to Athena', () => {
     const src = readOrchestratorSource();
-    assert.doesNotMatch(
-      src,
-      /if \(result\.resultText\.includes\('\<\!-- EXAM_PASS --\>'\)\) \{\s*decision = 'pass';\s*\}[\s\S]*?else if \(!schedule\) \{\s*decision = 'fail';\s*\}/,
-      'EXAM_PASS must remain terminal success even when Themis returns no schedule'
-    );
+    assert.match(src, /Audit inconclusive — Themis returned no verdict after a retry\./,
+      'Expected a terminal inconclusive fallback');
+    assert.doesNotMatch(src, /Themis rejected project completion/,
+      'The EXAM_FAIL rejection loop must be gone');
   });
 
-  it('returns to athena and creates issues on EXAM_FAIL', () => {
+  it('writes the audit report outside the repo, in the project data dir', () => {
     const src = readOrchestratorSource();
-    const examBlock = src.match(/else if \((?:this|runner)\.phase === 'examination'\) \{([\s\S]*?)\n      \}/);
-    assert.ok(examBlock, 'Could not find examination phase block');
-    const block = examBlock[1];
+    assert.match(src, /path\.join\(runner\.projectDir, 'reports'\)/,
+      'Audit reports belong under {projectDir}/reports');
+    assert.match(src, /final-audit-/,
+      'Audit report filenames should be recognizable');
+  });
+});
 
-    assert.match(block, /decision === 'fail'/,
-      'Expected explicit EXAM_FAIL handling');
-    assert.match(block, /phase:\s*'athena'/,
-      'Expected failed examination result to return control to Athena');
-    assert.match(block, /issue-create|createIssue|INSERT INTO issues/i,
-      'Expected failed examination result to create issues');
+describe('parseExamVerdict', () => {
+  it('recognizes EXAM_PASS as a clean verdict', () => {
+    assert.deepEqual(parseExamVerdict('done <!-- EXAM_PASS -->{"message":"ok"}<!-- /EXAM_PASS -->'),
+      { verdict: 'clean', summary: null, findings: [] });
   });
 
-  it('still falls back to raw feedback when EXAM_FAIL JSON is absent or incomplete', () => {
-    const src = readOrchestratorSource();
-    const examBlock = src.match(/else if \((?:this|runner)\.phase === 'examination'\) \{([\s\S]*?)\n      \}/);
-    assert.ok(examBlock, 'Could not find examination phase block');
-    const block = examBlock[1];
-
-    assert.match(block, /rawFeedback/,
-      'Expected examination failure path to fall back to raw Themis output when structured feedback is absent');
+  it('parses EXAM_FINDINGS with severity', () => {
+    const verdict = parseExamVerdict('<!-- EXAM_FINDINGS -->{"summary":"partial","findings":[{"title":"Gap","detail":"evidence","severity":"high"}]}<!-- /EXAM_FINDINGS -->');
+    assert.equal(verdict.verdict, 'findings');
+    assert.equal(verdict.summary, 'partial');
+    assert.deepEqual(verdict.findings, [{ title: 'Gap', detail: 'evidence', severity: 'high' }]);
   });
 
-  it('gives Athena context when Themis rejects project completion', () => {
-    const src = readOrchestratorSource();
-    const athenaSituation = src.match(/let situation = '';/);
-    assert.ok(athenaSituation, 'Could not find Athena situation builder');
-    assert.match(src, /examinationFeedback/,
-      'Expected server state to track examination feedback for Athena');
+  it('maps legacy EXAM_FAIL blocks to findings instead of rejection', () => {
+    const verdict = parseExamVerdict('<!-- EXAM_FAIL -->{"summary":"nope","feedback":"fix it","issues":[{"title":"Blocker","body":"details"}]}<!-- /EXAM_FAIL -->');
+    assert.equal(verdict.verdict, 'findings');
+    assert.equal(verdict.summary, 'nope');
+    assert.deepEqual(verdict.findings, [{ title: 'Blocker', detail: 'details', severity: null }]);
+  });
+
+  it('degrades unparseable verdict JSON into a findings verdict', () => {
+    const verdict = parseExamVerdict('<!-- EXAM_FINDINGS -->not json<!-- /EXAM_FINDINGS -->');
+    assert.equal(verdict.verdict, 'findings');
+    assert.equal(verdict.findings.length, 1);
+  });
+
+  it('returns null when no verdict tag is present', () => {
+    assert.equal(parseExamVerdict('<!-- SCHEDULE -->[{"delay":5}]<!-- /SCHEDULE -->'), null);
   });
 });

--- a/tests/health-signals.test.js
+++ b/tests/health-signals.test.js
@@ -1,0 +1,148 @@
+import { describe, it, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import Database from 'better-sqlite3';
+import {
+  DEFAULT_HEALTH_THRESHOLDS,
+  buildHealthContext,
+  computeHealthSignals,
+  getHealthThresholds,
+  healthTripwire,
+  parseHealthVerdict,
+} from '../src/orchestrator/health.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const phaseMachinePath = path.join(__dirname, '..', 'src', 'orchestrator', 'phase-machine.js');
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tbc-health-'));
+after(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+function makeProjectDb(name) {
+  const dbPath = path.join(tmpDir, `${name}.db`);
+  const db = new Database(dbPath);
+  db.exec(`
+    CREATE TABLE milestones (id INTEGER PRIMARY KEY AUTOINCREMENT, milestone_id TEXT UNIQUE, title TEXT, description TEXT NOT NULL, cycles_budget INTEGER DEFAULT 20, cycles_used INTEGER DEFAULT 0, branch_name TEXT, parent_milestone_id TEXT, linked_pr_id INTEGER, failure_reason TEXT, phase TEXT DEFAULT 'implementation', status TEXT DEFAULT 'active', created_at TEXT, completed_at TEXT);
+    CREATE TABLE tbc_prs (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'open', base_branch TEXT DEFAULT 'main', head_branch TEXT DEFAULT 'x', updated_at TEXT);
+    CREATE TABLE reports (id INTEGER PRIMARY KEY AUTOINCREMENT, cycle INTEGER, agent TEXT, body TEXT, milestone_id TEXT, cost REAL, created_at TEXT);
+    CREATE TABLE issues (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL, body TEXT DEFAULT '', status TEXT DEFAULT 'open', creator TEXT NOT NULL);
+  `);
+  return { db, dbPath };
+}
+
+function fakeRunner(dbPath, overrides = {}) {
+  return {
+    id: 'test',
+    cycleCount: 100,
+    lastHealthCheckCycle: 90,
+    consecutiveReplans: 0,
+    currentMilestoneId: null,
+    milestoneTitle: null,
+    specPath: path.join(tmpDir, 'no-spec.md'),
+    getDb() { return new Database(dbPath); },
+    getCostSummary() { return { total: 12.5, last24h: 3.25 }; },
+    ...overrides,
+  };
+}
+
+describe('health thresholds and tripwires', () => {
+  it('merges config overrides over defaults, ignoring invalid values', () => {
+    const thresholds = getHealthThresholds({ health: { consecutiveReplans: 5, milestoneDepth: -1, bogus: 9 } });
+    assert.equal(thresholds.consecutiveReplans, 5);
+    assert.equal(thresholds.milestoneDepth, DEFAULT_HEALTH_THRESHOLDS.milestoneDepth);
+    assert.equal(thresholds.noMergeStreak, DEFAULT_HEALTH_THRESHOLDS.noMergeStreak);
+    assert.equal(thresholds.bogus, undefined);
+  });
+
+  it('fires on each signal and stays quiet below thresholds', () => {
+    const t = DEFAULT_HEALTH_THRESHOLDS;
+    const calm = { consecutiveReplans: 0, milestoneFamilySize: 1, milestoneDepth: 1, noMergeStreak: 0, cyclesSinceLastHealthCheck: 3 };
+    assert.equal(healthTripwire(calm, t), null);
+    assert.match(healthTripwire({ ...calm, consecutiveReplans: 3 }, t), /consecutiveReplans/);
+    assert.match(healthTripwire({ ...calm, milestoneFamilySize: 8 }, t), /milestoneFamilySize/);
+    assert.match(healthTripwire({ ...calm, milestoneDepth: 4 }, t), /milestoneDepth/);
+    assert.match(healthTripwire({ ...calm, noMergeStreak: 5 }, t), /noMergeStreak/);
+    assert.match(healthTripwire({ ...calm, cyclesSinceLastHealthCheck: 50 }, t), /cycleFloor/);
+  });
+});
+
+describe('computeHealthSignals', () => {
+  it('measures the M87-style pathology: big family, deep nesting, no merges', () => {
+    const { db, dbPath } = makeProjectDb('pathology');
+    const insertMilestone = db.prepare("INSERT INTO milestones (milestone_id, title, description, status, created_at, completed_at) VALUES (?, ?, 'd', ?, ?, ?)");
+    insertMilestone.run('M87', 'parent', 'active', '2026-05-14T00:00:00Z', null);
+    for (let i = 1; i <= 9; i++) {
+      insertMilestone.run(`M87.${i}`, `child ${i}`, i % 3 ? 'completed' : 'failed', `2026-05-${14 + i}T00:00:00Z`, `2026-05-${14 + i}T12:00:00Z`);
+    }
+    db.prepare("INSERT INTO tbc_prs (title, status, updated_at) VALUES ('old merge', 'merged', '2026-05-14T00:00:00Z')").run();
+    db.prepare("INSERT INTO reports (cycle, agent, body, cost, created_at) VALUES (1, 'ares', 'b', 100.5, '2026-05-20T00:00:00Z')").run();
+    db.close();
+
+    const signals = computeHealthSignals(fakeRunner(dbPath, { currentMilestoneId: 'M87.9', consecutiveReplans: 2 }));
+    assert.equal(signals.consecutiveReplans, 2);
+    assert.equal(signals.milestoneFamilySize, 10);
+    assert.equal(signals.milestoneDepth, 2);
+    assert.equal(signals.noMergeStreak, 9);
+    assert.equal(signals.costSinceLastMerge, 100.5);
+    assert.equal(signals.cyclesSinceLastHealthCheck, 10);
+  });
+
+  it('counts all terminal milestones when nothing was ever merged', () => {
+    const { db, dbPath } = makeProjectDb('no-merge');
+    db.prepare("INSERT INTO milestones (milestone_id, title, description, status) VALUES ('M1', 't', 'd', 'completed')").run();
+    db.close();
+    const signals = computeHealthSignals(fakeRunner(dbPath));
+    assert.equal(signals.noMergeStreak, 1);
+    assert.equal(signals.milestoneFamilySize, 0, 'no current milestone → no family');
+  });
+});
+
+describe('health context and verdict parsing', () => {
+  it('builds a trajectory-level context with milestone history and human decisions', () => {
+    const { db, dbPath } = makeProjectDb('context');
+    db.prepare("INSERT INTO milestones (milestone_id, title, description, status) VALUES ('M1', 'Do the thing', 'd', 'completed')").run();
+    db.prepare("INSERT INTO issues (title, creator, status) VALUES ('HUMAN: accept 28% error?', 'athena', 'open')").run();
+    db.prepare("INSERT INTO issues (title, creator, status) VALUES ('Calibrate tier 1', 'human', 'open')").run();
+    db.close();
+    const context = buildHealthContext(fakeRunner(dbPath), { consecutiveReplans: 1 }, 'cycleFloor');
+    assert.match(context, /M1 \| completed \| \$0 \| Do the thing/);
+    assert.match(context, /HUMAN: accept 28% error\?/);
+    assert.match(context, /Calibrate tier 1/);
+    assert.match(context, /judge the trajectory, not the narrative/);
+    assert.doesNotMatch(context, /knowledge\//, 'context must not point the auditor at the knowledge base');
+  });
+
+  it('parses HEALTH verdicts and rejects malformed ones', () => {
+    assert.deepEqual(parseHealthVerdict('<!-- HEALTH -->{"verdict":"warn","diagnosis":"loop"}<!-- /HEALTH -->'),
+      { verdict: 'warn', diagnosis: 'loop', decisions: [] });
+    const stop = parseHealthVerdict('<!-- HEALTH -->{"verdict":"stop","diagnosis":"d","decisions":[{"question":"q","recommendation":"r"}]}<!-- /HEALTH -->');
+    assert.equal(stop.verdict, 'stop');
+    assert.equal(stop.decisions.length, 1);
+    assert.equal(parseHealthVerdict('<!-- HEALTH -->{"verdict":"panic"}<!-- /HEALTH -->'), null);
+    assert.equal(parseHealthVerdict('<!-- HEALTH -->not json<!-- /HEALTH -->'), null);
+    assert.equal(parseHealthVerdict('no tag'), null);
+  });
+});
+
+describe('health wiring in the phase machine', () => {
+  const src = fs.readFileSync(phaseMachinePath, 'utf-8');
+
+  it('runs the health audit at the top of the athena phase', () => {
+    assert.match(src, /if \(runner\.phase === 'athena'\) \{\s*\n\s*\/\/ Health check[\s\S]{0,200}maybeRunHealthAudit\(runner, deps, config, managers\)/,
+      'Expected the athena phase to consult the health auditor first');
+  });
+
+  it('injects warn diagnoses as a mandatory-response block and consumes them', () => {
+    assert.match(src, /Health audit warning \(mandatory response\)/);
+    assert.match(src, /runner\.setState\(\{ healthWarning: null \}\)/);
+  });
+
+  it('increments consecutiveReplans on every replan path and resets on verified milestones', () => {
+    const increments = src.match(/consecutiveReplans: \(runner\.consecutiveReplans \|\| 0\) \+ 1/g) || [];
+    assert.ok(increments.length >= 4,
+      `Expected replan increments on deadline-miss (x2) and verify-fail (x2) paths, found ${increments.length}`);
+    assert.match(src, /consecutiveReplans: 0/,
+      'Expected verified milestones to reset the replan counter');
+  });
+});

--- a/tests/project-blocked.test.js
+++ b/tests/project-blocked.test.js
@@ -1,0 +1,106 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { parseProjectBlockedDirective, renderBlockedDigest } from '../src/orchestrator/phase-machine.js';
+import { resumeRunner } from '../src/orchestrator/state-control.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const phaseMachinePath = path.join(__dirname, '..', 'src', 'orchestrator', 'phase-machine.js');
+const athenaPromptPath = path.join(__dirname, '..', 'agent', 'managers', 'athena.md');
+const managerPromptPath = path.join(__dirname, '..', 'agent', 'manager.md');
+
+function wrap(payload) {
+  return `Some reasoning...\n<!-- PROJECT_BLOCKED -->\n${payload}\n<!-- /PROJECT_BLOCKED -->`;
+}
+
+describe('PROJECT_BLOCKED directive', () => {
+  it('parses a valid blocked directive with defaults', () => {
+    const parsed = parseProjectBlockedDirective(wrap(JSON.stringify({
+      summary: 'Awaiting acceptance decisions',
+      decisions: [
+        { question: 'Accept 28% error?', recommendation: 'accept', context: 'CU model limit' },
+        { id: 7, question: 'Close issue #12?', recommendation: 'close' },
+      ],
+    })));
+    assert.ok(parsed?.blocked, 'should parse');
+    assert.equal(parsed.blocked.decisions.length, 2);
+    assert.equal(parsed.blocked.decisions[0].id, 1, 'missing ids are assigned by position');
+    assert.equal(parsed.blocked.decisions[1].id, 7, 'explicit ids are kept');
+    assert.equal(parsed.blocked.decisions[1].context, null);
+  });
+
+  it('rejects directives without decisions or with incomplete decisions', () => {
+    assert.match(parseProjectBlockedDirective(wrap('{"summary":"x"}')).error, /non-empty "decisions"/);
+    assert.match(parseProjectBlockedDirective(wrap('{"decisions":[{"question":"only q"}]}')).error, /"question" and "recommendation"/);
+    assert.match(parseProjectBlockedDirective(wrap('not json')).error, /not valid JSON/);
+    assert.equal(parseProjectBlockedDirective('no directive here'), null);
+  });
+
+  it('renders a one-line-per-decision digest with reply instructions', () => {
+    const digest = renderBlockedDigest({
+      summary: 'Awaiting acceptance decisions',
+      decisions: [
+        { id: 1, question: 'Accept 28% error?', recommendation: 'accept', context: 'CU model limit' },
+        { id: 2, question: 'Close issue #12?', recommendation: 'close', context: null },
+      ],
+    });
+    assert.match(digest, /Blocked on 2 human decision\(s\)/);
+    assert.match(digest, /1\. Accept 28% error\? \(recommend: accept\) — CU model limit/);
+    assert.match(digest, /2\. Close issue #12\? \(recommend: close\)/);
+    assert.match(digest, /rejecting an item requires a reason/);
+  });
+
+  it('parks the project and broadcasts when Athena emits PROJECT_BLOCKED', () => {
+    const src = fs.readFileSync(phaseMachinePath, 'utf-8');
+    const block = src.match(/const blockedParse = parseProjectBlockedDirective\(result\.resultText\);([\s\S]*?)continue;/);
+    assert.ok(block, 'Expected PROJECT_BLOCKED handling in the athena phase');
+    assert.match(block[1], /isBlocked: true/);
+    assert.match(block[1], /isPaused: true/);
+    assert.match(block[1], /pauseReason: digest/);
+    assert.match(block[1], /type: 'project-blocked'/);
+  });
+
+  it('injects the decision digest into Athena after resume and clears it', () => {
+    const src = fs.readFileSync(phaseMachinePath, 'utf-8');
+    assert.match(src, /if \(runner\.pendingUnblockDigest\) \{/,
+      'Athena situation should have an unblock branch');
+    assert.match(src, /Resumed after human-decision block/);
+    assert.match(src, /runner\.setState\(\{ pendingUnblockDigest: null \}\)/,
+      'digest is consumed once');
+  });
+
+  it('resume converts a blocked project into a pending unblock digest', () => {
+    const calls = [];
+    const runner = {
+      isComplete: false,
+      isBlocked: true,
+      pauseReason: 'old digest',
+      blockedDecisions: {
+        summary: 'Need decisions',
+        decisions: [{ id: 1, question: 'Q?', recommendation: 'accept', context: null }],
+      },
+      setState(patch) { calls.push(patch); Object.assign(this, patch); },
+    };
+    resumeRunner(runner, { log: () => {} });
+    assert.equal(runner.isBlocked, false);
+    assert.equal(runner.blockedDecisions, null);
+    assert.equal(runner.isPaused, false);
+    assert.equal(runner.phase, 'athena');
+    assert.match(runner.pendingUnblockDigest, /1\. Q\? \(recommend: accept\)/);
+    assert.equal(runner.wakeNow, true);
+  });
+
+  it('documents the directive for Athena and reframes HUMAN: issues as non-blocking', () => {
+    const athena = fs.readFileSync(athenaPromptPath, 'utf-8');
+    assert.match(athena, /<!-- PROJECT_BLOCKED -->/);
+    assert.match(athena, /recommendation/);
+    assert.match(athena, /`<!-- PROJECT_BLOCKED -->` \| Forward progress is gated on human decisions/);
+    const manager = fs.readFileSync(managerPromptPath, 'utf-8');
+    assert.match(manager, /breadcrumb, not a notification/);
+    assert.match(manager, /PROJECT_BLOCKED/);
+    assert.doesNotMatch(manager, /- human input, reviewer decisions/,
+      'pending human input must not be listed as a delay-wait reason');
+  });
+});

--- a/tests/wait-for-schedule.test.js
+++ b/tests/wait-for-schedule.test.js
@@ -1,0 +1,110 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import {
+  normalizeWaitForSpec,
+  parseSchedule,
+  WAIT_FOR_DEFAULT_POLL_MIN,
+  WAIT_FOR_DEFAULT_TIMEOUT_MIN,
+  WAIT_FOR_MAX_TIMEOUT_MIN,
+  WAIT_FOR_MIN_POLL_MIN,
+} from '../src/orchestrator/scheduler.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const phaseMachinePath = path.join(__dirname, '..', 'src', 'orchestrator', 'phase-machine.js');
+const schedulerPath = path.join(__dirname, '..', 'src', 'orchestrator', 'scheduler.js');
+
+function parse(text) {
+  return parseSchedule({}, { log: () => {} }, text);
+}
+
+describe('waitFor schedule steps', () => {
+  it('normalizes a minimal waitFor spec with defaults', () => {
+    const spec = normalizeWaitForSpec({ run: 26278530869 });
+    assert.deepEqual(spec, {
+      run: '26278530869',
+      timeoutMin: WAIT_FOR_DEFAULT_TIMEOUT_MIN,
+      pollMin: WAIT_FOR_DEFAULT_POLL_MIN,
+    });
+  });
+
+  it('caps timeout and floors poll interval', () => {
+    const spec = normalizeWaitForSpec({ run: '123', timeoutMin: 99999, pollMin: 0.1 });
+    assert.equal(spec.timeoutMin, WAIT_FOR_MAX_TIMEOUT_MIN);
+    assert.equal(spec.pollMin, WAIT_FOR_MIN_POLL_MIN);
+  });
+
+  it('rejects specs without a valid run id or with unknown keys', () => {
+    assert.equal(normalizeWaitForSpec({}), null);
+    assert.equal(normalizeWaitForSpec({ run: 'abc' }), null);
+    assert.equal(normalizeWaitForSpec({ run: -5 }), null);
+    assert.equal(normalizeWaitForSpec({ run: 123, branch: 'main' }), null);
+    assert.equal(normalizeWaitForSpec(null), null);
+    assert.equal(normalizeWaitForSpec([1]), null);
+  });
+
+  it('accepts waitFor steps in the schedule parser', () => {
+    const text = `<!-- SCHEDULE -->\n[\n  {"waitFor": {"run": 26278530869, "timeoutMin": 720}},\n  {"agent":"leo","task":"Inspect the terminal run result"}\n]\n<!-- /SCHEDULE -->`;
+    const schedule = parse(text);
+    assert.ok(schedule, 'waitFor schedule should parse');
+    assert.deepEqual(schedule._steps[0], {
+      waitFor: { run: '26278530869', timeoutMin: 720, pollMin: WAIT_FOR_DEFAULT_POLL_MIN },
+    });
+    assert.deepEqual(schedule._steps[1], { leo: { task: 'Inspect the terminal run result' } });
+  });
+
+  it('rejects malformed waitFor steps in the schedule parser', () => {
+    const missingRun = `<!-- SCHEDULE -->\n[\n  {"waitFor": {"timeoutMin": 60}}\n]\n<!-- /SCHEDULE -->`;
+    assert.equal(parse(missingRun), null);
+    const extraKeys = `<!-- SCHEDULE -->\n[\n  {"waitFor": {"run": 1}, "delay": 5}\n]\n<!-- /SCHEDULE -->`;
+    assert.equal(parse(extraKeys), null);
+  });
+
+  it('still accepts plain delay-only schedules', () => {
+    const waitOnly = `<!-- SCHEDULE -->\n[\n  {"delay":360}\n]\n<!-- /SCHEDULE -->`;
+    assert.deepEqual(parse(waitOnly), { _steps: [{ delay: 360 }] });
+  });
+
+  it('executes waitFor steps without treating them as workers', () => {
+    const src = fs.readFileSync(schedulerPath, 'utf-8');
+    assert.match(src, /if \(step\.waitFor !== undefined\) \{\s*\n\s*await waitForCondition\(runner, deps, step\.waitFor\);/,
+      'executeSchedule should route waitFor steps through waitForCondition');
+    assert.match(src, /const name = Object\.keys\(step\)\.find\(k => k !== 'delay' && k !== 'waitFor'\)/,
+      'agent-step detection should skip waitFor keys');
+  });
+
+  it('polls gh without spawning agents and records the outcome', () => {
+    const src = fs.readFileSync(schedulerPath, 'utf-8');
+    assert.match(src, /execFile\('gh', \['run', 'view', runId, '--json', 'status,conclusion'\]/,
+      'waitFor should poll via the gh CLI');
+    assert.match(src, /runner\.lastWaitResult = result/,
+      'waitFor outcome should be recorded on the runner');
+    const start = src.indexOf('export async function waitForCondition');
+    const end = src.indexOf('export async function executeSchedule');
+    assert.ok(start !== -1 && end > start, 'Expected waitForCondition before executeSchedule');
+    assert.doesNotMatch(src.slice(start, end), /runAgent/,
+      'waitForCondition must never run agents');
+  });
+
+  it('skips waitFor steps in manager directive validation', () => {
+    const src = fs.readFileSync(phaseMachinePath, 'utf-8');
+    assert.match(src, /if \(!step \|\| step\.delay !== undefined \|\| step\.waitFor !== undefined\) continue;/,
+      'validateManagerDirective should not treat waitFor as a worker name');
+  });
+
+  it('injects the last waitFor outcome into the next manager context', () => {
+    const src = fs.readFileSync(phaseMachinePath, 'utf-8');
+    assert.match(src, /function consumeWaitResultContext\(runner\)/,
+      'Expected a consumeWaitResultContext helper');
+    assert.match(src, /consumeWaitResultContext\(runner\) \+ situation/,
+      'Athena situation should include the waitFor outcome');
+    assert.match(src, /let aresContext = consumeWaitResultContext\(runner\);/,
+      'Ares context should include the waitFor outcome');
+    assert.match(src, /const apolloContext = consumeWaitResultContext\(runner\)/,
+      'Apollo context should include the waitFor outcome');
+    assert.match(src, /const themisContext = consumeWaitResultContext\(runner\)/,
+      'Themis context should include the waitFor outcome');
+  });
+});


### PR DESCRIPTION
## Why

Trace analysis of a 20-day TBC run (`sarchlab/mgpusim-dev`: 969 cycles, ~$5k, 176 milestones) showed the original spec was finished on **day 1**, then the project livelocked for 19 days trying to declare completion:

- Themis's "perfect and flawless" veto (EXAM_FAIL → Athena, unbounded) demanded a green CI run when the spec defined success as *knowing which benchmarks finish* — a partially-failing run was the deliverable.
- `HUMAN:` decision issues lived only in tbc-db where the human never saw them (their last comment: *"Where is the issue escalated to human. I do not see it"*), and nothing blocked on human input — the endgame loop (M87.1–M87.27) burned 478 agent runs / $1,645 over 8 days.
- Nothing detected 27 near-identical remediation milestones.
- CI waits used blind delay cycles: 125 waits, each resume spending a full manager run to learn "still running".

## What

**P1 — `PROJECT_BLOCKED` directive.** Athena can park the project on a validated decision digest (every decision has a `question` + `recommendation`; a bare "yes" accepts, rejections need a reason). Fires a `project-blocked` SSE event + web-push notification. Resume routes the digest and the human's replies into Athena's next cycle. `HUMAN:` issues are reframed as breadcrumbs; waiting on a human is no longer a valid delay-wait reason.

**P2 — Themis audits without veto.** Verdicts are `EXAM_PASS` or `EXAM_FINDINGS` (legacy `EXAM_FAIL` mapped to findings); either way the project completes and the findings are written to `{projectDir}/reports/final-audit-<ts>.md` — outside the repo. The rejection loop and Themis issue creation are gone; no verdict after one retry completes as "audit inconclusive". Prompt is spec-anchored: the spec's own success definition outranks generic polish.

**P3 — Health tripwires + hygeia auditor.** The orchestrator tracks consecutive replans, milestone family size/depth, no-merge streak, and cost-since-last-merge (thresholds overridable via a `health:` config key, plus an every-50-cycles floor). A tripped wire runs `hygeia`, a fresh-context auditor that sees the trajectory (spec, milestone table + costs, open human decisions) but not the team's narrative, and returns exactly one verdict: healthy (snooze), warn (mandatory-response block in Athena's next cycle), or stop (reuses the blocked flow). Against the trace's own numbers this would have tripped at M87.8 instead of M87.27.

**P4 — `waitFor` schedule steps.** `{"waitFor": {"run": <id>, "timeoutMin": 720}}` polls `gh run view` token-free until terminal/timeout; the outcome is injected as a one-line header into the next manager context. Rendered as a chip in the monitor's schedule diagram.

**P5 — Skills discipline (prompt-only).** Skill files are playbooks, not personas or policy: moment-specific rules go in task text where they expire; hiring requires a reason an existing worker can't do the job; retuning includes deleting stale content.

## Testing

- `npm test`: 229 pass / 0 fail. New: `project-blocked.test.js`, `wait-for-schedule.test.js`, `health-signals.test.js` (reproduces the M87 pathology in a temp DB and asserts the signals catch it); `examination-phase.test.js` rewritten to the new invariants.
- Note: the repo's pinned `better-sqlite3@12.6.2` does not compile on Node 26; I ran tests with `12.11.1` installed `--no-save`. Consider bumping the pin (separate change — package.json untouched here).
- Not yet exercised live: a real PROJECT_BLOCKED → notify → resume round-trip with a running server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)