### PR TITLE
chore(deps): upgrade lucide-react to 1.28.0

### DIFF
--- a/monitor/package-lock.json
+++ b/monitor/package-lock.json
@@ -15,7 +15,7 @@
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
         "dotenv": "^17.4.2",
-        "lucide-react": "^0.309.0",
+        "lucide-react": "^1.28.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-markdown": "^10.1.0",
@@ -1734,12 +1734,12 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.309.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.309.0.tgz",
-      "integrity": "sha512-zNVPczuwFrCfksZH3zbd1UDE6/WYhYAdbe2k7CImVyPAkXLgIwbs6eXQ4loigqDnUFjyFYCI5jZ1y10Kqal0dg==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.28.0.tgz",
+      "integrity": "sha512-fARAFJULsGuDDydjp6+6blekG/sBIM29TerzLjc9bQUKAcEfrSc4ZQKb25KRz4OMKd87cZTb5dgq0w/T6KufVg==",
       "license": "ISC",
       "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/markdown-table": {

--- a/monitor/package.json
+++ b/monitor/package.json
@@ -18,7 +18,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "dotenv": "^17.4.2",
-    "lucide-react": "^0.309.0",
+    "lucide-react": "^1.28.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-markdown": "^10.1.0",

--- a/monitor/src/components/layout/Footer.jsx
+++ b/monitor/src/components/layout/Footer.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Github } from 'lucide-react'
+import { GitBranch } from 'lucide-react'
 
 export default function Footer() {
   return (
@@ -13,7 +13,7 @@ export default function Footer() {
           rel="noopener noreferrer"
           className="flex items-center gap-1.5 hover:text-neutral-600 dark:hover:text-neutral-300 transition-colors"
         >
-          <Github className="w-4 h-4" />
+          <GitBranch className="w-4 h-4" />
           GitHub
         </a>
       </div>

--- a/monitor/src/components/layout/ProjectView.jsx
+++ b/monitor/src/components/layout/ProjectView.jsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/button'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 import SegmentedControl from '@/components/ui/segmented-control'
 import StatusPill from '@/components/ui/status-pill'
-import { Users, Sparkles, Settings, ScrollText, RefreshCw, Pause, Play, RotateCcw, Save, GitPullRequest, ArrowLeft, Github, Bell, ChevronDown, Lock, Unlock, Stethoscope, FileText } from 'lucide-react'
+import { Users, Sparkles, Settings, ScrollText, RefreshCw, Pause, Play, RotateCcw, Save, GitPullRequest, GitBranch, ArrowLeft, Bell, ChevronDown, Lock, Unlock, Stethoscope, FileText } from 'lucide-react'
 import { PanelSlot, closeAllPanels } from '@/components/ui/panel'
 
 import Footer from '@/components/layout/Footer'
@@ -1094,7 +1094,7 @@ export default function ProjectView({
                   className="p-1.5 rounded bg-neutral-200 dark:bg-neutral-700 hover:bg-neutral-300 dark:hover:bg-neutral-600 text-neutral-600 dark:text-neutral-300 inline-flex items-center"
                   title="GitHub Repository — open the source repo"
                 >
-                  <Github className="w-4 h-4" />
+                  <GitBranch className="w-4 h-4" />
                 </a>
               )}
               <a


### PR DESCRIPTION
Supersedes Dependabot PR #250.\n\n- upgrades lucide-react from 0.309.0 to 1.28.0\n- replaces the removed Github icon export with GitBranch\n- unblocks the coordinated React 19 upgrade because lucide-react 1.x accepts React 19 peers\n\nValidated locally:\n- clean npm ci with Node 22\n- npm run build\n- Playwright: 29/29 passed