### PR TITLE
Upgrade Anthropic tier defaults to Sonnet 5 and Opus 4.8

### DIFF
--- a/monitor/src/components/panels/ProjectSettingsPanel.jsx
+++ b/monitor/src/components/panels/ProjectSettingsPanel.jsx
@@ -318,7 +318,7 @@ export default function ProjectSettingsPanel({
                           initialValue={currentModels[tier] || ''}
                           placeholder={keyProvider === 'custom'
                             ? `Default (${providerTiers[tier]?.model || '—'})`
-                            : 'Model ID, e.g. claude-opus-4-7@high'}
+                            : 'Model ID, e.g. claude-opus-4-8@high'}
                           onCommit={(val) => {
                             const models = { ...currentModels };
                             if (val) models[tier] = val; else delete models[tier];

--- a/src/agent-runner.js
+++ b/src/agent-runner.js
@@ -1272,7 +1272,7 @@ async function executeTool(toolName, toolInput, cwd, remainingMs = 0, bashEnv = 
  *
  * @param {Object} opts
  * @param {string} opts.prompt       - The full system prompt / skill content
- * @param {string} opts.model        - Model name (e.g. 'claude-opus-4-7', 'openai/gpt-5.5')
+ * @param {string} opts.model        - Model name (e.g. 'claude-opus-4-8', 'openai/gpt-5.5')
  * @param {string} opts.token        - Auth token (OAuth, API key, or OpenAI key)
  * @param {string} opts.cwd          - Working directory for tool execution
  * @param {number} opts.timeoutMs    - Max runtime in milliseconds (0 = unlimited)
@@ -1286,7 +1286,7 @@ async function executeTool(toolName, toolInput, cwd, remainingMs = 0, bashEnv = 
 export async function runAgentWithAPI(opts) {
   const {
     prompt,
-    model: rawModel = 'claude-opus-4-7',
+    model: rawModel = 'claude-opus-4-8',
     token: initialToken,
     keyType = 'api',
     provider: initialProvider = null,

--- a/src/chat.js
+++ b/src/chat.js
@@ -321,7 +321,7 @@ function getChatToolDefinitions() {
  * @param {string} opts.projectPath  - Project repo path
  * @param {number} opts.chatId       - Chat session ID
  * @param {string} opts.userMessage  - User's message text
- * @param {string} opts.model        - Model name (e.g. 'claude-opus-4-7')
+ * @param {string} opts.model        - Model name (e.g. 'claude-opus-4-8')
  * @param {string} opts.token        - API key/token
  * @param {string} opts.provider     - Provider hint
  * @param {object|null} [opts.customConfig] - Custom provider config

--- a/src/model-tiers.js
+++ b/src/model-tiers.js
@@ -10,9 +10,9 @@
 
 export const MODEL_TIERS = {
   anthropic: {
-    high:  { model: 'claude-opus-4-7', reasoningEffort: 'high' },
-    mid:   { model: 'claude-sonnet-4-6', reasoningEffort: 'high' },
-    low:   { model: 'claude-sonnet-4-6' },
+    high:  { model: 'claude-opus-4-8', reasoningEffort: 'high' },
+    mid:   { model: 'claude-sonnet-5', reasoningEffort: 'high' },
+    low:   { model: 'claude-sonnet-5' },
     xlow:  { model: 'claude-haiku-4-5-20251001' },
   },
   openai: {

--- a/src/providers/pi-ai-adapter.js
+++ b/src/providers/pi-ai-adapter.js
@@ -19,7 +19,7 @@ import { callCustomModel } from './custom-adapter.js';
 // ---------------------------------------------------------------------------
 
 /**
- * Parse a TBC model string (e.g. "openai/gpt-5.5", "claude-opus-4-7",
+ * Parse a TBC model string (e.g. "openai/gpt-5.5", "claude-opus-4-8",
  * "google/gemini-3.1-pro-preview", "minimax/MiniMax-M2.7",
  * "openai-codex/gpt-5.5") into a { provider, modelId } pair that pi-ai
  * understands.
@@ -99,7 +99,7 @@ function synthesizeModel(provider, modelId) {
  * (see synthesizeModel) instead of undefined, so newly released models are
  * usable before the installed pi-ai catalog includes them.
  *
- * @param {string} rawModel - TBC model string (e.g. "claude-opus-4-7")
+ * @param {string} rawModel - TBC model string (e.g. "claude-opus-4-8")
  * @returns {{ piModel: object, providerName: string }}
  */
 export function resolveModel(rawModel, providerOverride = null) {

--- a/tests/model-catalog.test.js
+++ b/tests/model-catalog.test.js
@@ -45,7 +45,7 @@ test('resolveModel synthesizes a fallback for unknown models on a known provider
 });
 
 test('known models never get the catalogFallback flag', () => {
-  const { piModel } = resolveModel('claude-opus-4-7', 'anthropic');
+  const { piModel } = resolveModel('claude-opus-4-8', 'anthropic');
   assert.ok(piModel);
   assert.strictEqual(piModel.catalogFallback, undefined);
 });


### PR DESCRIPTION
## Summary
- Bump the anthropic `MODEL_TIERS` defaults: `high` → `claude-opus-4-8`, `mid`/`low` → `claude-sonnet-5` (`xlow` stays on `claude-haiku-4-5-20251001`, still current)
- Update matching doc comments/defaults in `src/agent-runner.js`, `src/chat.js`, `src/providers/pi-ai-adapter.js`, and the `monitor` UI placeholder text
- Update the fixed model ID in `tests/model-catalog.test.js`'s "no catalogFallback" assertion

## Why
Sonnet and Opus have newer releases (5 and 4.8) available in the installed `@earendil-works/pi-ai` catalog; the project's tier defaults were still pinned to the previous generation (4.6/4.7).

## Test plan
- [x] Confirmed `claude-sonnet-5` and `claude-opus-4-8` exist in the installed pi-ai catalog (`getModels('anthropic')`)
- [x] `node --test tests/model-catalog.test.js tests/model-override-validation.test.js` — all pass, including the dynamic per-tier catalog resolution test
- [x] `npm test` (full suite, 286 tests) — all pass