### PR TITLE
Fix clean-install release validation

### DIFF
--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -3,6 +3,15 @@ name: Clean Install Test
 on:
   push:
     tags: ['v*']
+  pull_request:
+    paths:
+      - '.github/workflows/install-test.yml'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'bin/**'
+      - 'src/**'
+      - 'agent/**'
+      - 'monitor/**'
   workflow_dispatch:
 
 jobs:
@@ -10,7 +19,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        node: [20, 22]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -19,10 +27,13 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 22
 
-      - name: Install from source
-        run: npm install -g .
+      - name: Build package tarball
+        run: npm pack
+
+      - name: Install packed artifact
+        run: npm install -g ./thebotcompany-*.tgz
 
       - name: Verify tbc CLI exists
         run: tbc --help
@@ -35,6 +46,10 @@ jobs:
           test -d ~/.thebotcompany
           test -f ~/.thebotcompany/projects.yaml
           echo "Config directory OK"
+
+      - name: Configure test server
+        run: |
+          printf 'TBC_PASSWORD=ci-test\nTBC_PORT=3100\n' > ~/.thebotcompany/.env
 
       - name: Verify tbc status (server not running)
         run: |

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: monitor/package-lock.json
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Human-free software development with self-organizing AI agent teams.
 
 ## Prerequisites
 
-- **Node.js** ≥ 20
+- **Node.js** ≥ 22.19
 - **[GitHub CLI](https://cli.github.com/)** (`gh`) — installed and authenticated
 - An API key from any supported provider (Anthropic, OpenAI, Google, etc.)
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -16,7 +16,7 @@ import { spawn, execSync } from 'child_process';
 import path from 'path';
 import fs from 'fs';
 import { fileURLToPath } from 'url';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import { createInterface } from 'readline';
 import crypto from 'crypto';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "thebotcompany",
       "version": "1.11.0",
       "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      },
       "dependencies": {
         "@earendil-works/pi-ai": "^0.80.10",
         "better-sqlite3": "^12.11.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
   ],
   "author": "Yifan Sun",
   "license": "MIT",
+  "engines": {
+    "node": ">=22.19.0"
+  },
   "dependencies": {
     "@earendil-works/pi-ai": "^0.80.10",
     "better-sqlite3": "^12.11.1",

--- a/src/oauth.js
+++ b/src/oauth.js
@@ -9,12 +9,14 @@
 
 import fs from 'fs';
 import path from 'path';
-import {
-  getOAuthProvider,
-  getOAuthProviders,
-} from '@earendil-works/pi-ai/oauth';
+import { builtinProviders } from '@earendil-works/pi-ai/providers/all';
 
 const TBC_HOME = process.env.TBC_HOME || path.join(process.env.HOME, '.thebotcompany');
+const OAUTH_PROVIDERS = builtinProviders().filter(provider => provider.auth.oauth);
+
+function getOAuthProvider(providerId) {
+  return OAUTH_PROVIDERS.find(provider => provider.id === providerId) || null;
+}
 
 // ---------------------------------------------------------------------------
 // Credential persistence
@@ -82,6 +84,7 @@ export async function startOAuthLogin(providerId, projectId = null) {
   if (!provider) {
     throw new Error(`Unknown OAuth provider: ${providerId}`);
   }
+  const oauth = provider.auth.oauth;
 
   const flowKey = projectId ? `${providerId}:${projectId}` : providerId;
 
@@ -95,31 +98,37 @@ export async function startOAuthLogin(providerId, projectId = null) {
   let authUrl = null;
   let resolveManualCode = null;
   let rejectManualCode = null;
+  let resolveAuthReady = null;
+  const abortController = new AbortController();
 
   const manualCodePromise = new Promise((resolve, reject) => {
     resolveManualCode = resolve;
     rejectManualCode = reject;
   });
 
-  const loginPromise = provider.login({
-    onAuth: (info) => {
-      authUrl = typeof info === 'string' ? info : info.url;
-    },
-    onPrompt: async (prompt) => {
-      // This is the fallback prompt — wait for manual code via API
-      return manualCodePromise;
-    },
-    onProgress: () => {},
-    onManualCodeInput: () => manualCodePromise,
+  const authReadyPromise = new Promise(resolve => {
+    resolveAuthReady = resolve;
   });
 
-  // Wait a tick for onAuth to be called
-  await new Promise(r => setTimeout(r, 200));
+  const loginPromise = oauth.login({
+    signal: abortController.signal,
+    notify: (event) => {
+      if (event.type === 'auth_url') {
+        authUrl = event.url;
+        resolveAuthReady();
+      } else if (event.type === 'device_code') {
+        authUrl = event.verificationUri;
+        resolveAuthReady();
+      }
+    },
+    prompt: () => manualCodePromise,
+  });
 
   const flow = {
     loginPromise,
     resolveManualCode,
     cancel: () => {
+      abortController.abort();
       rejectManualCode?.(new Error('Flow cancelled'));
       _activeFlows.delete(flowKey);
     },
@@ -131,10 +140,18 @@ export async function startOAuthLogin(providerId, projectId = null) {
     .then(credentials => {
       saveCredentials(providerId, credentials, projectId);
       _activeFlows.delete(flowKey);
+      resolveAuthReady();
     })
     .catch(() => {
       _activeFlows.delete(flowKey);
+      resolveAuthReady();
     });
+
+  // OAuth provider loading and device-code requests can take longer than one tick.
+  await Promise.race([
+    authReadyPromise,
+    new Promise(resolve => setTimeout(resolve, 5000)),
+  ]);
 
   // Timeout after 5 minutes
   setTimeout(() => {
@@ -210,7 +227,10 @@ export async function getAccessToken(providerId, projectId = null) {
       const provider = getOAuthProvider(providerId);
       if (!provider) continue;
       try {
-        const refreshed = await provider.refreshToken(creds);
+        const refreshed = await provider.auth.oauth.refresh({
+          type: 'oauth',
+          ...creds,
+        });
         saveCredentials(providerId, refreshed, scope);
         return refreshed.access;
       } catch {
@@ -229,9 +249,9 @@ export async function getAccessToken(providerId, projectId = null) {
 // ---------------------------------------------------------------------------
 
 export function listOAuthProviders() {
-  return getOAuthProviders().map(p => ({
+  return OAUTH_PROVIDERS.map(p => ({
     id: p.id,
-    name: p.name,
-    usesCallbackServer: p.usesCallbackServer || false,
+    name: p.auth.oauth.name || p.name,
+    usesCallbackServer: false,
   }));
 }

--- a/tests/oauth-provider-api.test.js
+++ b/tests/oauth-provider-api.test.js
@@ -1,0 +1,13 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { listOAuthProviders } from '../src/oauth.js';
+
+test('OAuth integration loads providers from the current pi-ai API', () => {
+  const providers = listOAuthProviders();
+
+  assert.ok(providers.length > 0);
+  assert.ok(providers.some(provider => provider.id === 'anthropic'));
+  assert.ok(providers.some(provider => provider.id === 'openai-codex'));
+  assert.ok(providers.every(provider => provider.id && provider.name));
+});


### PR DESCRIPTION
## Summary

- test the packed npm tarball instead of a global symlink to the checkout
- run clean-install validation on relevant pull requests and by manual dispatch
- migrate OAuth provider integration and js-yaml import to their current APIs
- align declared and CI runtime support with pi-ai requirement of Node >=22.19
- configure the CI server non-interactively before its health check

## Validation

- full Node 22 unit suite: 291 passed
- actionlint on both workflows
- isolated packed install under Node 22
- packaged monitor build, server startup, /api/status health check, and clean shutdown on a temporary port

This PR itself triggers Clean Install Test, so the release path is validated without creating a tag or GitHub release.