### PR TITLE
release: v1.10.0 — catalog-derived model selection, Sonnet 5/Opus 4.8 defaults

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thebotcompany",
-  "version": "1.9.1",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thebotcompany",
-      "version": "1.9.1",
+      "version": "1.10.0",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-ai": "^0.80.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thebotcompany",
-  "version": "1.9.1",
+  "version": "1.10.0",
   "description": "Multi-project AI agent orchestrator",
   "type": "module",
   "main": "src/server.js",


### PR DESCRIPTION
## Summary
Version bump only — all the underlying changes are already merged to `main`.

### Features
- **Catalog-derived model selection** (#240) — the settings and chat model pickers now derive their list from the pi-ai catalog instead of a hand-maintained regex allowlist, support arbitrary/custom model IDs with graceful fallback, and fix a bug where the `xlow` tier was silently dropped on save.
- **Sonnet 5 / Opus 4.8 tier defaults** (#241) — `high` now defaults to `claude-opus-4-8`, `mid`/`low` to `claude-sonnet-5`.

### Dependencies
- `pi-ai` bumped to `^0.73.1`, with automated future updates (#230)
- `js-yaml` bumped to v5, `vite`/`@vitejs/plugin-react` bumped to v8/v6 together, with the resulting breaking-change fixes applied (#242)
- Routine GitHub Actions and `monitor` package bumps (#231, #232, #233, #234, #236, #239)

## Test plan
- [x] `npm test` — 286/286 passing
- [x] `cd monitor && npx playwright test` — 29/29 passing