### PR TITLE
Upgrade pi-ai to 0.80.10: gpt-5.6 tier defaults and capability-aware effort selection

### DIFF
--- a/monitor/src/components/panels/ProjectSettingsPanel.jsx
+++ b/monitor/src/components/panels/ProjectSettingsPanel.jsx
@@ -268,10 +268,17 @@ export default function ProjectSettingsPanel({
 
           const recommendedModels = availableModels.filter(m => m.recommended);
           const otherModels = availableModels.filter(m => !m.recommended);
+          // Saved overrides may carry a provider prefix (tier defaults like
+          // "openai-codex/gpt-5.6-sol@xhigh") while catalog options use bare
+          // IDs — compare and render the bare form.
+          const bareTierValue = (tier) => {
+            const val = currentModels[tier] || '';
+            return val.startsWith(`${keyProvider}/`) ? val.slice(keyProvider.length + 1) : val;
+          };
           // A tier is in free-text mode if toggled there, or if its saved
           // value isn't one of the catalog options.
           const isCustomTier = (tier) => customModelTiers[tier] ||
-            (!!currentModels[tier] && !availableModels.some(m => m.id === currentModels[tier]));
+            (!!currentModels[tier] && !availableModels.some(m => m.id === bareTierValue(tier)));
 
           return (
           <div className="border-t border-neutral-200 dark:border-neutral-700 pt-5 mt-5">
@@ -331,7 +338,7 @@ export default function ProjectSettingsPanel({
                             type="button"
                             onClick={() => {
                               setCustomModelTiers(prev => ({ ...prev, [tier]: false }));
-                              if (currentModels[tier] && !availableModels.some(m => m.id === currentModels[tier])) {
+                              if (currentModels[tier] && !availableModels.some(m => m.id === bareTierValue(tier))) {
                                 const models = { ...currentModels };
                                 delete models[tier];
                                 setSelectedProject(prev => prev ? { ...prev, config: { ...prev.config, models } } : prev);
@@ -347,7 +354,7 @@ export default function ProjectSettingsPanel({
                       </>
                     ) : (
                       <select
-                        value={currentModels[tier] || ''}
+                        value={bareTierValue(tier)}
                         onChange={(e) => {
                           const val = e.target.value;
                           if (val === '__custom__') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.10.0",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.80.3",
+        "@earendil-works/pi-ai": "^0.80.10",
         "better-sqlite3": "^12.11.1",
         "dotenv": "^17.2.4",
         "js-yaml": "^5.2.1",
@@ -483,9 +483,9 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.3.tgz",
-      "integrity": "sha512-jPZLMeGL5kkMSEAwAklfXTMHqZvfhsJtCCpKGIr5Duk7mc0n4skjB1dugk7y0z3z8ZHIUCmPAWHdyDqgUz5vdA==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.10.tgz",
+      "integrity": "sha512-Moe/H8c87yacDGK9dPbWphZNjVsrb3nTrIHycOQJAkFEnY9PYxOOd74+ny44kATfPU9Dm7aTHefar3pZF+UKUA==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "author": "Yifan Sun",
   "license": "MIT",
   "dependencies": {
-    "@earendil-works/pi-ai": "^0.80.3",
+    "@earendil-works/pi-ai": "^0.80.10",
     "better-sqlite3": "^12.11.1",
     "dotenv": "^17.2.4",
     "js-yaml": "^5.2.1",

--- a/src/agent-runner.js
+++ b/src/agent-runner.js
@@ -18,7 +18,6 @@ import {
   buildAssistantMessage,
   buildToolResultMessages,
   buildUserMessage,
-  calculateCost,
 } from './providers/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -1272,7 +1271,7 @@ async function executeTool(toolName, toolInput, cwd, remainingMs = 0, bashEnv = 
  *
  * @param {Object} opts
  * @param {string} opts.prompt       - The full system prompt / skill content
- * @param {string} opts.model        - Model name (e.g. 'claude-opus-4-8', 'openai/gpt-5.5')
+ * @param {string} opts.model        - Model name (e.g. 'claude-opus-4-8', 'openai/gpt-5.6-sol')
  * @param {string} opts.token        - Auth token (OAuth, API key, or OpenAI key)
  * @param {string} opts.cwd          - Working directory for tool execution
  * @param {number} opts.timeoutMs    - Max runtime in milliseconds (0 = unlimited)

--- a/src/model-tiers.js
+++ b/src/model-tiers.js
@@ -16,14 +16,16 @@ export const MODEL_TIERS = {
     xlow:  { model: 'claude-haiku-4-5-20251001' },
   },
   openai: {
-    high:  { model: 'gpt-5.5', reasoningEffort: 'xhigh' },
-    mid:   { model: 'gpt-5.5', reasoningEffort: 'high' },
-    low:   { model: 'gpt-5.5', reasoningEffort: 'medium' },
-    xlow:  { model: 'gpt-4.1-mini' },
+    high:  { model: 'gpt-5.6-sol', reasoningEffort: 'xhigh' },
+    mid:   { model: 'gpt-5.6-sol', reasoningEffort: 'high' },
+    low:   { model: 'gpt-5.6-terra', reasoningEffort: 'medium' },
+    xlow:  { model: 'gpt-5.6-luna' },
   },
   google: {
     high:  { model: 'gemini-3.1-pro-preview', reasoningEffort: 'high' },
-    mid:   { model: 'gemini-3.1-pro-preview', reasoningEffort: 'medium' },
+    // gemini-3.1-pro-preview only supports low/high (its catalog map nulls
+    // the rest); "medium" was silently clamped to high anyway, so label it.
+    mid:   { model: 'gemini-3.1-pro-preview', reasoningEffort: 'high' },
     low:   { model: 'gemini-3-flash-preview' },
     xlow:  { model: 'gemini-3-flash-preview' },
   },
@@ -34,9 +36,12 @@ export const MODEL_TIERS = {
     xlow:  { model: 'minimax/MiniMax-M2.7' },
   },
   'openai-codex': {
-    high:  { model: 'openai-codex/gpt-5.5', reasoningEffort: 'xhigh' },
-    mid:   { model: 'openai-codex/gpt-5.5', reasoningEffort: 'high' },
-    low:   { model: 'openai-codex/gpt-5.5', reasoningEffort: 'medium' },
-    xlow:  { model: 'openai-codex/gpt-5.5', reasoningEffort: 'low' },
+    high:  { model: 'openai-codex/gpt-5.6-sol', reasoningEffort: 'xhigh' },
+    mid:   { model: 'openai-codex/gpt-5.6-sol', reasoningEffort: 'high' },
+    low:   { model: 'openai-codex/gpt-5.6-terra', reasoningEffort: 'medium' },
+    // Unlike the plain openai provider (whose bare entry runs reasoning-off
+    // via thinkingLevelMap.off), codex has no "off" mapping — an unset effort
+    // would fall back to the backend default (medium), so keep it explicit.
+    xlow:  { model: 'openai-codex/gpt-5.6-luna', reasoningEffort: 'low' },
   },
 };

--- a/src/providers/index.js
+++ b/src/providers/index.js
@@ -12,8 +12,9 @@ export {
   buildAssistantMessage,
   buildToolResultMessages,
   buildUserMessage,
-  calculateCost,
   getProviders,
   getModels,
   getModel,
+  getSupportedThinkingLevels,
+  THINKING_LEVELS,
 } from './pi-ai-adapter.js';

--- a/src/providers/pi-ai-adapter.js
+++ b/src/providers/pi-ai-adapter.js
@@ -8,20 +8,28 @@ import {
   getModel,
   getModels,
   getProviders,
+  getSupportedThinkingLevels,
   complete,
   completeSimple,
   Type,
 } from '@earendil-works/pi-ai/compat';
 import { callCustomModel } from './custom-adapter.js';
 
+/**
+ * Every reasoning-effort level pi-ai understands, in ascending order. Single
+ * source of truth for TBC's effort validation and UI lists; whether a given
+ * model supports a level is answered per-model by getSupportedThinkingLevels.
+ */
+export const THINKING_LEVELS = ['minimal', 'low', 'medium', 'high', 'xhigh', 'max'];
+
 // ---------------------------------------------------------------------------
 // Model resolution — map TBC model strings to pi-ai Model objects
 // ---------------------------------------------------------------------------
 
 /**
- * Parse a TBC model string (e.g. "openai/gpt-5.5", "claude-opus-4-8",
+ * Parse a TBC model string (e.g. "openai/gpt-5.6-sol", "claude-opus-4-8",
  * "google/gemini-3.1-pro-preview", "minimax/MiniMax-M2.7",
- * "openai-codex/gpt-5.5") into a { provider, modelId } pair that pi-ai
+ * "openai-codex/gpt-5.6-sol") into a { provider, modelId } pair that pi-ai
  * understands.
  */
 function parseTBCModel(rawModel) {
@@ -84,6 +92,10 @@ function synthesizeModel(provider, modelId) {
     baseUrl: sibling.baseUrl,
     headers: sibling.headers,
     reasoning: sibling.reasoning,
+    // Without a thinkingLevelMap pi-ai treats xhigh/max as unsupported and
+    // silently clamps them to high — borrow the sibling's map so a newer
+    // model keeps the effort range of its family.
+    thinkingLevelMap: sibling.thinkingLevelMap,
     input: ['text'],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     contextWindow: sibling.contextWindow,
@@ -156,9 +168,9 @@ function buildOptions({ token, isOAuth, reasoningEffort, signal, provider }) {
     opts.signal = signal;
   }
 
-  // Map TBC reasoning effort to pi-ai's unified reasoning levels
+  // Map TBC reasoning effort to pi-ai's unified reasoning levels (THINKING_LEVELS)
   if (reasoningEffort) {
-    opts.reasoning = reasoningEffort; // pi-ai accepts: 'minimal'|'low'|'medium'|'high'|'xhigh'
+    opts.reasoning = reasoningEffort;
   }
 
   // pi-ai handles OAuth tokens natively for all providers:
@@ -201,8 +213,12 @@ export async function callModel(piModel, systemPrompt, messages, tools, opts = {
   if (assistantMsg.stopReason === 'error' || assistantMsg.stopReason === 'aborted') {
     const errMsg = assistantMsg.errorMessage || `API call failed (stopReason: ${assistantMsg.stopReason})`;
     const err = new Error(errMsg);
-    // Try to extract HTTP status from the error message for retry logic
-    const statusMatch = errMsg.match(/status(?:\s+code)?:?\s*(\d{3})/i);
+    // Try to extract HTTP status from the error message for retry logic.
+    // pi-ai formats vary: "status: 429", "429 status code (no body)",
+    // "OpenAI API error (429): ...".
+    const statusMatch = errMsg.match(/status(?:\s+code)?:?\s*(\d{3})/i)
+      || errMsg.match(/\b(\d{3})\s+status\b/i)
+      || errMsg.match(/\((\d{3})\)/);
     if (statusMatch) err.status = parseInt(statusMatch[1], 10);
     throw err;
   }
@@ -246,6 +262,7 @@ function normalizeResponse(assistantMsg) {
       inputTokens: assistantMsg.usage?.input || 0,
       outputTokens: assistantMsg.usage?.output || 0,
       cacheReadTokens: assistantMsg.usage?.cacheRead || 0,
+      cacheWriteTokens: assistantMsg.usage?.cacheWrite || 0,
     },
     cost: assistantMsg.usage?.cost?.total || 0,
     // Keep the raw pi-ai message for building conversation history
@@ -293,24 +310,7 @@ export function buildUserMessage(text) {
 }
 
 // ---------------------------------------------------------------------------
-// Cost calculation
-// ---------------------------------------------------------------------------
-
-/**
- * Calculate cost from accumulated TBC usage stats using a pi-ai Model.
- */
-export function calculateCost(usage, piModel) {
-  if (!piModel?.cost) return 0;
-  const cost = piModel.cost;
-  return (
-    (usage.inputTokens * cost.input) +
-    (usage.outputTokens * cost.output) +
-    ((usage.cacheReadTokens || 0) * cost.cacheRead)
-  ) / 1_000_000;
-}
-
-// ---------------------------------------------------------------------------
 // Re-exports for discoverability
 // ---------------------------------------------------------------------------
 
-export { getProviders, getModels, getModel };
+export { getProviders, getModels, getModel, getSupportedThinkingLevels };

--- a/src/server.js
+++ b/src/server.js
@@ -11,7 +11,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { execSync } from 'child_process';
-import { getModels as getPiModels } from './providers/index.js';
+import { getModels as getPiModels, getModel as getPiModel } from './providers/index.js';
 import { MODEL_TIERS } from './model-tiers.js';
 import { buildCustomTierMap, resolveProviderRuntime } from './providers/custom-config.js';
 import { startOAuthLogin, submitManualCode, checkOAuthStatus, getAccessToken as getOAuthAccessToken, clearCredentials as clearOAuthCredentials, listOAuthProviders, loadCredentials as loadOAuthCredentials } from './oauth.js';
@@ -99,9 +99,16 @@ function resolveModelTier(tierOrModel, provider, projectModels) {
   if (projectModels && projectModels[tier]) {
     const override = projectModels[tier];
     const overrideModel = override.includes('@') ? override.split('@', 2)[0] : override;
+    // Compatible when the name infers the active provider, or when the active
+    // provider's own catalog knows the bare ID — openai-codex serves bare
+    // "gpt-*" IDs that would otherwise infer "openai" and be discarded.
     const overrideProvider = inferProviderFromModel(overrideModel);
-    if (!overrideProvider || overrideProvider === provider) {
-      // Support "model@effort" format (e.g. "gpt-5.5@xhigh")
+    let compatible = !overrideProvider || overrideProvider === provider;
+    if (!compatible && provider !== 'custom') {
+      try { compatible = !!getPiModel(provider, overrideModel); } catch { /* keep incompatible */ }
+    }
+    if (compatible) {
+      // Support "model@effort" format (e.g. "gpt-5.6-sol@xhigh")
       if (override.includes('@')) {
         const [model, reasoningEffort] = override.split('@', 2);
         return { model, reasoningEffort };

--- a/src/server/routes/project/available-models.js
+++ b/src/server/routes/project/available-models.js
@@ -8,10 +8,10 @@
  * New models arrive automatically with each pi-ai upgrade.
  */
 
+import { getSupportedThinkingLevels } from '../../../providers/index.js';
+
 // Models below this context window are too old/small for TBC's agent loops.
 const CONTEXT_WINDOW_FLOOR = 32_000;
-
-const EFFORT_LEVELS = ['medium', 'high', 'xhigh'];
 
 /** Strip a "provider/" prefix from a tier model string (e.g. "minimax/MiniMax-M2.7"). */
 function bareModelId(model, provider) {
@@ -51,7 +51,10 @@ export function buildAvailableModels(modelTiers, getPiModels) {
       // tier-default strings like "claude-haiku-4-5-..." selectable.
       entries.push({ id: model.id, name: model.name, recommended });
       if (model.reasoning) {
-        for (const effort of EFFORT_LEVELS) {
+        // Only the levels this model actually honors — pi-ai silently clamps
+        // anything else, so offering it would mislabel the runtime effort.
+        for (const effort of getSupportedThinkingLevels(model)) {
+          if (effort === 'off') continue;
           entries.push({ id: `${model.id}@${effort}`, name: `${model.name} (${effort})`, recommended });
         }
       }

--- a/src/server/routes/project/config.js
+++ b/src/server/routes/project/config.js
@@ -2,17 +2,22 @@ import fs from 'fs';
 import * as yaml from 'js-yaml';
 import { readJson, sendJson } from '../../http.js';
 import { buildAvailableModels } from './available-models.js';
-import { resolveModel } from '../../../providers/index.js';
+import { resolveModel, getSupportedThinkingLevels, THINKING_LEVELS } from '../../../providers/index.js';
 
-const VALID_EFFORTS = new Set(['minimal', 'low', 'medium', 'high', 'xhigh']);
+const VALID_EFFORTS = new Set(THINKING_LEVELS);
 
 /**
  * Validate a "model" or "model@effort" override string. Unknown model IDs are
  * allowed (they run via the catalog-fallback path) but produce a warning;
- * a malformed effort suffix is a hard error.
+ * a malformed effort suffix is a hard error, and an effort the model's
+ * catalog entry doesn't support warns (pi-ai clamps it at runtime).
  */
 function checkModelOverride(tier, value, { skipCatalogCheck = false } = {}) {
-  const [modelId, effort] = value.includes('@') ? value.split('@', 2) : [value, null];
+  const parts = value.split('@');
+  if (parts.length > 2) {
+    return { error: `${tier}: malformed model override "${value}" (expected "model" or "model@effort")` };
+  }
+  const [modelId, effort = null] = parts;
   if (!modelId) {
     return { error: `${tier}: missing model ID in "${value}"` };
   }
@@ -27,6 +32,9 @@ function checkModelOverride(tier, value, { skipCatalogCheck = false } = {}) {
   }
   if (piModel.catalogFallback) {
     return { warning: `${tier}: "${modelId}" is not in the model catalog — it will run untested, with cost tracked as $0` };
+  }
+  if (effort !== null && !getSupportedThinkingLevels(piModel).includes(effort)) {
+    return { warning: `${tier}: "${modelId}" does not support reasoning effort "${effort}" — it will run at the nearest supported level` };
   }
   return {};
 }

--- a/tests/available-models.test.js
+++ b/tests/available-models.test.js
@@ -19,6 +19,8 @@ function fakeCatalog(provider) {
   assert.equal(provider, 'acme');
   return [
     { id: 'acme-big', name: 'Acme Big', reasoning: true, contextWindow: 200000 },
+    { id: 'acme-deep', name: 'Acme Deep', reasoning: true, contextWindow: 200000,
+      thinkingLevelMap: { off: 'none', xhigh: 'xhigh', max: 'max' } },
     { id: 'acme-small', name: 'Acme Small', reasoning: false, contextWindow: 128000 },
     { id: 'acme-new', name: 'Acme New', reasoning: false, contextWindow: 1000000 },
     { id: 'acme-big-latest', name: 'Acme Big (latest)', reasoning: true, contextWindow: 200000 },
@@ -44,9 +46,21 @@ describe('buildAvailableModels', () => {
     assert.ok(entries.some(e => e.id === 'acme-new'), 'new catalog models appear automatically');
   });
 
-  it('lists reasoning models as a bare entry plus effort variants', () => {
+  it('lists reasoning models as a bare entry plus the effort variants the model supports', () => {
+    // No thinkingLevelMap → pi-ai supports minimal..high but not xhigh/max,
+    // which require an explicit declaration.
     const bigIds = entries.filter(e => e.id.startsWith('acme-big')).map(e => e.id);
-    assert.deepEqual(bigIds.sort(), ['acme-big', 'acme-big@high', 'acme-big@medium', 'acme-big@xhigh']);
+    assert.deepEqual(bigIds.sort(), [
+      'acme-big', 'acme-big@high', 'acme-big@low', 'acme-big@medium', 'acme-big@minimal',
+    ]);
+  });
+
+  it('emits @xhigh/@max variants only for models whose thinkingLevelMap declares them', () => {
+    const ids = entries.map(e => e.id);
+    assert.ok(ids.includes('acme-deep@xhigh'), 'declared xhigh yields an @xhigh variant');
+    assert.ok(ids.includes('acme-deep@max'), 'declared max yields an @max variant');
+    assert.ok(!ids.includes('acme-big@xhigh'), 'undeclared xhigh yields no variant');
+    assert.ok(!ids.includes('acme-big@max'), 'undeclared max yields no variant');
   });
 
   it('flags tier-default models as recommended (including prefixed tier entries) and sorts them first', () => {

--- a/tests/model-catalog.test.js
+++ b/tests/model-catalog.test.js
@@ -11,10 +11,10 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
 import { MODEL_TIERS } from '../src/model-tiers.js';
-import { resolveModel } from '../src/providers/index.js';
+import { resolveModel, getSupportedThinkingLevels } from '../src/providers/index.js';
 
 for (const [provider, tiers] of Object.entries(MODEL_TIERS)) {
-  for (const [tier, { model }] of Object.entries(tiers)) {
+  for (const [tier, { model, reasoningEffort }] of Object.entries(tiers)) {
     test(`MODEL_TIERS ${provider}/${tier} (${model}) resolves in the pi-ai catalog`, () => {
       const { piModel, providerName } = resolveModel(model, provider);
 
@@ -22,10 +22,19 @@ for (const [provider, tiers] of Object.entries(MODEL_TIERS)) {
       assert.strictEqual(providerName, provider);
       assert.strictEqual(piModel.provider, provider);
 
-      // Pricing must be present so calculateCost() produces real numbers.
+      // Pricing must be present so cost accounting produces real numbers.
       assert.ok(piModel.cost, `${model} has no cost data in pi-ai catalog`);
       assert.strictEqual(typeof piModel.cost.input, 'number');
       assert.strictEqual(typeof piModel.cost.output, 'number');
+
+      // A tier default must run at the effort it declares — pi-ai silently
+      // clamps unsupported levels, so a mismatch here is a lying label.
+      if (reasoningEffort) {
+        assert.ok(
+          getSupportedThinkingLevels(piModel).includes(reasoningEffort),
+          `${model} does not support reasoning effort "${reasoningEffort}"`
+        );
+      }
     });
   }
 }

--- a/tests/model-override-validation.test.js
+++ b/tests/model-override-validation.test.js
@@ -74,6 +74,28 @@ describe('POST models validation', () => {
     assert.equal(saved().models.high, 'claude-brand-new-model');
   });
 
+  it('accepts the max reasoning effort for max-capable models', async () => {
+    const { res, saved } = await postModels({ high: 'gpt-5.6-sol@max' });
+    assert.equal(res.statusCode, 200);
+    assert.deepEqual(res.body.warnings, []);
+    assert.equal(saved().models.high, 'gpt-5.6-sol@max');
+  });
+
+  it('warns when the model does not support the requested effort', async () => {
+    const { res, saved } = await postModels({ high: 'claude-haiku-4-5-20251001@max' });
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.body.warnings.length, 1);
+    assert.match(res.body.warnings[0], /does not support reasoning effort/);
+    assert.equal(saved().models.high, 'claude-haiku-4-5-20251001@max', 'clamped-but-valid override still saves');
+  });
+
+  it('rejects overrides with more than one @ separator', async () => {
+    const { res, saved } = await postModels({ high: 'gpt-5.6-sol@max@turbo' });
+    assert.equal(res.statusCode, 400);
+    assert.match(res.body.error, /malformed model override/);
+    assert.equal(saved(), null, 'nothing saved on validation failure');
+  });
+
   it('rejects malformed reasoning effort suffixes', async () => {
     const { res, saved } = await postModels({ high: 'claude-opus-4-7@turbo' });
     assert.equal(res.statusCode, 400);

--- a/tests/summarize-fallback.test.js
+++ b/tests/summarize-fallback.test.js
@@ -131,7 +131,7 @@ describe('Summarize fallback', () => {
     //
     // When the primary key (openai-codex) is rate-limited and fallback
     // returns an anthropic key, the model should be resolved for anthropic
-    // (e.g. claude-haiku), not for openai-codex (e.g. gpt-5.5).
+    // (e.g. claude-haiku), not for openai-codex.
 
     it('fallback key provider differs from primary — model must match fallback', async () => {
       const primary = addKey({ label: 'OpenAI', token: 'sk-proj-primary', provider: 'openai-codex' });
@@ -153,7 +153,7 @@ describe('Summarize fallback', () => {
       //   const resolved = resolveModelTier('low', providerName);
       //
       // This uses the FIRST key's provider (openai-codex), not keyResult.provider (anthropic).
-      // So it resolves to openai-codex/gpt-5.5 model, but sends the anthropic token.
+      // So it resolves to the openai-codex tier model, but sends the anthropic token.
       //
       // FIX: Use keyResult.provider for model resolution:
       //   const resolved = resolveModelTier('low', keyResult.provider);


### PR DESCRIPTION
## What

Bumps `@earendil-works/pi-ai` from 0.80.3 to 0.80.10, whose bundled catalog adds OpenAI's **gpt-5.6 family** — Sol ($5/$30 per Mtok), Terra ($2.5/$15), Luna ($1/$6), all reasoning models with 272k context and a new `max` thinking level — under both the `openai` and `openai-codex` providers.

**New tier defaults** (openai and openai-codex): high = `gpt-5.6-sol@xhigh`, mid = `gpt-5.6-sol@high`, low = `gpt-5.6-terra@medium`, xlow = `gpt-5.6-luna` (codex xlow keeps an explicit `low` effort — codex has no "off" mapping, so an unset effort would fall back to the backend default). gpt-5.5 remains selectable for overrides; tier defaults only control the `recommended` flag.

**Capability-aware efforts.** Effort variants are no longer a hand-maintained list:
- The model picker derives each reasoning model's `@effort` variants from pi-ai's `getSupportedThinkingLevels()`, so it never offers a level pi-ai would silently clamp (e.g. gemini-3.1-pro only shows `low`/`high`; gpt-5.6 shows through `@max`).
- Override validation shares a single `THINKING_LEVELS` constant, warns when a requested effort is unsupported by the model, and rejects malformed `model@x@y` strings.
- `tests/model-catalog.test.js` now asserts every tier default's effort is supported by its model, so a future catalog bump that would clamp a default fails CI.

## Review fixes

An adversarial multi-agent review of the upgrade surfaced these, all fixed here:

- **Codex overrides were dead**: the runtime provider gate inferred `openai` from bare `gpt-*` IDs and silently discarded every dropdown-produced override on an openai-codex key. `resolveModelTier` now also accepts an override when the active provider's catalog knows the bare ID.
- **Settings panel**: saved values with provider prefixes (`openai-codex/...`, `minimax/...`) never matched the bare dropdown IDs, forcing free-text mode; matching now strips the prefix.
- **Catalog-fallback models** (newer than the installed catalog) got no `thinkingLevelMap`, so xhigh/max silently clamped to high; `synthesizeModel` now copies the sibling's map.
- **Retry classification**: the HTTP-status regex didn't match pi-ai's actual error formats (`API error (429):`, `429 status code (no body)`), so terse transient errors read as fatal; the extraction now covers all three shapes.
- **Cost ledger**: normalized usage now includes `cacheWriteTokens` (gpt-5.6 prices cache writes at $6.25/MTok, gpt-5.5 was $0); the dead `calculateCost` that ignored cacheWrite and tiered rates is removed. (Persisting the new token column to the reports DB is left for a follow-up schema migration.)
- Google mid tier relabeled `@high` — `medium` is unsupported by gemini-3.1-pro and already ran clamped to high, so behavior is unchanged and the label is now honest. Stale `gpt-5.5` doc examples updated.

## Testing

- Full suite passes: 290/290 (new tests for supported-effort derivation, unsupported-effort warnings, multi-`@` rejection, and per-tier effort support).
- Smoke-verified: all six gpt-5.6 tier entries resolve with real pricing and no catalog fallback; bare `gpt-5.6-terra` + codex provider resolves to `openai-codex/gpt-5.6-terra`; status extraction returns 429/503/529 for pi-ai's real formats; monitor frontend builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)