### PR TITLE
Release v1.9.1: expose tbc-job in the package bin map

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thebotcompany",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thebotcompany",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "license": "MIT",
       "dependencies": {
         "@mariozechner/pi-ai": "^0.70.2",
@@ -17,7 +17,8 @@
       },
       "bin": {
         "tbc": "bin/cli.js",
-        "tbc-db": "bin/tbc-db.js"
+        "tbc-db": "bin/tbc-db.js",
+        "tbc-job": "bin/tbc-job.js"
       }
     },
     "node_modules/@anthropic-ai/sdk": {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "thebotcompany",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Multi-project AI agent orchestrator",
   "type": "module",
   "main": "src/server.js",
   "bin": {
     "tbc": "./bin/cli.js",
-    "tbc-db": "./bin/tbc-db.js"
+    "tbc-db": "./bin/tbc-db.js",
+    "tbc-job": "./bin/tbc-job.js"
   },
   "scripts": {
     "test": "node --test tests/*.test.js",


### PR DESCRIPTION
- **Version 1.9.0 → 1.9.1**
- **`bin` map**: add `tbc-job` next to `tbc`/`tbc-db`, so global npm installs link the command for human operators (agents already resolve it via the orchestrator-prepended `bin/` PATH).

🤖 Generated with [Claude Code](https://claude.com/claude-code)