### PR TITLE
Fix wakeNow leaking into the next cycle and skipping its waits

### DIFF
--- a/src/orchestrator/phase-machine.js
+++ b/src/orchestrator/phase-machine.js
@@ -243,6 +243,9 @@ export async function runRunnerLoop(runner, deps = {}) {
 
       // Start new cycle — preserve schedule state if resuming from reboot
       runner.abortCurrentCycle = false;
+      // A skip/resume wake request is consumed once a new cycle begins; if it
+      // leaked into the cycle, every delay/waitFor step would exit instantly.
+      runner.wakeNow = false;
       const resuming = !!runner.currentSchedule;
       if (!resuming) {
         runner.cycleCount++;

--- a/tests/wait-for-schedule.test.js
+++ b/tests/wait-for-schedule.test.js
@@ -88,6 +88,12 @@ describe('waitFor schedule steps', () => {
       'waitForCondition must never run agents');
   });
 
+  it('consumes wake requests at cycle start so waits are not skipped mid-cycle', () => {
+    const src = fs.readFileSync(phaseMachinePath, 'utf-8');
+    assert.match(src, /runner\.abortCurrentCycle = false;\s*\n\s*\/\/[^\n]*\n\s*\/\/[^\n]*\n\s*runner\.wakeNow = false;/,
+      'a leftover skip/resume wakeNow must be cleared when a new cycle begins, before any delay/waitFor step runs');
+  });
+
   it('skips waitFor steps in manager directive validation', () => {
     const src = fs.readFileSync(phaseMachinePath, 'utf-8');
     assert.match(src, /if \(!step \|\| step\.delay !== undefined \|\| step\.waitFor !== undefined\) continue;/,


### PR DESCRIPTION
A skip (or resume) sets wakeNow=true to break the current sleep, but it was only reset when the *next inter-cycle sleep* began. Any wake issued during a sleep therefore leaked into the following cycle, where every `{"delay": N}` and `{"waitFor": …}` schedule step checks `!runner.wakeNow` and exits instantly.

Observed live on gem5_akita_port: after a skip, Ares's `waitFor {job: m1-3-2-gem5-oracle-image-build}` "timed out" after 0 minutes. Now the wake request is consumed at cycle start.

`npm test`: 245 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)