### PR TITLE
Formal offline jobs: tbc-job CLI, waitFor {job}, monitor Jobs card

### DIFF
--- a/agent/manager.md
+++ b/agent/manager.md
@@ -140,6 +140,7 @@ You MUST include this exact format in your response when scheduling workers:
 The schedule is an **ordered array of steps**. Each step is one of:
 - `{"delay": N}` — wait N minutes before proceeding to the next step
 - `{"waitFor": {"run": <github run id>, "timeoutMin": 720}}` — block until that GitHub Actions run reaches a terminal state (or the timeout expires), polling cheaply without running any agent
+- `{"waitFor": {"job": "<tbc-job name>", "timeoutMin": 720}}` — same, for a formal offline job submitted with `tbc-job` (see Offline Jobs)
 - `{"agent": "name", "task": "...", "visibility": "..."}` — run that agent
 
 Delay-only schedules are required when waiting is the only useful action:

--- a/agent/manager.md
+++ b/agent/manager.md
@@ -160,7 +160,23 @@ Use a wait-only schedule when the remaining blocker is only waiting for somethin
 - reviewer decisions or issue/PR state that has not changed
 - any repeated monitor/recheck situation where the known state is unchanged
 
-**Prefer `waitFor` over blind delays when you know the GitHub Actions run id.** A `{"waitFor": {"run": <id>}}` step polls the run without burning any agent cycles and wakes you the moment it turns terminal; your next cycle context includes the outcome. Use `{"delay": N}` only when there is no run id to watch. Do not use either for pending human input — waiting on a human is a project-level block, not a schedule delay (see Escalate to Human).
+**Prefer `waitFor` over blind delays when there is something concrete to watch.** A `{"waitFor": {"run": <github run id>}}` or `{"waitFor": {"job": "<tbc-job name>"}}` step polls without burning any agent cycles and wakes you the moment the target turns terminal; your next cycle context includes the outcome. Use `{"delay": N}` only when there is no run or job to watch. Do not use either for pending human input — waiting on a human is a project-level block, not a schedule delay (see Escalate to Human).
+
+### Offline Jobs
+
+Long-running compute — builds, benchmark sweeps, simulations, corpus generation — must run as a **formal job**, not inside an agent's runtime and never as an informal `nohup ... &`. A formal job gets a tracked record, a log file, timeout enforcement, duplicate prevention, and a card in the monitor UI; an informal background process has none of that — it is invisible to the orchestrator and to the human, gets duplicated by fresh-context agents, and leaves orphans.
+
+```
+tbc-job submit --name gem5-oracle-build --timeout-min 240 --actor leo -- docker build -t gem5-pinned tools/gem5
+tbc-job status gem5-oracle-build
+tbc-job list
+tbc-job logs gem5-oracle-build --lines 60
+tbc-job cancel gem5-oracle-build
+```
+
+- Submitting a name that is already running returns the existing job instead of starting a duplicate — always reuse a stable, descriptive name for the same piece of work.
+- Jobs run detached in the repo directory by default (`--cwd` to override) and survive agent exits and orchestrator restarts.
+- The standard pattern: a worker writes the code/Dockerfile and submits the job in one cycle; the manager then emits `{"waitFor": {"job": "<name>"}}` and acts on the outcome next cycle. Do not schedule workers to babysit a running job.
 
 Do **not** manufacture progress by scheduling workers to recheck, monitor, audit, summarize, refresh docs, or re-verify the same unchanged external state. Those tasks burn cycles without advancing the milestone.
 

--- a/agent/worker.md
+++ b/agent/worker.md
@@ -4,3 +4,14 @@ You are a worker agent. You execute tasks assigned to you by your manager.
 
 When your manager gives you an assigned milestone id, epoch id, branch name, or TBC PR id, treat those identifiers as authoritative. Use them as given and do not invent replacements.
 
+
+## Offline Jobs
+
+Long-running compute — builds, benchmark sweeps, simulations, corpus generation — must run as a formal job via `tbc-job`, never inside your own runtime (you will hit the agent timeout) and never as an informal `nohup ... &` (invisible, untracked, gets duplicated by the next agent).
+
+```
+tbc-job submit --name gem5-oracle-build --timeout-min 240 --actor <your_name> -- <command>
+tbc-job status <name> · tbc-job list · tbc-job logs <name> · tbc-job cancel <name>
+```
+
+Submitting a name that is already running returns the existing job instead of starting a duplicate — reuse a stable name for the same piece of work. After submitting, report the job name to your manager so they can wait on it with `{"waitFor": {"job": "<name>"}}`; do not sit in your own run polling it.

--- a/bin/tbc-job
+++ b/bin/tbc-job
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import "./tbc-job.js";

--- a/bin/tbc-job.js
+++ b/bin/tbc-job.js
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+
+/**
+ * tbc-job — CLI for formal offline jobs
+ *
+ * Long-running commands (builds, benchmark sweeps, simulations) that must
+ * outlive a single agent run. Submitted jobs get a DB record, a log file,
+ * timeout enforcement, and show up in the monitor UI. Never use `nohup ... &`
+ * for long work — informal background processes are invisible and untracked.
+ *
+ * Usage:
+ *   tbc-job submit --name <name> [--timeout-min N] [--cwd path] [--actor who] -- <command...>
+ *   tbc-job status <name>
+ *   tbc-job list [--status running|succeeded|failed|timeout|killed]
+ *   tbc-job logs <name> [--lines N]
+ *   tbc-job cancel <name>
+ *
+ * The TBC_DB environment variable must point to the project's database file.
+ * The orchestrator sets this automatically when spawning agents.
+ */
+
+import Database from 'better-sqlite3';
+import path from 'node:path';
+import {
+  cancelJob,
+  getJob,
+  jobLogTail,
+  listJobs,
+  submitJob,
+} from '../src/orchestrator/jobs.js';
+
+const dbPath = process.env.TBC_DB;
+if (!dbPath) {
+  console.error('Error: TBC_DB environment variable not set');
+  process.exit(1);
+}
+if (path.basename(dbPath) !== 'project.db') {
+  console.error(`Error: TBC_DB must point to canonical project.db, got ${dbPath}`);
+  process.exit(1);
+}
+
+const db = new Database(dbPath);
+db.pragma('journal_mode = WAL');
+
+function fail(message) {
+  console.error(`Error: ${message}`);
+  process.exit(1);
+}
+
+function flagValue(args, flag) {
+  const index = args.indexOf(flag);
+  if (index === -1) return null;
+  return args[index + 1] ?? null;
+}
+
+function describe(job) {
+  const started = job.created_at;
+  const runtimeMin = job.finished_at
+    ? Math.round((Date.parse(job.finished_at) - Date.parse(job.created_at)) / 60000)
+    : Math.round((Date.now() - Date.parse(job.created_at)) / 60000);
+  const exit = job.exit_code === null || job.exit_code === undefined ? '-' : job.exit_code;
+  return `${job.name} | ${job.status} | exit=${exit} | ${runtimeMin}m | started ${started}${job.submitted_by ? ` by ${job.submitted_by}` : ''}\n  command: ${job.command}\n  log: ${job.log_path}`;
+}
+
+const [command, ...rest] = process.argv.slice(2);
+
+try {
+  if (command === 'submit') {
+    const sep = rest.indexOf('--');
+    if (sep === -1) fail('submit requires "-- <command...>" after the options');
+    const options = rest.slice(0, sep);
+    const jobCommand = rest.slice(sep + 1).join(' ').trim();
+    const name = flagValue(options, '--name');
+    if (!name) fail('submit requires --name');
+    const { job, alreadyRunning } = submitJob(db, dbPath, {
+      name,
+      command: jobCommand,
+      cwd: flagValue(options, '--cwd'),
+      timeoutMin: flagValue(options, '--timeout-min') || undefined,
+      submittedBy: flagValue(options, '--actor'),
+    });
+    if (alreadyRunning) {
+      console.log(`Job "${job.name}" is already running (submitted ${job.created_at}); not starting a duplicate.`);
+    } else {
+      console.log(`Submitted job "${job.name}" (pid ${job.pid}, timeout ${job.timeout_min}m).`);
+    }
+    console.log(describe(job));
+    console.log('Check later with: tbc-job status ' + job.name + ' — or have your manager emit {"waitFor": {"job": "' + job.name + '"}}.');
+  } else if (command === 'status') {
+    const name = rest[0];
+    if (!name) fail('status requires a job name');
+    const job = getJob(db, dbPath, name);
+    if (!job) fail(`No job named "${name}"`);
+    console.log(describe(job));
+  } else if (command === 'list') {
+    const jobs = listJobs(db, dbPath, { status: flagValue(rest, '--status') });
+    if (!jobs.length) {
+      console.log('No jobs.');
+    } else {
+      for (const job of jobs) console.log(describe(job));
+    }
+  } else if (command === 'logs') {
+    const name = rest[0];
+    if (!name) fail('logs requires a job name');
+    const job = getJob(db, dbPath, name);
+    if (!job) fail(`No job named "${name}"`);
+    const lines = parseInt(flagValue(rest, '--lines'), 10) || 40;
+    console.log(jobLogTail(dbPath, name, lines));
+  } else if (command === 'cancel') {
+    const name = rest[0];
+    if (!name) fail('cancel requires a job name');
+    const job = cancelJob(db, dbPath, name);
+    console.log(describe(job));
+  } else {
+    fail(`Unknown command "${command || ''}". Commands: submit, status, list, logs, cancel`);
+  }
+} catch (e) {
+  fail(e.message);
+}

--- a/monitor/src/components/ScheduleDiagram.jsx
+++ b/monitor/src/components/ScheduleDiagram.jsx
@@ -144,7 +144,7 @@ function ScheduleBody({ schedule }) {
                 background: dark ? '#262626' : '#f5f5f5',
                 padding: '3px 10px', borderRadius: 12,
               }}>
-                <Clock style={{ width: 12, height: 12 }} /> wait for run {step.waitFor.run}
+                <Clock style={{ width: 12, height: 12 }} /> wait for {step.waitFor.job ? `job ${step.waitFor.job}` : `run ${step.waitFor.run}`}
               </span>
             </div>
           )

--- a/monitor/src/components/layout/ProjectView.jsx
+++ b/monitor/src/components/layout/ProjectView.jsx
@@ -16,6 +16,7 @@ import IssuesSidebar from '@/components/project/IssuesSidebar'
 import HumanInterventionCard from '@/components/project/HumanInterventionCard'
 import AgentReportsCard from '@/components/project/AgentReportsCard'
 import MilestoneTreeCard from '@/components/project/MilestoneTreeCard'
+import JobsCard from '@/components/project/JobsCard'
 import ChatCard from '@/components/project/ChatCard'
 import SettingsPanel from '@/components/panels/SettingsPanel'
 import NotificationPanel from '@/components/panels/NotificationPanel'
@@ -1304,6 +1305,8 @@ export default function ProjectView({
                 onMilestoneClick={openMilestoneModal}
                 onPrClick={openPRModal}
               />
+
+              <JobsCard selectedProject={selectedProject} />
 
               <DashboardWidget icon={GitPullRequest} title={`Agent PRs (${prs.length})`}>
                   <div className="space-y-2">

--- a/monitor/src/components/project/JobsCard.jsx
+++ b/monitor/src/components/project/JobsCard.jsx
@@ -1,0 +1,105 @@
+import React, { useState, useEffect, useCallback } from 'react'
+import { Hammer, ChevronDown, ChevronRight } from 'lucide-react'
+import DashboardWidget from '@/components/ui/DashboardWidget'
+import StatusPill from '@/components/ui/status-pill'
+
+const STATUS_VARIANT = {
+  running: 'open',
+  succeeded: 'merged',
+  failed: 'closed',
+  timeout: 'closed',
+  killed: 'closed',
+}
+
+function runtimeLabel(job) {
+  const end = job.finished_at ? Date.parse(job.finished_at) : Date.now()
+  const minutes = Math.max(0, Math.round((end - Date.parse(job.created_at)) / 60000))
+  if (minutes < 60) return `${minutes}m`
+  return `${Math.floor(minutes / 60)}h ${minutes % 60}m`
+}
+
+function JobRow({ job, projectId }) {
+  const [open, setOpen] = useState(false)
+  const [log, setLog] = useState(null)
+
+  useEffect(() => {
+    if (!open) return
+    let cancelled = false
+    fetch(`/api/projects/${projectId}/jobs/${encodeURIComponent(job.name)}/log?lines=30`)
+      .then(res => res.json())
+      .then(data => { if (!cancelled) setLog(data.log || '(no log)') })
+      .catch(() => { if (!cancelled) setLog('(failed to load log)') })
+    return () => { cancelled = true }
+  }, [open, projectId, job.name, job.status])
+
+  const Chevron = open ? ChevronDown : ChevronRight
+  return (
+    <div className="block p-2 bg-neutral-50 dark:bg-neutral-900 rounded">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="flex items-center gap-2 w-full text-left cursor-pointer"
+      >
+        <Chevron className="w-3 h-3 text-neutral-400 shrink-0" />
+        <span className="text-sm font-medium text-neutral-800 dark:text-neutral-100 truncate">{job.name}</span>
+        <StatusPill variant={STATUS_VARIANT[job.status] || 'meta'}>{job.status}</StatusPill>
+      </button>
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1 ml-5 text-xs text-neutral-500 dark:text-neutral-400">
+        <span>{runtimeLabel(job)}</span>
+        {job.exit_code !== null && job.exit_code !== undefined && <span>exit {job.exit_code}</span>}
+        {job.submitted_by && <span>by {job.submitted_by}</span>}
+        <span>timeout {job.timeout_min}m</span>
+      </div>
+      {open && (
+        <div className="mt-2 ml-5">
+          <div className="text-xs text-neutral-500 dark:text-neutral-400 mb-1 break-all">$ {job.command}</div>
+          <pre className="text-[11px] leading-4 p-2 rounded bg-neutral-100 dark:bg-neutral-800 text-neutral-700 dark:text-neutral-300 overflow-x-auto max-h-48 whitespace-pre-wrap">
+            {log ?? 'Loading log…'}
+          </pre>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default function JobsCard({ selectedProject }) {
+  const [jobs, setJobs] = useState([])
+  const projectId = selectedProject?.id
+
+  const refresh = useCallback(() => {
+    if (!projectId) return
+    fetch(`/api/projects/${projectId}/jobs`)
+      .then(res => res.json())
+      .then(data => setJobs(Array.isArray(data.jobs) ? data.jobs : []))
+      .catch(() => {})
+  }, [projectId])
+
+  useEffect(() => {
+    refresh()
+    const interval = setInterval(refresh, 15000)
+    return () => clearInterval(interval)
+  }, [refresh])
+
+  const runningCount = jobs.filter(job => job.status === 'running').length
+
+  return (
+    <DashboardWidget
+      icon={Hammer}
+      title={`Jobs (${jobs.length})`}
+      badge={runningCount > 0 && (
+        <StatusPill variant="open">{runningCount} running</StatusPill>
+      )}
+    >
+      <div className="space-y-2">
+        {jobs.map(job => (
+          <JobRow key={job.name} job={job} projectId={projectId} />
+        ))}
+        {jobs.length === 0 && (
+          <p className="text-sm text-neutral-400 dark:text-neutral-500">
+            No offline jobs. Agents submit them with <code>tbc-job submit</code>.
+          </p>
+        )}
+      </div>
+    </DashboardWidget>
+  )
+}

--- a/src/orchestrator/jobs.js
+++ b/src/orchestrator/jobs.js
@@ -1,0 +1,198 @@
+import fs from 'fs';
+import path from 'path';
+import { spawn } from 'child_process';
+
+// Formal offline jobs: long-running commands (builds, benchmark sweeps,
+// simulations) that outlive a single agent run. A job submitted through this
+// module gets a DB record, a log file, timeout enforcement, and a card in the
+// monitor UI — unlike an informal `nohup ... &`, which is invisible to the
+// orchestrator and to the human.
+//
+// There is no daemon: the job runs as a detached process group that writes an
+// exit-code sentinel file when it finishes. Every read path (CLI, waitFor
+// polling, the jobs API route) reconciles DB state from the sentinel + pid.
+
+export const DEFAULT_JOB_TIMEOUT_MIN = 240;
+export const MAX_JOB_TIMEOUT_MIN = 2880; // 48h
+export const JOB_NAME_RE = /^[a-z0-9][a-z0-9._-]{0,63}$/i;
+
+export function ensureJobsTable(db) {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS jobs (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT UNIQUE NOT NULL,
+      command TEXT NOT NULL,
+      cwd TEXT,
+      pid INTEGER,
+      status TEXT NOT NULL DEFAULT 'running' CHECK(status IN ('running', 'succeeded', 'failed', 'timeout', 'killed')),
+      exit_code INTEGER,
+      timeout_min INTEGER NOT NULL DEFAULT ${DEFAULT_JOB_TIMEOUT_MIN},
+      submitted_by TEXT,
+      log_path TEXT,
+      created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+      finished_at TEXT
+    )
+  `);
+}
+
+export function jobsDir(dbPath) {
+  return path.join(path.dirname(dbPath), 'jobs');
+}
+
+function exitSentinelPath(dbPath, name) {
+  return path.join(jobsDir(dbPath), `${name}.exit`);
+}
+
+export function jobLogPath(dbPath, name) {
+  return path.join(jobsDir(dbPath), `${name}.log`);
+}
+
+function pidAlive(pid) {
+  if (!pid) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function killProcessGroup(pid) {
+  try {
+    process.kill(-pid, 'SIGTERM');
+  } catch {}
+  setTimeout(() => {
+    try { process.kill(-pid, 'SIGKILL'); } catch {}
+  }, 5000).unref?.();
+}
+
+function finishJob(db, job, status, exitCode, finishedAt = null) {
+  db.prepare('UPDATE jobs SET status = ?, exit_code = ?, finished_at = COALESCE(?, strftime(\'%Y-%m-%dT%H:%M:%SZ\', \'now\')) WHERE id = ?')
+    .run(status, exitCode, finishedAt, job.id);
+  return db.prepare('SELECT * FROM jobs WHERE id = ?').get(job.id);
+}
+
+// Bring a job row up to date with reality (sentinel file, pid, timeout).
+export function reconcileJob(db, dbPath, job) {
+  if (!job || job.status !== 'running') return job;
+
+  const sentinel = exitSentinelPath(dbPath, job.name);
+  if (fs.existsSync(sentinel)) {
+    let exitCode = null;
+    let finishedAt = null;
+    try {
+      exitCode = parseInt(fs.readFileSync(sentinel, 'utf-8').trim(), 10);
+      if (Number.isNaN(exitCode)) exitCode = null;
+      finishedAt = fs.statSync(sentinel).mtime.toISOString();
+    } catch {}
+    return finishJob(db, job, exitCode === 0 ? 'succeeded' : 'failed', exitCode, finishedAt);
+  }
+
+  const startedMs = Date.parse(job.created_at);
+  const timedOut = Number.isFinite(startedMs)
+    && Date.now() - startedMs > job.timeout_min * 60000;
+  if (timedOut) {
+    if (job.pid) killProcessGroup(job.pid);
+    return finishJob(db, job, 'timeout', null);
+  }
+
+  if (!pidAlive(job.pid)) {
+    // Process gone without writing a sentinel: crashed, was killed externally,
+    // or the machine rebooted mid-job.
+    return finishJob(db, job, 'failed', null);
+  }
+
+  return job;
+}
+
+export function getJob(db, dbPath, name) {
+  ensureJobsTable(db);
+  const job = db.prepare('SELECT * FROM jobs WHERE name = ?').get(name);
+  return job ? reconcileJob(db, dbPath, job) : null;
+}
+
+export function listJobs(db, dbPath, { status = null } = {}) {
+  ensureJobsTable(db);
+  const rows = db.prepare('SELECT * FROM jobs ORDER BY id DESC').all();
+  const reconciled = rows.map(job => reconcileJob(db, dbPath, job));
+  return status ? reconciled.filter(job => job.status === status) : reconciled;
+}
+
+export function submitJob(db, dbPath, { name, command, cwd = null, timeoutMin = DEFAULT_JOB_TIMEOUT_MIN, submittedBy = null }) {
+  ensureJobsTable(db);
+  if (!JOB_NAME_RE.test(name || '')) {
+    throw new Error(`Invalid job name "${name}": use letters, digits, dot, dash, underscore (max 64 chars)`);
+  }
+  if (!command || !String(command).trim()) {
+    throw new Error('Job command is empty');
+  }
+  const timeout = Math.min(Math.max(parseInt(timeoutMin, 10) || DEFAULT_JOB_TIMEOUT_MIN, 1), MAX_JOB_TIMEOUT_MIN);
+
+  const existing = getJob(db, dbPath, name);
+  if (existing && existing.status === 'running') {
+    return { job: existing, alreadyRunning: true };
+  }
+
+  const dir = jobsDir(dbPath);
+  fs.mkdirSync(dir, { recursive: true });
+  const logPath = jobLogPath(dbPath, name);
+  const sentinel = exitSentinelPath(dbPath, name);
+  try { fs.unlinkSync(sentinel); } catch {}
+  fs.writeFileSync(logPath, `# job: ${name}\n# command: ${command}\n# submitted: ${new Date().toISOString()}${submittedBy ? ` by ${submittedBy}` : ''}\n`);
+
+  const projectDir = path.dirname(dbPath);
+  const defaultCwd = fs.existsSync(path.join(projectDir, 'repo')) ? path.join(projectDir, 'repo') : projectDir;
+  const jobCwd = cwd || defaultCwd;
+  if (!fs.existsSync(jobCwd)) {
+    throw new Error(`Job cwd does not exist: ${jobCwd}`);
+  }
+
+  const logFd = fs.openSync(logPath, 'a');
+  // The wrapper writes the exit code to the sentinel no matter how the command
+  // ends; `detached` gives the job its own process group so timeout/cancel can
+  // kill the whole tree.
+  const wrapped = `(${command})\nprintf '%s' "$?" > ${JSON.stringify(sentinel)}`;
+  const proc = spawn('/bin/sh', ['-c', wrapped], {
+    cwd: jobCwd,
+    detached: true,
+    stdio: ['ignore', logFd, logFd],
+  });
+  proc.unref();
+  fs.closeSync(logFd);
+
+  db.prepare(`
+    INSERT INTO jobs (name, command, cwd, pid, status, exit_code, timeout_min, submitted_by, log_path, created_at, finished_at)
+    VALUES (?, ?, ?, ?, 'running', NULL, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), NULL)
+    ON CONFLICT(name) DO UPDATE SET
+      command = excluded.command,
+      cwd = excluded.cwd,
+      pid = excluded.pid,
+      status = 'running',
+      exit_code = NULL,
+      timeout_min = excluded.timeout_min,
+      submitted_by = excluded.submitted_by,
+      log_path = excluded.log_path,
+      created_at = excluded.created_at,
+      finished_at = NULL
+  `).run(name, command, jobCwd, proc.pid, timeout, submittedBy, logPath);
+
+  return { job: db.prepare('SELECT * FROM jobs WHERE name = ?').get(name), alreadyRunning: false };
+}
+
+export function cancelJob(db, dbPath, name) {
+  const job = getJob(db, dbPath, name);
+  if (!job) throw new Error(`No job named "${name}"`);
+  if (job.status !== 'running') return job;
+  if (job.pid) killProcessGroup(job.pid);
+  return finishJob(db, job, 'killed', null);
+}
+
+export function jobLogTail(dbPath, name, lines = 40) {
+  const logPath = jobLogPath(dbPath, name);
+  try {
+    const content = fs.readFileSync(logPath, 'utf-8');
+    return content.split('\n').slice(-lines).join('\n');
+  } catch {
+    return '(no log)';
+  }
+}

--- a/src/orchestrator/phase-machine.js
+++ b/src/orchestrator/phase-machine.js
@@ -25,7 +25,7 @@ function validateManagerDirective(runner, deps, resultText, managerName) {
   const schedule = runner.parseSchedule(text);
   if (!schedule) {
     return {
-      message: 'Malformed SCHEDULE directive. Use the canonical JSON array format exactly: <!-- SCHEDULE --> [ {"agent":"name","task":"..."} ] <!-- /SCHEDULE -->. Valid steps: {"agent":"name","task":"..."}, {"delay": minutes}, {"waitFor": {"run": <github run id>, "timeoutMin": N}}.',
+      message: 'Malformed SCHEDULE directive. Use the canonical JSON array format exactly: <!-- SCHEDULE --> [ {"agent":"name","task":"..."} ] <!-- /SCHEDULE -->. Valid steps: {"agent":"name","task":"..."}, {"delay": minutes}, {"waitFor": {"run": <github run id>}}, {"waitFor": {"job": "<tbc-job name>"}}.',
     };
   }
 
@@ -83,8 +83,11 @@ function consumeWaitResultContext(runner) {
   runner.saveState();
   const outcome = wait.timedOut
     ? `still ${wait.status || 'unknown'} when the ${wait.waitedMin}m wait timed out`
-    : `${wait.status}/${wait.conclusion || '-'} after ${wait.waitedMin}m`;
-  return `> **Last waitFor result:** GitHub Actions run ${wait.runId} → ${outcome}.\n\n`;
+    : `${wait.status}${wait.conclusion ? `/${wait.conclusion}` : ''} after ${wait.waitedMin}m`;
+  const target = wait.jobName
+    ? `Job "${wait.jobName}" (check details with: tbc-job status ${wait.jobName})`
+    : `GitHub Actions run ${wait.runId}`;
+  return `> **Last waitFor result:** ${target} → ${outcome}.\n\n`;
 }
 
 // Themis renders an audit verdict, never a veto: EXAM_PASS (clean) or

--- a/src/orchestrator/scheduler.js
+++ b/src/orchestrator/scheduler.js
@@ -2,21 +2,38 @@ import path from 'path';
 import fs from 'fs';
 import { execFile } from 'child_process';
 import { extractFocusedRefIds } from './object-refs.js';
+import { getJob, JOB_NAME_RE } from './jobs.js';
 
 export const WAIT_FOR_DEFAULT_TIMEOUT_MIN = 720;
 export const WAIT_FOR_MAX_TIMEOUT_MIN = 1440;
 export const WAIT_FOR_DEFAULT_POLL_MIN = 5;
 export const WAIT_FOR_MIN_POLL_MIN = 3;
+// Local job polls are free (no API call), so they can be tighter than gh polls.
+export const WAIT_FOR_JOB_MAX_TIMEOUT_MIN = 2880;
+export const WAIT_FOR_JOB_DEFAULT_POLL_MIN = 2;
+export const WAIT_FOR_JOB_MIN_POLL_MIN = 1;
 
 export function normalizeWaitForSpec(spec) {
   if (!spec || typeof spec !== 'object' || Array.isArray(spec)) return null;
+  const knownKeys = new Set(['run', 'job', 'timeoutMin', 'pollMin']);
+  if (Object.keys(spec).some(key => !knownKeys.has(key))) return null;
+  if (spec.run !== undefined && spec.job !== undefined) return null;
+
+  if (spec.job !== undefined) {
+    if (typeof spec.job !== 'string' || !JOB_NAME_RE.test(spec.job.trim())) return null;
+    const timeoutMin = Math.min(
+      Math.max(parseFloat(spec.timeoutMin) || WAIT_FOR_DEFAULT_TIMEOUT_MIN, 1),
+      WAIT_FOR_JOB_MAX_TIMEOUT_MIN
+    );
+    const pollMin = Math.max(parseFloat(spec.pollMin) || WAIT_FOR_JOB_DEFAULT_POLL_MIN, WAIT_FOR_JOB_MIN_POLL_MIN);
+    return { job: spec.job.trim(), timeoutMin, pollMin };
+  }
+
   const runId = spec.run;
   const isValidId = typeof runId === 'number'
     ? Number.isInteger(runId) && runId > 0
     : typeof runId === 'string' && /^\d+$/.test(runId.trim());
   if (!isValidId) return null;
-  const knownKeys = new Set(['run', 'timeoutMin', 'pollMin']);
-  if (Object.keys(spec).some(key => !knownKeys.has(key))) return null;
   const timeoutMin = Math.min(
     Math.max(parseFloat(spec.timeoutMin) || WAIT_FOR_DEFAULT_TIMEOUT_MIN, 1),
     WAIT_FOR_MAX_TIMEOUT_MIN
@@ -126,24 +143,46 @@ function ghRunStatus(repoDir, runId) {
   });
 }
 
-// Token-free wait: poll a GitHub Actions run with the gh CLI until it reaches a
-// terminal state or the timeout expires. Managers see the outcome via
-// runner.lastWaitResult in their next cycle context.
+function localJobStatus(runner, name) {
+  let db;
+  try {
+    db = runner.getDb();
+  } catch (e) {
+    return { error: e.message };
+  }
+  try {
+    const job = getJob(db, runner.projectDbPath, name);
+    if (!job) return { error: `no job named "${name}"` };
+    return { job };
+  } catch (e) {
+    return { error: e.message };
+  } finally {
+    try { db.close(); } catch {}
+  }
+}
+
+// Token-free wait: poll a GitHub Actions run (gh CLI) or a local tbc-job until
+// it reaches a terminal state or the timeout expires. Managers see the outcome
+// via runner.lastWaitResult in their next cycle context.
 export async function waitForCondition(runner, deps = {}, spec) {
   const normalized = normalizeWaitForSpec(spec);
   if (!normalized) return null;
-  const { run, timeoutMin, pollMin } = normalized;
+  const { run, job, timeoutMin, pollMin } = normalized;
   const repoCheckout = path.join(runner.projectDir, 'repo');
   const repoDir = fs.existsSync(repoCheckout) ? repoCheckout : runner.path;
   const deadline = Date.now() + timeoutMin * 60000;
   const startedAt = Date.now();
-  deps.log(`⏳ waitFor: polling run ${run} every ${pollMin}m (timeout ${timeoutMin}m)...`, runner.id);
+  const target = job ? `job "${job}"` : `run ${run}`;
+  deps.log(`⏳ waitFor: polling ${target} every ${pollMin}m (timeout ${timeoutMin}m)...`, runner.id);
 
   let last = { status: null, conclusion: null };
   while (runner.running && !runner.abortCurrentCycle && !runner.wakeNow) {
-    const check = await ghRunStatus(repoDir, run);
+    const check = job ? localJobStatus(runner, job) : await ghRunStatus(repoDir, run);
     if (check.error) {
-      deps.log(`waitFor: gh check failed (${check.error}) — will retry`, runner.id);
+      deps.log(`waitFor: ${target} check failed (${check.error}) — will retry`, runner.id);
+    } else if (check.job) {
+      last = { status: check.job.status, conclusion: check.job.exit_code === null ? null : `exit=${check.job.exit_code}` };
+      if (check.job.status !== 'running') break;
     } else {
       last = check;
       if (check.status === 'completed') break;
@@ -163,16 +202,17 @@ export async function waitForCondition(runner, deps = {}, spec) {
   runner.sleepUntil = null;
 
   const waitedMin = Math.round((Date.now() - startedAt) / 60000);
+  const terminal = job ? (last.status !== null && last.status !== 'running') : last.status === 'completed';
   const result = {
-    runId: run,
+    ...(job ? { jobName: job } : { runId: run }),
     status: last.status,
     conclusion: last.conclusion,
     waitedMin,
-    timedOut: last.status !== 'completed',
+    timedOut: !terminal,
   };
   runner.lastWaitResult = result;
   runner.saveState();
-  deps.log(`waitFor: run ${run} → ${result.status || 'unknown'}/${result.conclusion || '-'} after ${waitedMin}m${result.timedOut ? ' (timed out)' : ''}`, runner.id);
+  deps.log(`waitFor: ${target} → ${result.status || 'unknown'}/${result.conclusion || '-'} after ${waitedMin}m${result.timedOut ? ' (timed out)' : ''}`, runner.id);
   return result;
 }
 

--- a/src/orchestrator/state-control.js
+++ b/src/orchestrator/state-control.js
@@ -201,6 +201,11 @@ export function resumeRunner(runner, deps = {}) {
         isPaused: false,
         pauseReason: null,
         phase: 'athena',
+        // The human just intervened — that resolves the stall the health
+        // tripwires were measuring. Reset them so hygeia doesn't re-park the
+        // project before Athena can intake the human's answers.
+        consecutiveReplans: 0,
+        healthSnoozeUntilCycle: (runner.cycleCount || 0) + 25,
       });
     } else {
       runner.setState({ isPaused: false, pauseReason: null });

--- a/src/server/routes/project/activity.js
+++ b/src/server/routes/project/activity.js
@@ -1,4 +1,5 @@
 import { sendJson } from '../../http.js';
+import { jobLogTail, listJobs } from '../../../orchestrator/jobs.js';
 
 export async function handleProjectActivityRoutes(req, res, url, ctx) {
   const { runner, subPath } = ctx;
@@ -29,6 +30,29 @@ export async function handleProjectActivityRoutes(req, res, url, ctx) {
       `).all();
       db.close();
       sendJson(res, 200, { milestones });
+    } catch (error) {
+      sendJson(res, 500, { error: error.message });
+    }
+    return true;
+  }
+
+  if (req.method === 'GET' && subPath === 'jobs') {
+    try {
+      const db = runner.getDb();
+      const jobs = listJobs(db, runner.projectDbPath);
+      db.close();
+      sendJson(res, 200, { jobs });
+    } catch (error) {
+      sendJson(res, 500, { error: error.message });
+    }
+    return true;
+  }
+
+  const jobLogMatch = req.method === 'GET' && subPath.match(/^jobs\/([A-Za-z0-9][A-Za-z0-9._-]{0,63})\/log$/);
+  if (jobLogMatch) {
+    try {
+      const lines = Math.min(parseInt(url.searchParams.get('lines')) || 60, 500);
+      sendJson(res, 200, { log: jobLogTail(runner.projectDbPath, jobLogMatch[1], lines) });
     } catch (error) {
       sendJson(res, 500, { error: error.message });
     }

--- a/tests/project-blocked.test.js
+++ b/tests/project-blocked.test.js
@@ -90,6 +90,10 @@ describe('PROJECT_BLOCKED directive', () => {
     assert.equal(runner.phase, 'athena');
     assert.match(runner.pendingUnblockDigest, /1\. Q\? \(recommend: accept\)/);
     assert.equal(runner.wakeNow, true);
+    assert.equal(runner.consecutiveReplans, 0,
+      'human intervention resets the replan counter');
+    assert.ok(runner.healthSnoozeUntilCycle > 0,
+      'health tripwires are snoozed after an unblock so hygeia cannot immediately re-park');
   });
 
   it('documents the directive for Athena and reframes HUMAN: issues as non-blocking', () => {

--- a/tests/tbc-jobs.test.js
+++ b/tests/tbc-jobs.test.js
@@ -1,0 +1,158 @@
+import { describe, it, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { fileURLToPath } from 'url';
+import Database from 'better-sqlite3';
+import {
+  cancelJob,
+  getJob,
+  jobLogTail,
+  listJobs,
+  submitJob,
+} from '../src/orchestrator/jobs.js';
+import { normalizeWaitForSpec, WAIT_FOR_JOB_DEFAULT_POLL_MIN } from '../src/orchestrator/scheduler.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const schedulerPath = path.join(__dirname, '..', 'src', 'orchestrator', 'scheduler.js');
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tbc-jobs-'));
+after(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+function makeProject(name) {
+  const projectDir = path.join(tmpDir, name);
+  fs.mkdirSync(projectDir, { recursive: true });
+  const dbPath = path.join(projectDir, 'project.db');
+  return { dbPath, db: new Database(dbPath) };
+}
+
+async function waitUntil(fn, timeoutMs = 5000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const value = fn();
+    if (value) return value;
+    await sleep(100);
+  }
+  throw new Error('waitUntil timed out');
+}
+
+describe('formal offline jobs', () => {
+  it('runs a job to success and reconciles exit code and log', async () => {
+    const { db, dbPath } = makeProject('success');
+    const { job, alreadyRunning } = submitJob(db, dbPath, {
+      name: 'hello',
+      command: 'echo hi-there',
+      submittedBy: 'leo',
+    });
+    assert.equal(alreadyRunning, false);
+    assert.equal(job.status, 'running');
+    assert.ok(job.pid > 0);
+
+    const done = await waitUntil(() => {
+      const current = getJob(db, dbPath, 'hello');
+      return current.status !== 'running' ? current : null;
+    });
+    assert.equal(done.status, 'succeeded');
+    assert.equal(done.exit_code, 0);
+    assert.equal(done.submitted_by, 'leo');
+    assert.ok(done.finished_at, 'finished_at recorded');
+    assert.match(jobLogTail(dbPath, 'hello'), /hi-there/);
+    db.close();
+  });
+
+  it('records failure exit codes', async () => {
+    const { db, dbPath } = makeProject('failure');
+    submitJob(db, dbPath, { name: 'boom', command: 'exit 3' });
+    const done = await waitUntil(() => {
+      const current = getJob(db, dbPath, 'boom');
+      return current.status !== 'running' ? current : null;
+    });
+    assert.equal(done.status, 'failed');
+    assert.equal(done.exit_code, 3);
+    db.close();
+  });
+
+  it('deduplicates a running job by name and allows re-running a finished one', async () => {
+    const { db, dbPath } = makeProject('dedup');
+    submitJob(db, dbPath, { name: 'work', command: 'sleep 5' });
+    const second = submitJob(db, dbPath, { name: 'work', command: 'echo other' });
+    assert.equal(second.alreadyRunning, true);
+    assert.equal(second.job.command, 'sleep 5', 'running job is not replaced');
+
+    cancelJob(db, dbPath, 'work');
+    const cancelled = getJob(db, dbPath, 'work');
+    assert.equal(cancelled.status, 'killed');
+
+    const rerun = submitJob(db, dbPath, { name: 'work', command: 'echo again' });
+    assert.equal(rerun.alreadyRunning, false, 'finished job can be re-run under the same name');
+    await waitUntil(() => getJob(db, dbPath, 'work').status !== 'running' ? getJob(db, dbPath, 'work') : null);
+    assert.equal(getJob(db, dbPath, 'work').status, 'succeeded');
+    db.close();
+  });
+
+  it('marks a job failed when its process dies without a sentinel', async () => {
+    const { db, dbPath } = makeProject('crash');
+    const { job } = submitJob(db, dbPath, { name: 'crashy', command: 'sleep 30' });
+    process.kill(-job.pid, 'SIGKILL'); // simulate crash/reboot: whole group dies, no sentinel
+    const done = await waitUntil(() => {
+      const current = getJob(db, dbPath, 'crashy');
+      return current.status !== 'running' ? current : null;
+    });
+    assert.equal(done.status, 'failed');
+    assert.equal(done.exit_code, null);
+    db.close();
+  });
+
+  it('enforces the job timeout on reconcile', async () => {
+    const { db, dbPath } = makeProject('timeout');
+    submitJob(db, dbPath, { name: 'slow', command: 'sleep 60', timeoutMin: 1 });
+    // Backdate the start so the next reconcile sees it as expired
+    db.prepare("UPDATE jobs SET created_at = '2020-01-01T00:00:00Z' WHERE name = 'slow'").run();
+    const done = getJob(db, dbPath, 'slow');
+    assert.equal(done.status, 'timeout');
+    db.close();
+  });
+
+  it('validates names and rejects empty commands', () => {
+    const { db, dbPath } = makeProject('invalid');
+    assert.throws(() => submitJob(db, dbPath, { name: 'bad name!', command: 'echo x' }), /Invalid job name/);
+    assert.throws(() => submitJob(db, dbPath, { name: 'ok', command: '  ' }), /command is empty/);
+    db.close();
+  });
+
+  it('lists jobs with reconciliation and status filter', async () => {
+    const { db, dbPath } = makeProject('list');
+    submitJob(db, dbPath, { name: 'a', command: 'echo a' });
+    submitJob(db, dbPath, { name: 'b', command: 'sleep 30' });
+    await waitUntil(() => getJob(db, dbPath, 'a').status === 'succeeded');
+    const running = listJobs(db, dbPath, { status: 'running' });
+    assert.deepEqual(running.map(job => job.name), ['b']);
+    cancelJob(db, dbPath, 'b');
+    db.close();
+  });
+});
+
+describe('waitFor job specs', () => {
+  it('normalizes job waits with their own poll defaults', () => {
+    assert.deepEqual(normalizeWaitForSpec({ job: 'gem5-oracle-build' }), {
+      job: 'gem5-oracle-build',
+      timeoutMin: 720,
+      pollMin: WAIT_FOR_JOB_DEFAULT_POLL_MIN,
+    });
+  });
+
+  it('rejects specs naming both run and job, or bad job names', () => {
+    assert.equal(normalizeWaitForSpec({ run: 1, job: 'x' }), null);
+    assert.equal(normalizeWaitForSpec({ job: 'bad name!' }), null);
+    assert.equal(normalizeWaitForSpec({ job: '' }), null);
+  });
+
+  it('polls local jobs without shelling out to gh', () => {
+    const src = fs.readFileSync(schedulerPath, 'utf-8');
+    assert.match(src, /const check = job \? localJobStatus\(runner, job\) : await ghRunStatus\(repoDir, run\);/,
+      'waitForCondition should branch to local job polling');
+    assert.match(src, /if \(check\.job\.status !== 'running'\) break;/,
+      'job waits should end on any terminal job status');
+  });
+});


### PR DESCRIPTION
## Why

Stacked on #224. Long-running compute had two homes, both wrong: inside an agent's runtime (capped by `agentTimeoutMs`, holds an LLM hostage as a babysitter) or an informal `nohup … &` (invisible to the orchestrator and the human, duplicated by fresh-context agents, orphaned on kill-epoch). The gem5_akita_port project hit this concretely: its oracle needs a ~2h pinned-gem5 Docker build that no agent can host.

Design rule: **a formal job is displayed in the frontend; an informal call cannot be** — visibility is the contract.

## What

- **`src/orchestrator/jobs.js`** — `jobs` table in project.db + detached process-group execution. A wrapper writes an exit-code sentinel file when the command ends; every read path (CLI, waitFor polls, API route) reconciles DB state from sentinel + pid liveness + timeout. No daemon; jobs survive agent exits and orchestrator restarts.
- **`bin/tbc-job`** (on agent PATH like `tbc-db`): `submit --name <n> [--timeout-min N] [--cwd p] [--actor a] -- <cmd>`, `status`, `list`, `logs`, `cancel`. Submitting a name that's already running returns the existing job — dedup by construction. Finished names can be re-run.
- **`{"waitFor": {"job": "<name>"}}`** — second condition type next to `{"run": …}`: token-free local polling (2m default, 1m floor), outcome injected into the next manager context ("Job \"gem5-oracle-build\" → succeeded/exit=0 after 96m").
- **Monitor**: Jobs card on the project page (status pill, runtime, exit code, submitted-by, expandable log tail) backed by new `GET …/jobs` and `GET …/jobs/<name>/log` routes; the schedule diagram renders `wait for job <name>` chips.
- **Prompts**: `manager.md` and `worker.md` gain Offline Jobs sections — long work goes through `tbc-job`, never `nohup`; workers submit and report the name, managers `waitFor` it, nobody babysits.

## Testing

`npm test`: 239 pass / 0 fail. New `tests/tbc-jobs.test.js` exercises real detached processes: success/failure exit codes, dedup + re-run, crash-without-sentinel → failed, timeout kill on reconcile, name validation, list filtering, and the waitFor job spec normalization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)