### PR TITLE
Release v1.9.0: version bump + better-sqlite3 ^12.11.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "thebotcompany",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thebotcompany",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "license": "MIT",
       "dependencies": {
         "@mariozechner/pi-ai": "^0.70.2",
-        "better-sqlite3": "^12.6.2",
+        "better-sqlite3": "^12.11.1",
         "dotenv": "^17.2.4",
         "js-yaml": "^4.1.0",
         "web-push": "^3.6.7"
@@ -1738,9 +1738,9 @@
       }
     },
     "node_modules/better-sqlite3": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.6.2.tgz",
-      "integrity": "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==",
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
+      "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -1748,7 +1748,7 @@
         "prebuild-install": "^7.1.1"
       },
       "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
       }
     },
     "node_modules/bignumber.js": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thebotcompany",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Multi-project AI agent orchestrator",
   "type": "module",
   "main": "src/server.js",
@@ -24,7 +24,7 @@
   "license": "MIT",
   "dependencies": {
     "@mariozechner/pi-ai": "^0.70.2",
-    "better-sqlite3": "^12.6.2",
+    "better-sqlite3": "^12.11.1",
     "dotenv": "^17.2.4",
     "js-yaml": "^4.1.0",
     "web-push": "^3.6.7"


### PR DESCRIPTION
Release prep for v1.9.0:

- **Version 1.8.0 → 1.9.0**
- **better-sqlite3 ^12.6.2 → ^12.11.1** — 12.6.2 fails to compile against Node 26's V8 API (`no member named 'This' in v8::PropertyCallbackInfo`), breaking `npm install` for anyone on current Node. 12.11.1 builds cleanly on Node 25 and 26. Lockfile updated; 245 tests pass with the new binary.

Release notes draft for the v1.9.0 tag will follow in the release itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)