### PR TITLE
release: v1.11.0 — GPT-5.6 defaults and capability-aware efforts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thebotcompany",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thebotcompany",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-ai": "^0.80.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thebotcompany",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Multi-project AI agent orchestrator",
   "type": "module",
   "main": "src/server.js",


### PR DESCRIPTION
## Summary
Version bump only — the underlying GPT-5.6 support is already merged to `main` in #251.

### Features
- **GPT-5.6 family** — adds Sol, Terra, and Luna under both OpenAI and OpenAI Codex, with new tier defaults and real catalog pricing.
- **Capability-aware reasoning efforts** — model pickers derive supported effort variants from pi-ai, including the new `max` level, and tier defaults are checked against catalog capabilities.
- **Runtime fixes** — honors catalog-backed Codex overrides, normalizes provider-prefixed saved values, improves transient HTTP-status extraction, and includes cache-write usage in normalized responses.

### Dependencies
- `@earendil-works/pi-ai` upgraded from `^0.80.3` to `^0.80.10` (#251).

## Test plan
- [x] PR #251 GitHub test check — 290/290 passing
- [x] Release manifests agree on version 1.11.0
